### PR TITLE
fix(ci): prevent redundant dependency update runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: pip
-    directories:
-      - "/"
-      - "/src/vidxp/requirements"
-      - "/src/vidxp/capabilities/dialogue"
-      - "/src/vidxp/capabilities/scene"
-      - "/src/vidxp/capabilities/actor"
-      - "/src/vidxp/benchmarks"
-      - "/utils"
+    directory: "/"
     schedule:
       interval: cron
       cronjob: "0 9 1,15 * *"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - labeled
-      - unlabeled
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -15,6 +13,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   validate:
@@ -24,27 +23,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v7
-        with:
-          python-version: "3.11"
-          cache: pip
-
-      - name: Install repository tooling
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r utils/build-requirements.txt
-
-      - name: Require a changelog fragment
-        if: >-
-          github.event_name == 'pull_request' &&
-          !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
-        run: towncrier check --compare-with "${{ github.event.pull_request.base.sha }}"
-
       - name: Determine validation scope
         id: scope
         shell: bash
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_ACTOR: ${{ github.actor }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           changed_files="$(git diff --name-only "$BASE_SHA" HEAD)"
           if grep -Eq '^(\.github/workflows/ci\.yml$|src/|tests/|utils/|LICENSE$|MANIFEST\.in$|pyproject\.toml$)' <<< "$changed_files"; then
@@ -57,8 +43,41 @@ jobs:
           else
             run_container=false
           fi
+
+          if [[ "$PR_ACTOR" == "dependabot[bot]" ]] ||
+            gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
+              --jq '.[].name' | grep -Fxq 'skip-changelog'; then
+            require_changelog=false
+          else
+            require_changelog=true
+          fi
+
+          if [[ "$run_suite" == "true" || "$require_changelog" == "true" ]]; then
+            needs_python=true
+          else
+            needs_python=false
+          fi
+
           echo "run_suite=$run_suite" >> "$GITHUB_OUTPUT"
           echo "run_container=$run_container" >> "$GITHUB_OUTPUT"
+          echo "require_changelog=$require_changelog" >> "$GITHUB_OUTPUT"
+          echo "needs_python=$needs_python" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-python@v7
+        if: steps.scope.outputs.needs_python == 'true'
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install repository tooling
+        if: steps.scope.outputs.needs_python == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r utils/build-requirements.txt
+
+      - name: Require a changelog fragment
+        if: steps.scope.outputs.require_changelog == 'true'
+        run: towncrier check --compare-with "${{ github.event.pull_request.base.sha }}"
 
       - name: Install test surface
         if: steps.scope.outputs.run_suite == 'true'

--- a/changes/19.bugfix.md
+++ b/changes/19.bugfix.md
@@ -1,0 +1,1 @@
+Prevent dependency updates and label changes from spawning redundant CI runs.


### PR DESCRIPTION
## Summary

- stop the required CI workflow from running on each pull-request label change
- exempt Dependabot PRs from contributor changelog fragments
- calculate validation scope before Python setup so release-workflow-only dependency PRs finish without installing repository tooling
- read current PR labels so maintainers can apply `skip-changelog` and rerun a failed human-authored check
- remove overlapping pip scan directories that produced duplicate Dependabot PRs

## Root cause

CI subscribed to `labeled` and `unlabeled` events even though Dependabot applies labels separately while opening a PR. The surviving run then required a Towncrier fragment from the bot. Separately, Dependabot's `/` pip scan already discovered nested requirement files, so listing `/utils` and the capability directories again caused duplicate update PRs.

## Impact

A publishing-workflow-only Dependabot PR now receives one fast successful `validate` result plus dependency review. It does not install Python tooling, run the package suite, build the container, or require a changelog fragment. Human changes still receive the same scoped validation and changelog policy.

## Validation

- actionlint across all workflows
- shell-condition checks for Dependabot, current `skip-changelog`, and normal human PR paths
- configuration diff and Towncrier fragment checks
