### PR TITLE
fix(ci): make release gates deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,23 @@ on:
         description: Exact commit to validate.
         required: false
         type: string
-      full:
-        description: Run every validation surface without PR path scoping.
+      force_validation:
+        description: Run validation without PR path scoping.
         required: false
         default: false
         type: boolean
-      skip_containers:
-        description: Skip container validation when a downstream release job builds and smokes the same images.
+      python_versions:
+        description: JSON array of Python versions to validate.
+        required: false
+        default: '["3.14"]'
+        type: string
+      provider_platforms:
+        description: JSON array of runner labels for provider validation.
+        required: false
+        default: '["windows-2025"]'
+        type: string
+      run_containers:
+        description: Run container validation when validation is forced.
         required: false
         default: false
         type: boolean
@@ -32,12 +42,13 @@ permissions:
   pull-requests: read
 
 jobs:
-  validate:
+  scope:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ${{ fromJSON(inputs.full && '["3.11","3.12","3.13","3.14"]' || '["3.14"]') }}
+    outputs:
+      needs_python: ${{ steps.scope.outputs.needs_python }}
+      require_changelog: ${{ steps.scope.outputs.require_changelog }}
+      run_container: ${{ steps.scope.outputs.run_container }}
+      run_suite: ${{ steps.scope.outputs.run_suite }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -49,19 +60,15 @@ jobs:
         shell: bash
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          FORCE_FULL: ${{ inputs.full || false }}
-          SKIP_CONTAINERS: ${{ inputs.skip_containers || false }}
+          FORCE_VALIDATION: ${{ inputs.force_validation || false }}
+          RUN_CONTAINERS: ${{ inputs.run_containers || false }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [[ "$FORCE_FULL" == "true" ]]; then
+          if [[ "$FORCE_VALIDATION" == "true" ]]; then
             {
               echo "run_suite=true"
-              if [[ "$SKIP_CONTAINERS" == "true" ]]; then
-                echo "run_container=false"
-              else
-                echo "run_container=true"
-              fi
+              echo "run_container=$RUN_CONTAINERS"
               echo "require_changelog=false"
               echo "needs_python=true"
             } >> "$GITHUB_OUTPUT"
@@ -101,24 +108,35 @@ jobs:
           echo "require_changelog=$require_changelog" >> "$GITHUB_OUTPUT"
           echo "needs_python=$needs_python" >> "$GITHUB_OUTPUT"
 
+  validate:
+    if: needs.scope.outputs.needs_python == 'true'
+    needs: scope
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.14"]') }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
+
       - uses: actions/setup-python@v7
-        if: steps.scope.outputs.needs_python == 'true'
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
 
       - name: Install repository tooling
-        if: steps.scope.outputs.needs_python == 'true'
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r utils/build-requirements.txt
 
       - name: Require a changelog fragment
-        if: steps.scope.outputs.require_changelog == 'true' && matrix.python-version == '3.14'
+        if: needs.scope.outputs.require_changelog == 'true' && matrix.python-version == '3.14'
         run: towncrier check --compare-with "${{ github.event.pull_request.base.sha }}"
 
       - name: Install test surface
-        if: steps.scope.outputs.run_suite == 'true'
+        if: needs.scope.outputs.run_suite == 'true'
         run: |
           python -m pip install "uv==0.12.0"
           uv sync \
@@ -132,21 +150,21 @@ jobs:
             --no-dev
 
       - name: Lint
-        if: steps.scope.outputs.run_suite == 'true' && matrix.python-version == '3.14'
+        if: needs.scope.outputs.run_suite == 'true' && matrix.python-version == '3.14'
         run: ruff check src tests
 
       - name: Test
-        if: steps.scope.outputs.run_suite == 'true'
+        if: needs.scope.outputs.run_suite == 'true'
         run: uv run --no-sync python -m unittest discover -s tests -q
         env:
           PYTHONPATH: src
 
       - name: Build wheel and source distribution
-        if: steps.scope.outputs.run_suite == 'true' && matrix.python-version == '3.14'
+        if: needs.scope.outputs.run_suite == 'true' && matrix.python-version == '3.14'
         run: python -m build
 
       - name: Verify minimal wheel
-        if: steps.scope.outputs.run_suite == 'true' && matrix.python-version == '3.14'
+        if: needs.scope.outputs.run_suite == 'true' && matrix.python-version == '3.14'
         shell: bash
         run: |
           python -m venv .wheel-smoke
@@ -186,15 +204,15 @@ jobs:
           PY
 
       - name: Validate Compose configuration
-        if: steps.scope.outputs.run_container == 'true' && matrix.python-version == '3.14'
+        if: needs.scope.outputs.run_container == 'true' && matrix.python-version == '3.14'
         run: docker compose config --quiet
 
       - name: Build container
-        if: steps.scope.outputs.run_container == 'true' && matrix.python-version == '3.14'
+        if: needs.scope.outputs.run_container == 'true' && matrix.python-version == '3.14'
         run: docker build --tag vidxp:ci .
 
       - name: Smoke container
-        if: steps.scope.outputs.run_container == 'true' && matrix.python-version == '3.14'
+        if: needs.scope.outputs.run_container == 'true' && matrix.python-version == '3.14'
         shell: bash
         run: |
           docker run --detach --name vidxp-ci \
@@ -224,12 +242,14 @@ jobs:
           exit 1
 
   provider-platform-smoke:
+    if: needs.scope.outputs.run_suite == 'true'
+    needs: scope
     name: CPU providers (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(inputs.full && '["ubuntu-24.04","windows-2025","macos-15"]' || '["windows-2025"]') }}
+        os: ${{ fromJSON(inputs.provider_platforms || '["windows-2025"]') }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -244,10 +264,14 @@ jobs:
           python -m pip install "uv==0.12.0"
           uv sync --frozen --extra local-worker --no-dev
 
-      - name: Verify provider contracts without model downloads
-        run: |
-          uv run --no-sync python -m unittest discover -s tests -p "test_models.py" -q
-          uv run --no-sync python -m unittest discover -s tests -p "test_indexing.py" -q
+      - name: Verify model provider contracts without network downloads
+        run: uv run --no-sync python -m unittest discover -s tests -p "test_models.py" -q
+        env:
+          PYTHONPATH: src
+          VIDXP_ALLOW_MODEL_DOWNLOADS: "false"
+
+      - name: Verify indexing provider contracts without network downloads
+        run: uv run --no-sync python -m unittest discover -s tests -p "test_indexing.py" -q
         env:
           PYTHONPATH: src
           VIDXP_ALLOW_MODEL_DOWNLOADS: "false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          # Towncrier compares BASE_SHA...HEAD in this job.
+          fetch-depth: 0
           ref: ${{ inputs.checkout_ref || github.sha }}
 
       - uses: actions/setup-python@v7

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -11,8 +11,19 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validate-source:
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: ./.github/workflows/ci.yml
+    with:
+      checkout_ref: ${{ github.sha }}
+      force_validation: true
+
   release:
     if: github.ref == 'refs/heads/main'
+    needs: validate-source
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -42,7 +53,7 @@ jobs:
         env:
           BUILD_CHANGELOG: "1"
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: semantic-release version --no-changelog
+        run: semantic-release version --no-changelog --no-vcs-release
 
       - name: Smoke distribution
         if: steps.release.outputs.released == 'true'
@@ -71,23 +82,11 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  validate-release:
-    if: needs.release.outputs.released == 'true'
-    needs: release
-    permissions:
-      contents: read
-      pull-requests: read
-    uses: ./.github/workflows/ci.yml
-    with:
-      checkout_ref: ${{ needs.release.outputs.commit_sha }}
-      full: true
-      skip_containers: true
-
   publish-pypi:
     if: needs.release.outputs.released == 'true'
     needs:
       - release
-      - validate-release
+      - build-desktop
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -110,7 +109,7 @@ jobs:
       needs.release.outputs.released == 'true'
     needs:
       - release
-      - validate-release
+      - build-desktop
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -241,9 +240,7 @@ jobs:
 
   build-desktop:
     if: needs.release.outputs.released == 'true'
-    needs:
-      - release
-      - validate-release
+    needs: release
     uses: ./.github/workflows/desktop.yml
     with:
       checkout_ref: ${{ needs.release.outputs.commit_sha }}
@@ -252,7 +249,6 @@ jobs:
     if: needs.release.outputs.released == 'true'
     needs:
       - release
-      - validate-release
       - publish-pypi
       - publish-container
       - build-desktop
@@ -280,6 +276,11 @@ jobs:
         with:
           name: github-release-notes
           path: .
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: pypi-distribution
+          path: dist/
 
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release-to-test-pypi.yml
+++ b/.github/workflows/release-to-test-pypi.yml
@@ -15,6 +15,7 @@ on:
       - "utils/**"
       - "desktop/**"
       - "uv.lock"
+      - ".github/workflows/ci.yml"
       - ".github/workflows/desktop.yml"
       - ".github/workflows/release-to-test-pypi.yml"
 
@@ -33,7 +34,9 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       checkout_ref: ${{ github.sha }}
-      full: true
+      force_validation: true
+      provider_platforms: '["ubuntu-24.04","windows-2025","macos-15"]'
+      run_containers: true
 
   prerelease:
     needs: validate
@@ -65,7 +68,12 @@ jobs:
         env:
           BUILD_RELEASE_NOTES: "1"
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: semantic-release version --as-prerelease --prerelease-token b --no-changelog
+        run: >-
+          semantic-release version
+          --as-prerelease
+          --prerelease-token b
+          --no-changelog
+          --no-vcs-release
 
       - name: Smoke distribution
         if: steps.release.outputs.released == 'true'
@@ -76,15 +84,6 @@ jobs:
           .release-smoke/bin/python -m pip check
           .release-smoke/bin/vidxp --version
 
-      - name: Publish GitHub release
-        if: steps.release.outputs.released == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          semantic-release publish --tag "${{ steps.release.outputs.tag }}"
-          gh release edit "${{ steps.release.outputs.tag }}" \
-            --notes-file .release-notes.md
-
       - name: Preserve distribution
         if: steps.release.outputs.released == 'true'
         uses: actions/upload-artifact@v7
@@ -94,9 +93,20 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+      - name: Preserve release notes
+        if: steps.release.outputs.released == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: testpypi-release-notes
+          path: .release-notes.md
+          if-no-files-found: error
+          retention-days: 7
+
   publish-testpypi:
     if: needs.prerelease.outputs.released == 'true'
-    needs: prerelease
+    needs:
+      - prerelease
+      - build-desktop
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
@@ -116,33 +126,60 @@ jobs:
 
   build-desktop:
     if: needs.prerelease.outputs.released == 'true'
-    needs:
-      - prerelease
-      - publish-testpypi
+    needs: prerelease
     uses: ./.github/workflows/desktop.yml
     with:
       checkout_ref: ${{ needs.prerelease.outputs.commit_sha }}
 
-  publish-desktop:
+  publish-github:
     if: needs.prerelease.outputs.released == 'true'
     needs:
       - prerelease
+      - publish-testpypi
       - build-desktop
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prerelease.outputs.commit_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+
+      - name: Install release tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r utils/build-requirements.txt
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: testpypi-distribution
+          path: dist/
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: testpypi-release-notes
+          path: .
+
       - uses: actions/download-artifact@v8
         with:
           pattern: vidxp-desktop-*
           path: desktop-dist/
           merge-multiple: true
 
-      - name: Attach desktop installers to the prerelease
+      - name: Publish complete GitHub prerelease
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          semantic-release publish --tag "${{ needs.prerelease.outputs.tag }}"
+          gh release edit "${{ needs.prerelease.outputs.tag }}" \
+            --notes-file .release-notes.md
           gh release upload "${{ needs.prerelease.outputs.tag }}" \
             desktop-dist/* \
             --clobber

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,8 +6,15 @@ on:
       - ".github/dependabot.yml"
       - ".github/workflows/**"
       - "pyproject.toml"
+      - "uv.lock"
       - "src/**/*.txt"
       - "utils/build-requirements.txt"
+      - "desktop/package.json"
+      - "desktop/package-lock.json"
+      - "desktop/runtime-constraints.txt"
+      - "desktop/sidecars.json"
+      - "desktop/src-tauri/Cargo.toml"
+      - "desktop/src-tauri/Cargo.lock"
 
 concurrency:
   group: security-${{ github.event.pull_request.number || github.ref }}

--- a/changes/+release-publication.feature.md
+++ b/changes/+release-publication.feature.md
@@ -3,5 +3,6 @@ Align public release artifacts:
 - stamp the Python package, Tauri package, desktop runtime manifest, and native app versions through semantic release
 - build PyPI distributions and local/control/worker container images from the exact validated release commit
 - build unsigned NSIS, DMG, and AppImage desktop installers from locked target-specific profiles and attach them to the matching GitHub release
+- publish the GitHub release only after its package and desktop artifacts have passed their release gates
 - verify the minimal wheel separately from optional capability, UI, MCP, server, benchmark, and test extras
 - keep the repository README's relative assets while rewriting them only in the temporary PyPI build

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -126,7 +126,11 @@ class ModelTests(unittest.TestCase):
                 filename=downloaded.name,
                 sha256=hashlib.sha256(content).hexdigest(),
             )
-            runtime = self.runtime(directory, allowed_specs=(spec,))
+            runtime = self.runtime(
+                directory,
+                allowed_specs=(spec,),
+                allow_model_downloads=True,
+            )
             retrieve = Mock(return_value=str(downloaded))
             fake_pooch = types.SimpleNamespace(retrieve=retrieve)
             with patch.dict(sys.modules, {"pooch": fake_pooch}):


### PR DESCRIPTION
## Summary

- fix the provider test so its mocked download explicitly opts in even when CI disables network model downloads
- split provider test commands so Windows cannot hide an earlier failure behind a later successful command
- compute PR validation scope once and make Python versions, provider platforms, and container validation independent reusable-workflow inputs
- reduce prerelease validation to Python 3.14 while retaining explicit Linux, Windows, macOS provider checks and container smoke coverage
- validate stable source before semantic-release creates and pushes its version commit/tag
- suppress semantic-release's implicit early GitHub release and publish GitHub only after package and desktop gates pass
- require desktop installers to build before publishing TestPyPI, PyPI, or GHCR artifacts
- preserve and pass distribution, release-note, and desktop artifacts to their final publication jobs
- expand dependency-review path gating to cover Python, npm, Cargo, desktop constraints, and sidecar locks

## Root causes fixed

- `test_actor_download_uses_pinned_media_object_not_lfs_pointer` inherited `VIDXP_ALLOW_MODEL_DOWNLOADS=false` despite mocking the download provider
- PowerShell returned the second test command's status, making the Windows provider job falsely green after the first command failed
- the single `full` input coupled four Python versions, three provider operating systems, path bypass, and container work
- provider jobs ignored PR path scope entirely
- prerelease did not trigger when the reusable CI workflow changed
- `semantic-release version` created a remote release by default before downstream jobs completed
- stable validation ran after version/tag creation
- stable GitHub publication did not download the built Python distribution

## Validation

- `actionlint -color`
- `$env:PYTHONPATH='src'; $env:VIDXP_ALLOW_MODEL_DOWNLOADS='false'; uv run --no-sync python -m unittest discover -s tests -p 'test_models.py' -q` (22 passed)
- `$env:PYTHONPATH='src'; $env:VIDXP_ALLOW_MODEL_DOWNLOADS='false'; uv run --no-sync python -m unittest discover -s tests -p 'test_indexing.py' -q` (13 passed)
- `git diff --check`

## Changelog

- Updated the pending release-publication feature note; this corrects the unreleased publication flow rather than adding a fictional post-release bug entry.