### PR TITLE
fix: use publishable CLIP dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "torch",
   "typer",
   "whisperx>=3.8.6,<3.9",
-  "clip @ git+https://github.com/openai/CLIP.git",
+  "clip-anytorch==2.6.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Replaces the direct OpenAI CLIP Git dependency with clip-anytorch==2.6.0 because TestPyPI rejects direct URL dependencies in published package metadata. The replacement preserves the existing clip API and OpenAI ViT-B/32 checkpoint; validated text and image embeddings matched byte-for-byte. Validation also included successful isolated wheel and source-distribution builds, with generated wheel metadata containing no Git URL.