### PR TITLE
fix(mcp): complete follow-up evidence delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ self-hosted VidXP server.
 Search and question results can include directly inspectable frames and clips, so
 agents can show the evidence behind an answer without making users translate raw
 timestamps. Evidence rendering is best-effort: a result can still be useful when
-an individual frame or clip cannot be produced.
+an individual frame or clip cannot be produced. Agents can request additional
+ranked evidence in small batches without rerunning the search.
 
 Remote agents can hand users a short-lived page for selecting and uploading
 multiple videos. Local agents can ingest approved filesystem paths without moving

--- a/docs/architecture/platform.md
+++ b/docs/architecture/platform.md
@@ -924,10 +924,12 @@ the authoritative indexed frame number. Other intervals and anonymous actor
 clusters use a clearly labeled representative full frame. Requested clips are
 range-clamped and rendered through the same snippet artifact service before the
 original search/query job succeeds, so the ordinary agent path is one submit plus
-polling that same job. `create_evidence_clip` derives a fallback clip solely from a
-completed source job and its stable evidence ID; callers cannot supply authoritative
-timestamps. Keyframe-only retrieval keeps the existing read scope; requesting clip
-rendering requires repository write scope, matching the low-level clip operation.
+polling that same job. `materialize_job_evidence` accepts one to ten stable evidence
+IDs from that completed result and produces follow-up keyframes or clips without
+rerunning retrieval. `create_evidence_clip` derives a single fallback clip from the
+same source-job contract; callers cannot supply authoritative timestamps.
+Keyframe-only retrieval keeps the existing read scope; requesting clip rendering
+requires repository write scope, matching the low-level clip operation.
 Evidence artifacts are best-effort and may fail independently, so completed result
 sets can contain partial frame or clip delivery.
 
@@ -1049,6 +1051,7 @@ Initial curated tools:
 - `query_video`
 - `create_clip`
 - `create_evidence_clip`
+- `materialize_job_evidence`
 - `get_artifact_download`
 - `list_jobs`
 - `get_job`

--- a/skills/vidxp-find-video-evidence/SKILL.md
+++ b/skills/vidxp-find-video-evidence/SKILL.md
@@ -36,6 +36,23 @@ can deliver frames and clips itself.
    only for results worth presenting. Do not rerun retrieval or reconstruct
    timestamps in FFmpeg.
 
+## Current actor scope
+
+- Use `query_video`, not `search_moments`, when anonymous actor-cluster context
+  is useful. The actor capability has no text-search operation, so it cannot
+  search a person's name or accept a reference identity.
+- Treat actor evidence as video-scoped anonymous face clusters containing a
+  detection count and first-to-last sampled timestamp range. It does not prove
+  a name, continuous presence, speaking identity, or cross-video identity.
+- Actor evidence may fall outside the three items materialized automatically.
+  Select its evidence IDs from the completed job and use
+  `materialize_job_evidence` when a representative frame or clip is useful.
+- Label the returned actor image honestly: it is currently a representative
+  full frame near the middle of the cluster range, not an exact detection frame,
+  face crop, contact sheet, or identity verification.
+- Do not claim that MCP can list exact actor detections or create actor overlays.
+  Those operations exist in other VidXP interfaces but are not MCP tools yet.
+
 ## Polling and presentation
 
 - Explain that search and grounded queries are durable jobs and may take time,

--- a/skills/vidxp-find-video-evidence/SKILL.md
+++ b/skills/vidxp-find-video-evidence/SKILL.md
@@ -30,6 +30,11 @@ can deliver frames and clips itself.
    ResourceLinks.
 6. Inspect returned keyframes before asserting that a person or action is
    visibly present. Distinguish visual appearances from dialogue mentions.
+7. When useful candidates extend beyond the initial evidence delivery, call
+   `materialize_job_evidence` with evidence IDs from the completed job in
+   batches of at most ten. Request keyframes for verification and add clips
+   only for results worth presenting. Do not rerun retrieval or reconstruct
+   timestamps in FFmpeg.
 
 ## Polling and presentation
 
@@ -45,6 +50,10 @@ can deliver frames and clips itself.
   `get_job` response supplies keyframes, clips, or ResourceLinks, present them to
   the user directly instead of returning only timestamps or waiting for another
   request.
+- Include the returned evidence blocks or working resource/download references
+  in the final answer. Never leave an evidence heading empty. If the host does
+  not render a ResourceLink, say so and use `get_artifact_download` to provide
+  the transport-authoritative alternative.
 - Stop polling on success, failure, or cancellation. Preserve the job ID and
   report structured remediation when the job does not succeed.
 
@@ -66,3 +75,6 @@ can deliver frames and clips itself.
   `create_evidence_clip`; VidXP resolves and clamps its range. Use
   `get_artifact_download` only when the returned ResourceLink is insufficient for
   the host or the user explicitly asks for a path or download link.
+- Use external FFmpeg extraction only after VidXP returns a structured failure
+  for both follow-up materialization and the evidence-clip fallback, and disclose
+  that substitution to the user.

