### PR TITLE
fix(release): resolve repository in finalizers

### DIFF
--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -112,11 +112,19 @@ jobs:
         run: |
           tag="${{ inputs.tag }}"
           version="${tag#desktop-v}"
-          gh release upload "$tag" desktop-dist/* --clobber
+          gh release upload "$tag" desktop-dist/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
           if [[ "$version" == *-* ]]; then
-            gh release edit "$tag" --draft=false --prerelease
+            gh release edit "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --draft=false \
+              --prerelease
           else
-            gh release edit "$tag" --draft=false --latest
+            gh release edit "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --draft=false \
+              --latest
           fi
 
       - name: Synchronize stable source back to main
@@ -125,5 +133,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run sync-channels.yml \
+            --repo "$GITHUB_REPOSITORY" \
             --ref main \
             -f release_sha="${{ needs.verify.outputs.source_sha }}"

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -161,13 +161,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          gh release upload "${{ inputs.tag }}" dist/* --clobber
-          gh release edit "${{ inputs.tag }}" --draft=false
+          gh release upload "${{ inputs.tag }}" dist/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+          gh release edit "${{ inputs.tag }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft=false
 
       - name: Synchronize stable source back to main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run sync-channels.yml \
+            --repo "$GITHUB_REPOSITORY" \
             --ref main \
             -f release_sha="${{ needs.build.outputs.source_sha }}"

--- a/.github/workflows/release-to-test-pypi.yml
+++ b/.github/workflows/release-to-test-pypi.yml
@@ -144,7 +144,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          gh release upload "${{ inputs.tag }}" dist/* --clobber
+          gh release upload "${{ inputs.tag }}" dist/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
           gh release edit "${{ inputs.tag }}" \
+            --repo "$GITHUB_REPOSITORY" \
             --draft=false \
             --prerelease

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -435,6 +435,21 @@ class PackagingTests(unittest.TestCase):
             release_workflow,
         )
 
+        publisher_repo_flags = {
+            "release-to-test-pypi.yml": 2,
+            "release-to-pypi.yml": 3,
+            "publish-desktop.yml": 4,
+        }
+        for workflow, expected in publisher_repo_flags.items():
+            contents = (
+                ROOT / ".github" / "workflows" / workflow
+            ).read_text(encoding="utf-8")
+            self.assertEqual(
+                contents.count('--repo "$GITHUB_REPOSITORY"'),
+                expected,
+                workflow,
+            )
+
         desktop_publish = (
             ROOT / ".github" / "workflows" / "publish-desktop.yml"
         ).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- pass explicit repository context to beta, stable, and desktop release finalizers
- pass explicit repository context to stable channel synchronization dispatches
- lock the no-checkout publisher contract with packaging tests

## Validation
- `uv run --no-sync python -m unittest tests.test_packaging -q`
- actionlint across every workflow
- corrected core publisher completed against `v0.3.0-b.1`: https://github.com/grayhatdevelopers/vidxp/actions/runs/30606611268
- corrected desktop publisher completed against `desktop-v0.3.0-b.1`: https://github.com/grayhatdevelopers/vidxp/actions/runs/30606612979
- TestPyPI, six public GHCR tags, both GitHub prereleases, and all five release assets verified