### PR TITLE
ci: skip package upload when no release is created

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -49,6 +49,7 @@ jobs:
           semantic-release version --commit --tag --push
 
       - name: Publish to PyPI
+        if: steps.release.outputs.released == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/

--- a/.github/workflows/release-to-test-pypi.yml
+++ b/.github/workflows/release-to-test-pypi.yml
@@ -40,12 +40,14 @@ jobs:
           pip install -r utils/build-requirements.txt
 
       - name: Determine and tag prerelease version
+        id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           semantic-release version --commit --tag --push
 
       - name: Publish to TestPyPI
+        if: steps.release.outputs.released == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## Summary

- Expose the semantic-release result from the TestPyPI version step.
- Run TestPyPI and PyPI uploads only when semantic-release reports that it created a release.

## Root cause

Semantic-release treats "no release required" as a successful result and does not create `dist/`. The upload step previously ran unconditionally, so documentation-only changes reached the publisher with no distributions and failed.

## Validation

- Parsed both workflow files as YAML.
- Ran `git diff --check`.
- Confirmed the PR adds only the three release-output guard lines.