--- a/skills/vidxp-ingest-video/SKILL.md
+++ b/skills/vidxp-ingest-video/SKILL.md
@@ -17,21 +17,28 @@ changes.
    connected and stop instead of inventing a substitute.
 2. Call `get_workspace` to inspect existing media and index coverage. Avoid
    importing the same video again when it is already registered or indexed.
-3. Call `get_runtime_readiness` before automatic indexing. If required model
-   artifacts are missing, call `prepare_models` and poll that job with `get_job`
-   until it reaches a terminal state.
-4. Select ingestion from the tools actually exposed by the current transport:
+3. Select index modalities explicitly from the indexable capabilities returned
+   by `get_workspace`. For ordinary dialogue, scene, action, and named-person
+   retrieval, use `dialogue` and `scene` when available. Add `actor` only when
+   the user explicitly wants anonymous recurring-face cluster summaries; it
+   does not identify people by name or across videos, and exact detection or
+   overlay operations are not exposed through MCP yet. Do not omit `modalities`,
+   because omission indexes every installed capability.
+4. Call `get_runtime_readiness` before automatic indexing. If models required
+   by the selected modalities are missing, call `prepare_models` for those same
+   modalities and poll that job with `get_job` until it reaches a terminal state.
+5. Select ingestion from the tools actually exposed by the current transport:
    - When `ingest_local_media` is available and the video has a filesystem path
      accessible to VidXP, pass one to ten paths and poll only
      `get_media_ingestion`.
    - Otherwise call `create_media_upload`, give the returned upload link to the
      user, and poll only `get_media_upload` after files are selected.
-5. Keep `index_after_import` enabled unless the user explicitly asks to register
+6. Keep `index_after_import` enabled unless the user explicitly asks to register
    media without indexing. Reuse the same idempotency key when retrying the same
    request.
-6. Stop polling when the returned aggregate state is terminal. Treat each file
+7. Stop polling when the returned aggregate state is terminal. Treat each file
    independently so one failure does not hide successful siblings.
-7. If the same request also asks to find or explain video content, continue with
+8. If the same request also asks to find or explain video content, continue with
    the VidXP evidence workflow as soon as the successful media becomes indexed
    and searchable; do not stop after ingestion or make the user ask again.
 

--- a/skills/vidxp-ingest-video/SKILL.md
+++ b/skills/vidxp-ingest-video/SKILL.md
@@ -31,6 +31,9 @@ changes.
    request.
 6. Stop polling when the returned aggregate state is terminal. Treat each file
    independently so one failure does not hide successful siblings.
+7. If the same request also asks to find or explain video content, continue with
+   the VidXP evidence workflow as soon as the successful media becomes indexed
+   and searchable; do not stop after ingestion or make the user ask again.
 
 ## Long-running operations
 

--- a/src/vidxp/application_models.py
+++ b/src/vidxp/application_models.py
@@ -793,10 +793,14 @@ class EvidenceDeliveryMode(StrEnum):
 
 class EvidenceDeliveryPolicy(ApplicationModel):
     mode: EvidenceDeliveryMode = EvidenceDeliveryMode.none
-    max_items: int = Field(default=3, ge=1, le=5)
+    max_items: int = Field(default=3, ge=1, le=10)
     padding_before_seconds: float = Field(default=2.0, ge=0, le=30)
     padding_after_seconds: float = Field(default=2.0, ge=0, le=30)
     clip_profile: SnippetProfile = SnippetProfile.compatible_mp4
+
+
+class InitialEvidenceDeliveryPolicy(EvidenceDeliveryPolicy):
+    max_items: int = Field(default=3, ge=1, le=5)
 
 
 class SearchCommand(ApplicationModel):
@@ -822,7 +826,7 @@ class SearchCommand(ApplicationModel):
         le=100,
         description="Maximum fused moments to return across the selected scope.",
     )
