### PR TITLE
ci: scope releases and document installation

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches:
       - release
+    paths:
+      - "src/**"
+      - "pyproject.toml"
+      - "README.md"
+      - "LICENSE"
+      - "MANIFEST.in"
+      - "utils/build_package.sh"
+      - "utils/build-requirements.txt"
+      - "utils/fix_readme_links.py"
 
 permissions:
   contents: write
@@ -17,12 +26,12 @@ jobs:
       name: pypi
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 

--- a/.github/workflows/release-to-test-pypi.yml
+++ b/.github/workflows/release-to-test-pypi.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "src/**"
+      - "pyproject.toml"
+      - "README.md"
+      - "LICENSE"
+      - "MANIFEST.in"
+      - "utils/build_package.sh"
+      - "utils/build-requirements.txt"
+      - "utils/fix_readme_links.py"
 
 permissions:
   contents: write
@@ -15,12 +24,12 @@ jobs:
     environment: testpypi
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 

--- a/INSTALLATION_GUIDE.md
+++ b/INSTALLATION_GUIDE.md
@@ -4,11 +4,16 @@
 
 - Python 3.10 through 3.13
 - FFmpeg available on `PATH`
-- A C/C++ build toolchain if pip needs to compile `dlib`
+- CMake and a C/C++ build toolchain for `dlib`
 
-On Windows, install the Microsoft C++ Build Tools if no compatible `dlib` wheel is available. Do not keep platform-specific wheels in the repository.
+The official `dlib` releases on PyPI are source distributions. A clean VidXP
+installation therefore compiles `dlib` locally on every supported Python
+version unless a compatible build is already cached or supplied by the
+environment. Changing from Python 3.13 to 3.11 does not avoid this requirement.
+On Windows, install CMake and the Microsoft C++ Build Tools. Do not keep
+platform-specific wheels in the repository.
 
-## Environment
+## Create an environment
 
 ```bash
 python -m venv venv
@@ -22,10 +27,50 @@ venv\Scripts\activate
 source venv/bin/activate
 ```
 
+## Install from PyPI
+
+Upgrade pip:
+
 ```bash
 python -m pip install --upgrade pip
+```
+
+Install the command-line package:
+
+```bash
+python -m pip install vidxp
+```
+
+Install the command-line package and browser interface:
+
+```bash
+python -m pip install "vidxp[frontend]"
+```
+
+`frontend` is a pip optional dependency group that installs Streamlit. The
+package name remains `vidxp`.
+
+## Install from source
+
+From the repository root:
+
+```bash
+python -m pip install .
+```
+
+Include the Streamlit interface with:
+
+```bash
 python -m pip install ".[frontend]"
 ```
+
+## Installation expectations
+
+VidXP includes PyTorch, WhisperX, computer-vision, and face-recognition
+dependencies. The first installation can take time and consume several
+gigabytes of disk space. The exact download and installed sizes vary by
+operating system, Python version, package versions, and whether CPU or
+accelerator-specific packages are selected.
 
 Confirm that both installed entry points start:
 
@@ -46,3 +91,5 @@ VidXP downloads model weights on first use instead of expecting repository-local
 | Word alignment | WhisperX default for the detected language |
 
 SentenceTransformer and WhisperX use the Hugging Face cache. CLIP uses its standard user cache. These downloads are not part of `pip install`, so the first indexing or search operation requires network access.
+Model caches require additional disk space beyond the Python installation, and
+the first use of each capability takes longer while its weights are downloaded.

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@
 VidXP supports Python 3.10 through 3.13 and requires FFmpeg.
 
 ```bash
-git clone https://github.com/grayhatdevelopers/vidxp
-cd vidxp
 python -m venv venv
 ```
 
@@ -50,13 +48,28 @@ venv\Scripts\activate
 source venv/bin/activate
 ```
 
-Install VidXP with the Streamlit frontend:
+Install the CLI from PyPI:
 
 ```bash
-python -m pip install ".[frontend]"
+python -m pip install vidxp
 ```
 
-See [INSTALLATION_GUIDE.md](INSTALLATION_GUIDE.md) for platform notes.
+To include the browser-based Streamlit interface:
+
+```bash
+python -m pip install "vidxp[frontend]"
+```
+
+`vidxp` is the package name. `frontend` is an optional dependency group that
+adds Streamlit; it is not part of the package name.
+
+To install from a source checkout instead, use `python -m pip install .` for the
+CLI or `python -m pip install ".[frontend]"` for the CLI and browser interface.
+
+The machine-learning dependencies make the first installation comparatively
+large and may require local build tools. See
+[INSTALLATION_GUIDE.md](INSTALLATION_GUIDE.md) for platform requirements and
+first-run model downloads.
 
 ### Model downloads
 


### PR DESCRIPTION
## Summary

- Restrict TestPyPI and PyPI publishing workflows to package-affecting paths, so benchmark-only documentation merges do not trigger releases.
- Update `actions/checkout` and `actions/setup-python` to their stable v7 release lines.
- Document PyPI and source installation separately, including what the optional `frontend` extra installs.
- Clarify the `dlib` build requirement, installation expectations, and first-use model downloads.

## Why

The publishing workflows previously ran on every push to their release branch, including changes that could not affect the package. The installation documentation also only showed a source checkout command and did not explain the published package name or the Streamlit extra.

## Validation

- Parsed both workflow files as YAML.
- Ran `git diff --check`.
- Confirmed the PR diff contains only the two release workflows and two installation documents.
- Confirmed there are no frontend, package-version, or changelog changes in this PR.
