### PR TITLE
feat(skills): add VidXP agent workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,17 @@ inspectable, or renderable roles available for each video. Invalid capability
 or media selections are rejected before a durable job is queued and include an
 actionable next step.
 
+### ChatGPT and Codex skills
+
+VidXP includes reusable skill source folders for the two common agent workflows:
+
+- [Ingest and index videos](skills/vidxp-ingest-video/SKILL.md)
+- [Find moments and return inspectable evidence](skills/vidxp-find-video-evidence/SKILL.md)
+
+Download a skill folder and add it through a supported ChatGPT desktop or Codex
+Skills surface. The skills require a connected VidXP MCP server; installable
+plugin packaging for additional ChatGPT surfaces will follow separately.
+
 - [Python, HTTP, and MCP installation](INSTALLATION_GUIDE.md)
 - [Optional capability packages](INSTALLATION_GUIDE.md#optional-dependency-extras)
 - [Coolify server setup](docs/deployment/coolify.md)

--- a/skills/vidxp-find-video-evidence/SKILL.md
+++ b/skills/vidxp-find-video-evidence/SKILL.md
@@ -31,14 +31,35 @@ can deliver frames and clips itself.
 6. Inspect returned keyframes before asserting that a person or action is
    visibly present. Distinguish visual appearances from dialogue mentions.
 
+## Polling and presentation
+
+- Explain that search and grounded queries are durable jobs and may take time,
+  especially when clips must be rendered.
+- Honor a server-provided polling interval when present. Otherwise poll after
+  about 5 seconds initially and back off to about 15 seconds for sustained work.
+  Never busy-loop or create a shell script merely to wait.
+- Reuse the submitted job ID and idempotency key. Give a concise update when the
+  job stage changes and approximately once per minute during long unchanged
+  work; do not narrate every poll or invent an ETA.
+- Evidence is not progressive while the job is running. As soon as the completed
+  `get_job` response supplies keyframes, clips, or ResourceLinks, present them to
+  the user directly instead of returning only timestamps or waiting for another
+  request.
+- Stop polling on success, failure, or cancellation. Preserve the job ID and
+  report structured remediation when the job does not succeed.
+
 ## Evidence rules
 
 - Report the source video, resolved interval, modalities, evidence ID, and
   available frame or clip for each useful result.
 - Describe ranking scores as retrieval scores, not calibrated probabilities.
-- Do not assign a real identity to an anonymous actor cluster without grounded
-  identity evidence. Do not claim an exhaustive list of a named person's
-  appearances when the available capability cannot establish that identity.
+- Treat actor detections and clusters as anonymous until a trusted reference or
+  identity registry grounds them. A person's name in the query, dialogue, or
+  scene description is not identity proof.
+- For named-person searches, verify candidate appearances against each returned
+  frame and label uncertain results as candidates. Do not claim an exhaustive
+  list of appearances when the available capability cannot establish identity
+  across the whole video.
 - A failed or empty search means no matching indexed evidence was found; it does
   not prove that the event is absent from the original video.
 - If a result has authoritative evidence but no requested clip, prefer

--- a/skills/vidxp-find-video-evidence/SKILL.md
+++ b/skills/vidxp-find-video-evidence/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: vidxp-find-video-evidence
+description: Use VidXP to search indexed videos, answer grounded questions about video content, locate when people, actions, dialogue, or scenes occur, and return inspectable keyframes or clips. Trigger for requests such as "find where X appears," "when does Y happen," "what is said," "what happens," or "show me the matching clip," even when the user does not name VidXP. Do not trigger for ingesting new media or ordinary video editing.
+---
+
+# Find video evidence with VidXP
+
+Use VidXP retrieval and its returned evidence as one workflow. Do not make the
+user translate timestamps into separate clip requests when the ordinary search
+can deliver frames and clips itself.
+
+## Workflow
+
+1. Resolve the declared `vidxp` MCP dependency. When the host supports lazy
+   connector or tool discovery, search for VidXP before concluding it is absent.
+   If its tools still cannot be loaded, say that the VidXP connector is not
+   connected and stop instead of silently using unrelated search tools.
+2. Call `get_workspace` before searching. Select the requested indexed media ID
+   when the user identifies one video; otherwise search the active snapshot.
+   If the requested video is not indexed, explain that ingestion or indexing is
+   required before retrieval.
+3. Choose the operation by the requested outcome:
+   - Use `search_moments` to locate or list matching moments.
+   - Use `query_video` for a grounded answer that combines retrieved evidence.
+4. Request `keyframes_and_clips` when the user asks where something occurs,
+   wants verification, or is likely to share/download the result. Use keyframes
+   alone only when clips add no value.
+5. Poll only the submitted job with `get_job`. The completed job is the
+   authoritative source for ranked results, evidence, frames, clips, and
+   ResourceLinks.
+6. Inspect returned keyframes before asserting that a person or action is
+   visibly present. Distinguish visual appearances from dialogue mentions.
+
+## Evidence rules
+
+- Report the source video, resolved interval, modalities, evidence ID, and
+  available frame or clip for each useful result.
+- Describe ranking scores as retrieval scores, not calibrated probabilities.
+- Do not assign a real identity to an anonymous actor cluster without grounded
+  identity evidence. Do not claim an exhaustive list of a named person's
+  appearances when the available capability cannot establish that identity.
+- A failed or empty search means no matching indexed evidence was found; it does
+  not prove that the event is absent from the original video.
+- If a result has authoritative evidence but no requested clip, prefer
+  `create_evidence_clip`; VidXP resolves and clamps its range. Use
+  `get_artifact_download` only when the returned ResourceLink is insufficient for
+  the host or the user explicitly asks for a path or download link.

--- a/skills/vidxp-find-video-evidence/agents/openai.yaml
+++ b/skills/vidxp-find-video-evidence/agents/openai.yaml
@@ -1,0 +1,13 @@
+interface:
+  display_name: "Find Video Evidence with VidXP"
+  short_description: "Search indexed videos and return verifiable evidence"
+  default_prompt: "Use $vidxp-find-video-evidence to find and verify moments in my indexed videos."
+
+policy:
+  allow_implicit_invocation: true
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "vidxp"
+      description: "VidXP video search and evidence tools"

--- a/skills/vidxp-ingest-video/SKILL.md
+++ b/skills/vidxp-ingest-video/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: vidxp-ingest-video
+description: Use VidXP to upload, import, register, and automatically index video files through its MCP tools. Trigger for requests to add, upload, ingest, import, register, or index one or more videos, including attached videos and accessible local paths, even when the user does not name VidXP. Do not trigger for editing, transcoding, or searching a video that is already indexed.
+---
+
+# Ingest video with VidXP
+
+Use the VidXP MCP tools for the complete ingestion workflow. Do not replace them
+with an ad hoc upload script, base64 media in tool arguments, or manual database
+changes.
+
+## Workflow
+
+1. Resolve the declared `vidxp` MCP dependency. When the host supports lazy
+   connector or tool discovery, search for VidXP before concluding it is absent.
+   If its tools still cannot be loaded, say that the VidXP connector is not
+   connected and stop instead of inventing a substitute.
+2. Call `get_workspace` to inspect existing media and index coverage. Avoid
+   importing the same video again when it is already registered or indexed.
+3. Call `get_runtime_readiness` before automatic indexing. If required model
+   artifacts are missing, call `prepare_models` and poll that job with `get_job`
+   until it reaches a terminal state.
+4. Select ingestion from the tools actually exposed by the current transport:
+   - When `ingest_local_media` is available and the video has a filesystem path
+     accessible to VidXP, pass one to ten paths and poll only
+     `get_media_ingestion`.
+   - Otherwise call `create_media_upload`, give the returned upload link to the
+     user, and poll only `get_media_upload` after files are selected.
+5. Keep `index_after_import` enabled unless the user explicitly asks to register
+   media without indexing. Reuse the same idempotency key when retrying the same
+   request.
+6. Stop polling when the returned aggregate state is terminal. Treat each file
+   independently so one failure does not hide successful siblings.
+
+## Recovery and output
+
+- If import fails, report its structured error and remediation.
+- If indexing fails after registration, do not upload the file again. Use the
+  returned media ID with `start_indexing` when the user wants to retry.
+- Report each filename, lifecycle state, media ID, index job, and searchable
+  snapshot or generation when present.
+- State clearly whether each video is merely uploaded, registered, indexing, or
+  indexed and searchable.

--- a/skills/vidxp-ingest-video/SKILL.md
+++ b/skills/vidxp-ingest-video/SKILL.md
@@ -32,6 +32,23 @@ changes.
 6. Stop polling when the returned aggregate state is terminal. Treat each file
    independently so one failure does not hide successful siblings.
 
+## Long-running operations
+
+- Tell the user before polling that model preparation and indexing can take
+  several minutes, depending on video length, selected capabilities, hardware,
+  and whether models are already cached.
+- Honor a server-provided polling interval when present. Otherwise poll after
+  about 5 seconds initially and back off to about 15 seconds for sustained work.
+  Never busy-loop or create a shell script merely to wait.
+- Keep using the original job, ingestion, and idempotency identifiers. Do not
+  submit duplicate work because a state remains unchanged.
+- Give a concise update when the lifecycle stage or measured progress changes,
+  and approximately once per minute during a long unchanged stage. Do not emit
+  every poll result.
+- Report only progress and timing returned or directly measured by VidXP. Do not
+  invent an ETA. If the interaction must stop before completion, provide the
+  recovery identifier needed to resume polling later.
+
 ## Recovery and output
 
 - If import fails, report its structured error and remediation.

--- a/skills/vidxp-ingest-video/agents/openai.yaml
+++ b/skills/vidxp-ingest-video/agents/openai.yaml
@@ -1,0 +1,13 @@
+interface:
+  display_name: "Ingest Video with VidXP"
+  short_description: "Upload or ingest videos and index them with VidXP"
+  default_prompt: "Use $vidxp-ingest-video to ingest and index my video with VidXP."
+
+policy:
+  allow_implicit_invocation: true
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "vidxp"
+      description: "VidXP video ingestion and indexing tools"


### PR DESCRIPTION
## Summary

- add a public `vidxp-ingest-video` skill for local-path and browser-handoff ingestion with automatic indexing
- add a public `vidxp-find-video-evidence` skill for grounded search, keyframe inspection, and clip delivery
- declare ChatGPT-facing metadata, implicit invocation, and the VidXP MCP dependency for both workflows
- link the downloadable skill sources from the product README

## Why

Natural requests such as “index this video” and “find where Harry appears” should select VidXP and follow its native MCP workflow without requiring users to name individual tools or reconstruct timestamp-to-clip sequences.

## User impact

The skills teach ChatGPT and Codex to discover the VidXP connector, choose transport-appropriate ingestion, poll the authoritative durable operation, and return inspectable evidence. They are stored as public source packages under `skills/`; plugin packaging remains separate.

## Validation

- both skill folders pass the official `quick_validate.py` validator
- ChatGPT metadata and MCP dependency declarations parse successfully
- README links resolve
- `git diff --check` passes

BEGIN_COMMIT_OVERRIDE
chore(codex): add initial guided video workflows
END_COMMIT_OVERRIDE