-    evidence_delivery: EvidenceDeliveryPolicy | None = Field(
+    evidence_delivery: InitialEvidenceDeliveryPolicy | None = Field(
         default=None,
         description=(
             "Optional bounded frame/clip delivery. Omit to preserve the "
@@ -972,7 +976,7 @@ class QueryVideoCommand(ApplicationModel):
         le=50,
         description="Maximum ranked evidence moments used for the answer.",
     )
-    evidence_delivery: EvidenceDeliveryPolicy | None = Field(
+    evidence_delivery: InitialEvidenceDeliveryPolicy | None = Field(
         default=None,
         description=(
             "Optional bounded frame/clip delivery. Omit to preserve the "
@@ -1136,7 +1140,7 @@ class EvidenceDeliveryItem(ApplicationModel):
 
 class EvidenceDeliveryResult(ApplicationModel):
     policy: EvidenceDeliveryPolicy
-    items: tuple[EvidenceDeliveryItem, ...] = Field(max_length=5)
+    items: tuple[EvidenceDeliveryItem, ...] = Field(max_length=10)
 
 
 class DraftClaim(ApplicationModel):

--- a/src/vidxp/composition.py
+++ b/src/vidxp/composition.py
@@ -24,6 +24,7 @@ from vidxp.capabilities.registry import (
 from vidxp.control_plane import ControlPlaneApplication
 from vidxp.core.storage import BUNDLED_CHROMA_SERVER_URL
 from vidxp.dependencies import active_requirements, packaged_requirements
+from vidxp.evidence_delivery import EvidenceDeliveryService
 from vidxp.infrastructure.local_index import (
     LOCAL_INDEX_RUNTIME_CHECKS,
     SERVER_INDEX_RUNTIME_CHECKS,
@@ -122,6 +123,7 @@ class ControlPlaneContext:
     jobs: JobService
     authorization: AuthorizationPolicy
     settings: VidXPSettings
+    evidence_delivery: EvidenceDeliveryService | None = None
     catalog: SQLCatalog | None = None
     uploads: RemoteUploadService | None = None
     _closed: bool = field(default=False, init=False, repr=False, compare=False)
@@ -279,6 +281,22 @@ def _create_control_plane_components(
     )
 
 
+def _create_artifact_service(
+    settings: VidXPSettings,
+    components: _ControlPlaneComponents,
+) -> ArtifactService:
+    return ArtifactService(
+        catalog=components.catalog,
+        store=components.artifact_store,
+        media=components.media,
+        probe=components.probe,
+        actor_renderer=LocalActorRenderer(),
+        snippet_renderer=FFmpegSnippetRenderer(settings.ffmpeg_executable),
+        frame_renderer=FFmpegFrameRenderer(settings.ffmpeg_executable),
+        max_snippet_duration_seconds=settings.max_snippet_duration_seconds,
+    )
+
+
 def settings_for_repository(
     repository: RepositoryConfig,
     *,
@@ -318,16 +336,7 @@ def create_application(
         chroma_server_url=_server_chroma_url(active_settings),
         snapshot_repository=components.snapshots,
     )
-    artifacts = ArtifactService(
-        catalog=components.catalog,
-        store=components.artifact_store,
-        media=components.media,
-        probe=components.probe,
-        actor_renderer=LocalActorRenderer(),
-        snippet_renderer=FFmpegSnippetRenderer(active_settings.ffmpeg_executable),
-        frame_renderer=FFmpegFrameRenderer(active_settings.ffmpeg_executable),
-        max_snippet_duration_seconds=(active_settings.max_snippet_duration_seconds),
-    )
+    artifacts = _create_artifact_service(active_settings, components)
     upload_service = RemoteUploadService(
         settings=active_settings,
         catalog=components.catalog,
@@ -420,6 +429,7 @@ def create_control_plane_application(
 ) -> ControlPlaneContext:
     active_settings = settings or VidXPSettings()
     components = _create_control_plane_components(active_settings)
+    artifacts = _create_artifact_service(active_settings, components)
     application = ControlPlaneApplication(
         layout=active_settings.layout,
         capabilities=CapabilityService(components.registry),
@@ -451,6 +461,11 @@ def create_control_plane_application(
         jobs=jobs,
         authorization=AuthorizationPolicy(),
         settings=active_settings,
+        evidence_delivery=EvidenceDeliveryService(
+            artifacts=artifacts,
+            media=components.media,
+            max_clip_duration_seconds=(active_settings.max_snippet_duration_seconds),
+        ),
         catalog=components.catalog,
         uploads=uploads,
     )
@@ -506,6 +521,7 @@ def create_http_application(
         jobs=control.jobs,
         authorization=control.authorization,
         settings=control.settings,
+        evidence_delivery=control.evidence_delivery,
         catalog=control.catalog,
         uploads=control.uploads,
         readiness=ReadinessService(

--- a/src/vidxp/evidence_delivery.py
+++ b/src/vidxp/evidence_delivery.py
@@ -286,6 +286,33 @@ class EvidenceDeliveryService:
         )
         return answer.model_copy(update={"evidence_delivery": delivery})
 
+    def deliver_selected(
+        self,
+        result: FusedSearchResult | QueryAnswer,
+        evidence_ids: tuple[str, ...],
+        policy: EvidenceDeliveryPolicy,
+        *,
+        execution: ExecutionContext | None = None,
+    ) -> EvidenceDeliveryResult:
+        """Materialize a bounded selection from a completed retrieval result."""
+
+        candidates = (
+            self._search_candidates(result)
+            if isinstance(result, FusedSearchResult)
+            else self._query_candidates(result)
+        )
+        by_id = {candidate.evidence_id: candidate for candidate in candidates}
+        missing = tuple(item for item in evidence_ids if item not in by_id)
+        if missing:
+            raise ApplicationError(
+                "evidence_not_in_source_job",
+                ErrorCategory.not_found,
+                "One or more evidence IDs do not belong to the completed source job.",
+                details={"evidence_ids": list(missing)},
+            )
+        selected = tuple(by_id[item] for item in evidence_ids)
+        return self._deliver(selected, policy, execution=execution)
+
     def _deliver(
         self,
         candidates: tuple[_Candidate, ...],

--- a/src/vidxp/mcp.py
+++ b/src/vidxp/mcp.py
@@ -43,10 +43,12 @@ from vidxp.application_models import (
     CreateIndexCommand,
     ErrorCategory,
     ErrorDetail,
-    EvidenceArtifact,
     EvidenceDeliveryMode,
     EvidenceDeliveryPolicy,
+    EvidenceDeliveryResult,
+    FusedSearchResult,
     Identifier,
+    InitialEvidenceDeliveryPolicy,
     IndexStatus,
     Job,
     JobId,
@@ -63,6 +65,7 @@ from vidxp.application_models import (
     Principal,
     PrepareModelsCommand,
     QueryVideoCommand,
+    QueryAnswer,
     RuntimeReadiness,
     SearchCommand,
     Sha256,
@@ -95,7 +98,7 @@ from vidxp.idempotency import (
     scoped_request_key,
 )
 from vidxp.core.identifiers import ArtifactId
-from vidxp.evidence_projection import project_job_artifacts
+from vidxp.evidence_delivery import EvidenceDeliveryService
 from vidxp.settings import HttpAuthMode
 from vidxp.upload_service import RemoteUploadService
 
@@ -214,6 +217,16 @@ def _uploads(context: ControlPlaneContext) -> RemoteUploadService:
             "Media ingestion is unavailable on this transport.",
         )
     return context.uploads
+
+
+def _evidence_delivery(context: ControlPlaneContext) -> EvidenceDeliveryService:
+    if context.evidence_delivery is None:
+        raise ApplicationError(
+            "evidence_delivery_unavailable",
+            ErrorCategory.unavailable,
+            "Evidence materialization is unavailable on this runtime.",
+        )
+    return context.evidence_delivery
 
 
 def _ingestion_modalities(
@@ -509,9 +522,12 @@ def create_mcp_server(
             "snapshot. MCP defaults to three ranked evidence frames; request "
             "keyframes_and_clips to receive bounded ready clips in the same "
             "completed job. The ordinary flow is submit search/query, then poll "
-            "that job. create_evidence_clip, create_clip, and "
-            "get_artifact_download remain advanced fallbacks. Use list_jobs to "
-            "recover job IDs across agent sessions."
+            "that job. Use materialize_job_evidence with evidence IDs from the "
+            "completed result to inspect additional candidates in batches of "
+            "ten without rerunning retrieval or supplying timestamps. "
+            "create_evidence_clip, create_clip, and get_artifact_download remain "
+            "advanced fallbacks. Use list_jobs to recover job IDs across agent "
+            "sessions."
         ),
         version=__version__,
         token_verifier=token_verifier,
@@ -776,6 +792,103 @@ def create_mcp_server(
             download_expires_at=download_expires_at,
             delivery_error=delivery_error,
         ), link
+
+    async def project_evidence_delivery(
+        delivery: EvidenceDeliveryResult,
+    ) -> tuple[
+        EvidenceDeliveryResult,
+        list[ImageContent | ResourceLink | TextContent],
+    ]:
+        blocks: list[ImageContent | ResourceLink | TextContent] = []
+        projected_items = []
+        for item in delivery.items:
+            keyframe = item.keyframe
+            clip = item.clip
+            label = (
+                f"evidence {item.evidence_id} rank {item.rank}; "
+                f"media {item.media_id}; {','.join(item.modalities)}"
+            )
+            if item.range is not None:
+                label += (
+                    f"; {item.range.source_start_seconds:.3f}-"
+                    f"{item.range.source_end_seconds:.3f}s"
+                )
+            if keyframe is not None:
+                frame_delivery, frame_link = await project_artifact_delivery(
+                    keyframe.artifact.artifact,
+                    title=f"VidXP evidence frame #{item.rank}",
+                    description=label,
+                )
+                keyframe = keyframe.model_copy(
+                    update={
+                        "artifact": keyframe.artifact.model_copy(
+                            update={
+                                "resource_uri": frame_delivery.resource_uri,
+                                "delivery": frame_delivery,
+                            }
+                        )
+                    }
+                )
+                frame = keyframe.artifact.artifact
+                if (
+                    frame.byte_size <= 512_000
+                    and frame.byte_size <= settings.mcp_max_resource_bytes
+                    and keyframe.width <= 1280
+                    and keyframe.height <= 1280
+                ):
+                    image_bytes = await artifact_bytes(
+                        frame.artifact_id,
+                        expected_mime_type="image/png",
+                    )
+                    blocks.append(
+                        ImageContent(
+                            data=base64.b64encode(image_bytes).decode(),
+                            mimeType="image/png",
+                        )
+                    )
+                if frame_link is not None:
+                    blocks.append(frame_link)
+            if clip is not None and item.range is not None:
+                clip_delivery, clip_link = await project_artifact_delivery(
+                    clip.artifact,
+                    title=f"VidXP evidence clip #{item.rank}",
+                    description=(
+                        f"{label}; resolved clip "
+                        f"{item.range.clip_start_seconds:.3f}-"
+                        f"{item.range.clip_end_seconds:.3f}s"
+                    ),
+                )
+                clip = clip.model_copy(
+                    update={
+                        "resource_uri": clip_delivery.resource_uri,
+                        "delivery": clip_delivery,
+                    }
+                )
+                if clip_link is not None:
+                    blocks.append(clip_link)
+            projected_items.append(
+                item.model_copy(update={"keyframe": keyframe, "clip": clip})
+            )
+        return (
+            delivery.model_copy(update={"items": tuple(projected_items)}),
+            blocks,
+        )
+
+    def completed_evidence_result(
+        source_job_id: JobId,
+    ) -> FusedSearchResult | QueryAnswer:
+        source = context.jobs.get(source_job_id)
+        if (
+            source.state != JobState.succeeded
+            or source.result is None
+            or source.kind not in {JobKind.search, JobKind.query}
+        ):
+            raise ApplicationError(
+                "evidence_source_job_not_complete",
+                ErrorCategory.conflict,
+                "Evidence materialization requires a completed search or query job.",
+            )
+        return source.result.result
 
     @server.tool(
         title="Inspect VidXP workspace",
@@ -1144,7 +1257,7 @@ def create_mcp_server(
             if command.evidence_delivery is None:
                 projected = command.model_copy(
                     update={
-                        "evidence_delivery": EvidenceDeliveryPolicy(
+                        "evidence_delivery": InitialEvidenceDeliveryPolicy(
                             mode=EvidenceDeliveryMode.keyframes
                         )
                     }
@@ -1194,7 +1307,7 @@ def create_mcp_server(
             if command.evidence_delivery is None:
                 projected = command.model_copy(
                     update={
-                        "evidence_delivery": EvidenceDeliveryPolicy(
+                        "evidence_delivery": InitialEvidenceDeliveryPolicy(
                             mode=EvidenceDeliveryMode.keyframes
                         )
                     }
@@ -1273,25 +1386,12 @@ def create_mcp_server(
         profile: SnippetProfile = SnippetProfile.compatible_mp4,
     ) -> Job:
         def submit(actor: Principal) -> Job:
-            source = context.jobs.get(source_job_id)
-            if (
-                source.state != JobState.succeeded
-                or source.result is None
-                or source.kind not in {JobKind.search, JobKind.query}
-            ):
-                raise ApplicationError(
-                    "evidence_source_job_not_complete",
-                    ErrorCategory.conflict,
-                    "Evidence clips require a completed search or query job.",
-                )
-            result = source.result.result
-            candidate, resolved = (
-                context.application.evidence_delivery.resolve_job_evidence(
-                    result,
-                    evidence_id,
-                    padding_before=padding_before_seconds,
-                    padding_after=padding_after_seconds,
-                )
+            result = completed_evidence_result(source_job_id)
+            candidate, resolved = _evidence_delivery(context).resolve_job_evidence(
+                result,
+                evidence_id,
+                padding_before=padding_before_seconds,
+                padding_after=padding_after_seconds,
             )
             return context.jobs.submit_snippet(
                 CreateSnippetCommand(
@@ -1317,6 +1417,77 @@ def create_mcp_server(
             default_principal=default_principal,
             permission=RepositoryPermission.write,
             operation=submit,
+        )
+
+    @server.tool(
+        title="Materialize job evidence",
+        description=(
+            "Prepare keyframes and optional clips for one to ten evidence IDs "
+            "from a completed search/query job. Use this to inspect candidates "
+            "outside the initial bounded evidence delivery without supplying "
+            "timestamps or rerunning retrieval."
+        ),
+        annotations=_SUBMIT,
+        structured_output=True,
+    )
+    async def materialize_job_evidence(
+        source_job_id: JobId,
+        evidence_ids: Annotated[
+            tuple[Sha256, ...],
+            Field(min_length=1, max_length=10),
+        ],
+        mode: Literal[
+            EvidenceDeliveryMode.keyframes,
+            EvidenceDeliveryMode.keyframes_and_clips,
+        ] = EvidenceDeliveryMode.keyframes,
+        padding_before_seconds: Annotated[float, Field(ge=0, le=30)] = 2.0,
+        padding_after_seconds: Annotated[float, Field(ge=0, le=30)] = 2.0,
+        profile: SnippetProfile = SnippetProfile.compatible_mp4,
+    ) -> Annotated[CallToolResult, EvidenceDeliveryResult]:
+        if len(evidence_ids) != len(set(evidence_ids)):
+            raise _application_error(
+                ApplicationError(
+                    "duplicate_evidence_ids",
+                    ErrorCategory.validation,
+                    "Evidence IDs must be unique within one materialization request.",
+                )
+            )
+
+        def materialize(_actor: Principal) -> EvidenceDeliveryResult:
+            result = completed_evidence_result(source_job_id)
+            return _evidence_delivery(context).deliver_selected(
+                result,
+                evidence_ids,
+                EvidenceDeliveryPolicy(
+                    mode=mode,
+                    max_items=len(evidence_ids),
+                    padding_before_seconds=padding_before_seconds,
+                    padding_after_seconds=padding_after_seconds,
+                    clip_profile=profile,
+                ),
+            )
+
+        delivery = await _invoke_async(
+            context,
+            default_principal=default_principal,
+            permission=(
+                RepositoryPermission.write
+                if mode == EvidenceDeliveryMode.keyframes_and_clips
+                else RepositoryPermission.read
+            ),
+            operation=materialize,
+        )
+        projected, blocks = await project_evidence_delivery(delivery)
+        if not blocks:
+            blocks.append(
+                TextContent(
+                    type="text",
+                    text="VidXP could not produce the requested evidence artifacts.",
+                )
+            )
+        return CallToolResult(
+            content=blocks,
+            structured_content=projected.model_dump(mode="json"),
         )
 
     @server.tool(
@@ -1399,77 +1570,17 @@ def create_mcp_server(
             result = job.result.result
             delivery = result.evidence_delivery
             if delivery is not None:
-                projected_artifacts: dict[str, EvidenceArtifact] = {}
-                for item in delivery.items:
-                    keyframe = item.keyframe
-                    clip = item.clip
-                    label = (
-                        f"evidence {item.evidence_id} rank {item.rank}; "
-                        f"media {item.media_id}; "
-                        f"{','.join(item.modalities)}"
-                    )
-                    if item.range is not None:
-                        label += (
-                            f"; {item.range.source_start_seconds:.3f}-"
-                            f"{item.range.source_end_seconds:.3f}s"
-                        )
-                    if keyframe is not None:
-                        frame_delivery, frame_link = await project_artifact_delivery(
-                            keyframe.artifact.artifact,
-                            title=f"VidXP evidence frame #{item.rank}",
-                            description=label,
-                        )
-                        projected_artifacts[
-                            keyframe.artifact.artifact.artifact_id
-                        ] = keyframe.artifact.model_copy(
+                projected_delivery, blocks = await project_evidence_delivery(delivery)
+                projected = job.model_copy(
+                    update={
+                        "result": job.result.model_copy(
                             update={
-                                "resource_uri": frame_delivery.resource_uri,
-                                "delivery": frame_delivery,
-                            }
-                        )
-                        if (
-                            keyframe.artifact.artifact.byte_size <= 512_000
-                            and keyframe.artifact.artifact.byte_size
-                            <= settings.mcp_max_resource_bytes
-                            and keyframe.width <= 1280
-                            and keyframe.height <= 1280
-                        ):
-                            image_bytes = await artifact_bytes(
-                                keyframe.artifact.artifact.artifact_id,
-                                expected_mime_type="image/png",
-                            )
-                            blocks.append(
-                                ImageContent(
-                                    data=base64.b64encode(image_bytes).decode(),
-                                    mimeType="image/png",
+                                "result": result.model_copy(
+                                    update={"evidence_delivery": projected_delivery}
                                 )
-                            )
-                        if frame_link is not None:
-                            blocks.append(frame_link)
-                    if clip is not None and item.range is not None:
-                        clip_delivery, clip_link = await project_artifact_delivery(
-                            clip.artifact,
-                            title=f"VidXP evidence clip #{item.rank}",
-                            description=(
-                                f"{label}; resolved clip "
-                                f"{item.range.clip_start_seconds:.3f}-"
-                                f"{item.range.clip_end_seconds:.3f}s"
-                            ),
-                        )
-                        projected_artifacts[clip.artifact.artifact_id] = clip.model_copy(
-                            update={
-                                "resource_uri": clip_delivery.resource_uri,
-                                "delivery": clip_delivery,
                             }
                         )
-                        if clip_link is not None:
-                            blocks.append(clip_link)
-                projected = project_job_artifacts(
-                    job,
-                    project_artifact=lambda evidence: projected_artifacts.get(
-                        evidence.artifact.artifact_id,
-                        evidence,
-                    ),
+                    }
                 )
         if not blocks:
             blocks.append(

--- a/tests/test_evidence_delivery.py
+++ b/tests/test_evidence_delivery.py
@@ -306,6 +306,37 @@ class EvidenceDeliveryTests(unittest.TestCase):
             )
         self.assertEqual(raised.exception.code, "evidence_not_in_source_job")
 
+    def test_selected_delivery_materializes_only_requested_job_evidence(self):
+        service, artifacts = self.service()
+        source = fused()
+        evidence_id = source.moments[0].moment_id
+
+        delivery = service.deliver_selected(
+            source,
+            (evidence_id,),
+            EvidenceDeliveryPolicy(
+                mode=EvidenceDeliveryMode.keyframes_and_clips,
+                max_items=1,
+            ),
+        )
+
+        self.assertEqual([item.evidence_id for item in delivery.items], [evidence_id])
+        self.assertIsNotNone(delivery.items[0].keyframe)
+        self.assertIsNotNone(delivery.items[0].clip)
+        artifacts.create_evidence_frame.assert_called_once()
+        artifacts.create_snippet.assert_called_once()
+
+        with self.assertRaises(ApplicationError) as raised:
+            service.deliver_selected(
+                source,
+                ("f" * 64,),
+                EvidenceDeliveryPolicy(
+                    mode=EvidenceDeliveryMode.keyframes,
+                    max_items=1,
+                ),
+            )
+        self.assertEqual(raised.exception.code, "evidence_not_in_source_job")
+
     def test_range_resolution_failure_is_scoped_to_the_evidence_item(self):
         service, _artifacts = self.service()
         service.media.require_record.side_effect = RuntimeError("media unavailable")

--- a/tests/test_job_contracts.py
+++ b/tests/test_job_contracts.py
@@ -11,6 +11,8 @@ from vidxp.application_models import (
     ApplicationError,
     ErrorCategory,
     ErrorDetail,
+    EvidenceDeliveryMode,
+    EvidenceDeliveryPolicy,
     CreateActorOverlayCommand,
     CreateIndexCommand,
     Job,
@@ -278,6 +280,18 @@ class JobContractTests(unittest.TestCase):
             )
         )
         self.assertIn("%20", encoded_cluster.cluster_id)
+
+    def test_initial_evidence_stays_bounded_while_followup_allows_ten(self):
+        followup = EvidenceDeliveryPolicy(
+            mode=EvidenceDeliveryMode.keyframes,
+            max_items=10,
+        )
+        self.assertEqual(followup.max_items, 10)
+
+        with self.assertRaises(ValidationError):
+            SearchCommand(query="taxi", evidence_delivery=followup)
+        with self.assertRaises(ValidationError):
+            QueryVideoCommand(question="Where is it?", evidence_delivery=followup)
 
     def test_canonical_dbos_job_id_has_a_hex_operation_identity(self):
         execution = ExecutionContext(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -45,6 +45,7 @@ from vidxp.application_models import (
     EvidenceDeliveryMode,
     EvidenceDeliveryPolicy,
     IndexStatus,
+    InitialEvidenceDeliveryPolicy,
     Job,
     JobKind,
     JobPage,
@@ -112,6 +113,7 @@ MCP_TOOL_NAMES = [
     "query_video",
     "create_clip",
     "create_evidence_clip",
+    "materialize_job_evidence",
     "get_artifact_download",
     "list_jobs",
     "get_job",
@@ -650,9 +652,7 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
                     "get_media_upload",
                     {"upload_session_id": UPLOAD_SESSION_ID},
                 )
-                preserved_media_id = status.structured_content["items"][0][
-                    "media_id"
-                ]
+                preserved_media_id = status.structured_content["items"][0]["media_id"]
                 retried = await client.call_tool(
                     "start_indexing",
                     {
@@ -1104,7 +1104,7 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
         rendered = output.getvalue()
         self.assertIn("OK VidXP MCP", rendered)
         self.assertIn("Index state: missing", rendered)
-        self.assertIn("Tools: 20", rendered)
+        self.assertIn("Tools: 21", rendered)
         self.assertIn("get_index_status", rendered)
 
     async def test_server_info_exposes_vidxp_branding(self):
@@ -1266,7 +1266,7 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
                 question="What happens after the taxi arrives?",
                 media_id=MEDIA_ID,
                 modalities=("scene", "dialogue"),
-                evidence_delivery=EvidenceDeliveryPolicy(
+                evidence_delivery=InitialEvidenceDeliveryPolicy(
                     mode=EvidenceDeliveryMode.keyframes
                 ),
             ),
@@ -1413,9 +1413,7 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
                         artifact_delivery=transport,
                     )
                     async with Client(server) as client:
-                        result = await client.call_tool(
-                            "get_job", {"job_id": JOB_ID}
-                        )
+                        result = await client.call_tool("get_job", {"job_id": JOB_ID})
                         uri = f"vidxp://artifacts/{ARTIFACT_ID}/content.png"
                         resource = await client.read_resource(uri)
 
@@ -1555,9 +1553,10 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
             context.jobs.submit_snippet.return_value = queued_job().model_copy(
                 update={"kind": JobKind.snippet}
             )
-            context.application.evidence_delivery = Mock()
+            evidence_delivery = Mock()
+            context = replace(context, evidence_delivery=evidence_delivery)
             resolved = source.result.result.evidence_delivery.items[0].range
-            context.application.evidence_delivery.resolve_job_evidence.return_value = (
+            evidence_delivery.resolve_job_evidence.return_value = (
                 SimpleNamespace(media_id=MEDIA_ID),
                 resolved,
             )
@@ -1587,12 +1586,93 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(command.end_seconds, resolved.clip_end_seconds)
             calls = context.jobs.submit_snippet.call_args_list
             self.assertEqual(calls[0].kwargs["job_id"], calls[1].kwargs["job_id"])
-            resolver = context.application.evidence_delivery.resolve_job_evidence
+            resolver = evidence_delivery.resolve_job_evidence
             resolver.assert_called_with(
                 source.result.result,
                 "e" * 64,
                 padding_before=2.0,
                 padding_after=2.0,
+            )
+
+    async def test_materialize_job_evidence_returns_selected_frames_and_clips(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            frame_path = root / "frame.png"
+            frame_path.write_bytes(b"x")
+            context = self.context(root, mcp_stdio_filesystem_accessible=False)
+            frame = Artifact(
+                artifact_id=ARTIFACT_ID,
+                media_id=MEDIA_ID,
+                generation_id="523456781234423481234567890abcde",
+                job_id=JOB_ID,
+                kind=ArtifactKind.evidence_frame,
+                profile="png",
+                mime_type="image/png",
+                byte_size=1,
+                sha256="a" * 64,
+                state=ArtifactState.ready,
+                created_at=datetime.now(timezone.utc),
+            )
+            clip = Artifact(
+                artifact_id="423456781234423481234567890abcde",
+                media_id=MEDIA_ID,
+                job_id=JOB_ID,
+                kind=ArtifactKind.snippet,
+                profile="compatible_mp4",
+                mime_type="video/mp4",
+                byte_size=4,
+                sha256="b" * 64,
+                state=ArtifactState.ready,
+                created_at=datetime.now(timezone.utc),
+            )
+            source = search_evidence_job(frame, clip)
+            delivery = source.result.result.evidence_delivery
+            evidence_delivery = Mock()
+            evidence_delivery.deliver_selected.return_value = delivery
+            context = replace(context, evidence_delivery=evidence_delivery)
+            context.jobs.get.return_value = source
+            context.application.open_artifact_content.return_value = LocalFileResource(
+                path=frame_path,
+                filename="frame.png",
+                mime_type="image/png",
+                byte_size=1,
+                etag="a" * 64,
+            )
+            server = create_mcp_server(
+                context,
+                default_principal=Principal(
+                    subject="agent",
+                    scopes=frozenset({"vidxp.read", "vidxp.write"}),
+                ),
+            )
+
+            async with Client(server) as client:
+                result = await client.call_tool(
+                    "materialize_job_evidence",
+                    {
+                        "source_job_id": JOB_ID,
+                        "evidence_ids": ["e" * 64],
+                        "mode": "keyframes_and_clips",
+                    },
+                )
+
+            self.assertFalse(result.is_error, result.content)
+            self.assertTrue(
+                any(isinstance(block, ImageContent) for block in result.content)
+            )
+            self.assertEqual(
+                sum(isinstance(block, ResourceLink) for block in result.content),
+                2,
+            )
+            item = result.structured_content["items"][0]
+            self.assertIsNotNone(item["keyframe"]["artifact"]["resource_uri"])
+            self.assertIsNotNone(item["clip"]["resource_uri"])
+            call = evidence_delivery.deliver_selected.call_args
+            self.assertEqual(call.args[0], source.result.result)
+            self.assertEqual(call.args[1], ("e" * 64,))
+            self.assertEqual(
+                call.args[2].mode,
+                EvidenceDeliveryMode.keyframes_and_clips,
             )
 
     async def test_one_job_search_returns_frame_and_ready_clip(self):
@@ -2323,7 +2403,7 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
                 server.should_exit = True
                 await serving
 
-        self.assertEqual(len(discovered.tools), 18)
+        self.assertEqual(len(discovered.tools), 19)
         self.assertNotIn(
             "create_media_upload",
             {tool.name for tool in discovered.tools},


### PR DESCRIPTION
## Summary
- repair `create_evidence_clip` for the control-plane application used by stdio and Streamable HTTP
- add `materialize_job_evidence` for explicit follow-up keyframe/clip batches of up to 10 evidence IDs while retaining the automatic 5-item search/query ceiling
- reuse the existing evidence renderer and transport-specific artifact projection rather than requiring timestamps or rerunning retrieval
- update the public VidXP skills to surface returned evidence and accurately describe the current anonymous actor-cluster scope
- default the ingestion skill to dialogue and scene, leaving actor indexing opt-in until its exact detection and overlay operations are available through MCP

## Validation
- 74 focused tests passed, plus 7 subtests
- Ruff and `git diff --check` passed
- both public skills passed `quick_validate.py`
- real stdio MCP regression verified the formerly crashing evidence-clip path
- real MCP materialization returned a complete 10-item evidence batch
- shared server schema verified 10 follow-up items and the retained 5-item automatic ceiling

BEGIN_COMMIT_OVERRIDE
chore(mcp): stabilize follow-up evidence delivery
END_COMMIT_OVERRIDE