### PR TITLE
feat(mcp): add reusable evidence boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ See the [Coolify guide](docs/deployment/coolify.md) for the complete setup.
 - Group recurring faces in a video and render a highlighted actor overlay.
 - Search one selected video or every video in the active library.
 - Open matching timestamps and export downloadable clips and overlays.
+- Review larger result sets as annotated evidence boards, then open the exact
+  frames or clips worth inspecting.
 - Retrieve completed clips through native MCP resources, local stdio paths, or
   short-lived resumable HTTPS downloads without embedding video bytes in tool JSON.
 - Keep personal, client, or project libraries separate.
@@ -194,6 +196,9 @@ agents can show the evidence behind an answer without making users translate raw
 timestamps. Evidence rendering is best-effort: a result can still be useful when
 an individual frame or clip cannot be produced. Agents can request additional
 ranked evidence in small batches without rerunning the search.
+For broader result sets, an agent can first show bounded evidence-board pages
+with a tile-to-evidence map, then fetch exact frames or clips only for the
+selected tiles.
 
 Remote agents can hand users a short-lived page for selecting and uploading
 multiple videos. Local agents can ingest approved filesystem paths without moving

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ See the [Coolify guide](docs/deployment/coolify.md) for the complete setup.
 - Group recurring faces in a video and render a highlighted actor overlay.
 - Search one selected video or every video in the active library.
 - Open matching timestamps and export downloadable clips and overlays.
-- Review larger result sets as annotated evidence boards, then open the exact
-  frames or clips worth inspecting.
+- Receive search and query results as annotated evidence boards, then open the
+  exact frames or clips worth inspecting.
 - Retrieve completed clips through native MCP resources, local stdio paths, or
   short-lived resumable HTTPS downloads without embedding video bytes in tool JSON.
 - Keep personal, client, or project libraries separate.

--- a/docs/architecture/platform.md
+++ b/docs/architecture/platform.md
@@ -933,6 +933,14 @@ requires repository write scope, matching the low-level clip operation.
 Evidence artifacts are best-effort and may fail independently, so completed result
 sets can contain partial frame or clip delivery.
 
+`create_evidence_board` freezes ranked candidates from a completed search or query
+job and submits a durable CPU job. It reuses the existing evidence-frame and
+artifact services to compose annotated, media-separated JPEG pages. The default
+budget is 24 tiles per page and four pages per job; `next_start_rank` continues
+without a fixed ten-item board cap. Completed board jobs return native MCP image
+resources plus a tile map back to the original evidence IDs. Individual frames and
+clips remain the authoritative drill-down path.
+
 ## 18. FastAPI adapter
 
 FastAPI owns:
@@ -1052,6 +1060,7 @@ Initial curated tools:
 - `create_clip`
 - `create_evidence_clip`
 - `materialize_job_evidence`
+- `create_evidence_board`
 - `get_artifact_download`
 - `list_jobs`
 - `get_job`

--- a/docs/architecture/platform.md
+++ b/docs/architecture/platform.md
@@ -917,29 +917,21 @@ its listener. Filesystem-isolated or remote deployments with an oversized artifa
 and no public download origin report delivery as unavailable with configuration
 guidance.
 
-Search and query jobs can request bounded evidence delivery. MCP defaults to the
-strongest three keyframes; callers may select `none`, `keyframes`, or
-`keyframes_and_clips`, with a hard maximum of five items. Scene evidence extracts
-the authoritative indexed frame number. Other intervals and anonymous actor
-clusters use a clearly labeled representative full frame. Requested clips are
-range-clamped and rendered through the same snippet artifact service before the
-original search/query job succeeds, so the ordinary agent path is one submit plus
-polling that same job. `materialize_job_evidence` accepts one to ten stable evidence
-IDs from that completed result and produces follow-up keyframes or clips without
-rerunning retrieval. `create_evidence_clip` derives a single fallback clip from the
-same source-job contract; callers cannot supply authoritative timestamps.
-Keyframe-only retrieval keeps the existing read scope; requesting clip rendering
-requires repository write scope, matching the low-level clip operation.
-Evidence artifacts are best-effort and may fail independently, so completed result
-sets can contain partial frame or clip delivery.
+MCP search and query jobs compile their ranked candidates into annotated,
+media-separated JPEG evidence boards before the original job succeeds. The board
+uses the existing evidence-frame and artifact services, returns native image
+resources plus a tile map to stable evidence IDs, and is included in the same
+`get_job` response. The default budget is 24 tiles per page and four pages per
+job; `next_start_rank` continues without imposing the standalone-artifact limit.
 
-`create_evidence_board` freezes ranked candidates from a completed search or query
-job and submits a durable CPU job. It reuses the existing evidence-frame and
-artifact services to compose annotated, media-separated JPEG pages. The default
-budget is 24 tiles per page and four pages per job; `next_start_rank` continues
-without a fixed ten-item board cap. Completed board jobs return native MCP image
-resources plus a tile map back to the original evidence IDs. Individual frames and
-clips remain the authoritative drill-down path.
+Callers may additionally request `keyframes` or `keyframes_and_clips`, with a hard
+maximum of five standalone items in the initial job. Scene evidence extracts the
+authoritative indexed frame number; other intervals and anonymous actor clusters
+use a labeled representative frame. `materialize_job_evidence` accepts one to ten
+board evidence IDs for later frame or clip drill-down without rerunning retrieval.
+`create_evidence_board` remains for custom selections and continuation pages, and
+`create_evidence_clip` remains the single-item fallback. Clip rendering requires
+repository write scope; boards and keyframes retain read scope.
 
 ## 18. FastAPI adapter
 

--- a/skills/vidxp-find-video-evidence/SKILL.md
+++ b/skills/vidxp-find-video-evidence/SKILL.md
@@ -5,100 +5,44 @@ description: Use VidXP to search indexed videos, answer grounded questions about
 
 # Find video evidence with VidXP
 
-Use VidXP retrieval and its returned evidence as one workflow. Do not make the
-user translate timestamps into separate clip requests when the ordinary search
-can deliver frames and clips itself.
-
 ## Workflow
 
-1. Resolve the declared `vidxp` MCP dependency. When the host supports lazy
-   connector or tool discovery, search for VidXP before concluding it is absent.
-   If its tools still cannot be loaded, say that the VidXP connector is not
-   connected and stop instead of silently using unrelated search tools.
-2. Call `get_workspace` before searching. Select the requested indexed media ID
-   when the user identifies one video; otherwise search the active snapshot.
-   If the requested video is not indexed, explain that ingestion or indexing is
-   required before retrieval.
-3. Choose the operation by the requested outcome:
-   - Use `search_moments` to locate or list matching moments.
-   - Use `query_video` for a grounded answer that combines retrieved evidence.
-4. Set `command.evidence_delivery.mode` to `keyframes_and_clips` when the user
-   asks where something occurs, wants verification, or is likely to
-   share/download the result. For example:
-   `"evidence_delivery": {"mode": "keyframes_and_clips", "max_items": 3}`.
-   This object belongs inside `command`; never send `command.materialize`,
-   which is not a `search_moments` or `query_video` input. Use `keyframes` when
-   clips add no value.
-5. Poll only the submitted job with `get_job`. The completed job is the
-   authoritative source for ranked results, evidence, frames, clips, and
-   ResourceLinks.
-6. Inspect returned keyframes before asserting that a person or action is
-   visibly present. Distinguish visual appearances from dialogue mentions.
-7. For a broad result set, call `create_evidence_board` on the completed source
-   job and poll its returned job ID. Inspect its annotated pages and tile map;
-   follow `next_start_rank` when another bounded page set remains. Boards are
-   overviews, not replacements for the underlying evidence IDs.
-8. Drill into selected board tiles with `materialize_job_evidence` in batches of
-   at most ten. Request keyframes for exact inspection and add clips only for
-   results worth presenting. Do not rerun retrieval or reconstruct timestamps
-   in FFmpeg.
+1. Resolve the `vidxp` MCP tools, then call `get_workspace`. If the requested
+   video is not indexed, explain that it must be indexed first.
+2. Use `search_moments` to locate moments or `query_video` for a synthesized,
+   grounded answer. Set `command.media_id` when the user means one video.
+3. Omit `command.evidence_delivery` for the normal path. The completed job
+   includes an annotated board covering the ranked results.
+4. Poll only that job with `get_job`, honoring `poll_after_seconds`. Search and
+   query may take time; update the user when the stage changes or about once per
+   minute, never on every poll and never with an invented ETA.
+5. Inspect and show the returned board before making visual claims. Use its tile
+   evidence IDs for follow-up:
+   - `materialize_job_evidence` accepts up to ten selected IDs and returns
+     standalone keyframes or clips without rerunning retrieval.
+   - `create_evidence_board` is only for a custom selection or the
+     `next_start_rank` continuation; poll its returned job ID.
+6. When standalone artifacts are required in the initial job, put exactly this
+   inside `command`: `"evidence_delivery": {"mode":
+   "keyframes_and_clips", "max_items": 3}`. Never send
+   `command.materialize`.
 
-## Current actor scope
+## Actor scope
 
-- Use `query_video`, not `search_moments`, when anonymous actor-cluster context
-  is useful. The actor capability has no text-search operation, so it cannot
-  search a person's name or accept a reference identity.
-- Treat actor evidence as video-scoped anonymous face clusters containing a
-  detection count and first-to-last sampled timestamp range. It does not prove
-  a name, continuous presence, speaking identity, or cross-video identity.
-- Actor evidence may fall outside the three items materialized automatically.
-  Select its evidence IDs from the completed job and use
-  `materialize_job_evidence` when a representative frame or clip is useful.
-- Label the returned actor image honestly: it is currently a representative
-  full frame near the middle of the cluster range, not an exact detection frame,
-  face crop, contact sheet, or identity verification.
-- Do not claim that MCP can list exact actor detections or create actor overlays.
-  Those operations exist in other VidXP interfaces but are not MCP tools yet.
+- Actor data is available through `query_video`, not name search. It represents
+  anonymous, video-scoped face clusters—not a named or cross-video identity.
+- Treat its image as a representative full frame, not an exact face crop or
+  proof of continuous presence. Do not claim exhaustive named appearances.
+- Use scene evidence plus board inspection for named-person requests, and label
+  uncertain matches as candidates.
 
-## Polling and presentation
+## Output
 
-- Explain that search and grounded queries are durable jobs and may take time,
-  especially when clips must be rendered.
-- Honor a server-provided polling interval when present. Otherwise poll after
-  about 5 seconds initially and back off to about 15 seconds for sustained work.
-  Never busy-loop or create a shell script merely to wait.
-- Reuse the submitted job ID and idempotency key. Give a concise update when the
-  job stage changes and approximately once per minute during long unchanged
-  work; do not narrate every poll or invent an ETA.
-- Evidence is not progressive while a search, query, or board job is running.
-  As soon as the completed `get_job` response supplies board pages, keyframes,
-  clips, or ResourceLinks, present them directly instead of returning only
-  timestamps or waiting for another request.
-- Include the returned evidence blocks or working resource/download references
-  in the final answer. Never leave an evidence heading empty. If the host does
-  not render a ResourceLink, say so and use `get_artifact_download` to provide
-  the transport-authoritative alternative.
-- Stop polling on success, failure, or cancellation. Preserve the job ID and
-  report structured remediation when the job does not succeed.
-
-## Evidence rules
-
-- Report the source video, resolved interval, modalities, evidence ID, and
-  available frame or clip for each useful result.
-- Describe ranking scores as retrieval scores, not calibrated probabilities.
-- Treat actor detections and clusters as anonymous until a trusted reference or
-  identity registry grounds them. A person's name in the query, dialogue, or
-  scene description is not identity proof.
-- For named-person searches, verify candidate appearances against each returned
-  frame and label uncertain results as candidates. Do not claim an exhaustive
-  list of appearances when the available capability cannot establish identity
-  across the whole video.
-- A failed or empty search means no matching indexed evidence was found; it does
-  not prove that the event is absent from the original video.
-- If a result has authoritative evidence but no requested clip, prefer
-  `create_evidence_clip`; VidXP resolves and clamps its range. Use
-  `get_artifact_download` only when the returned ResourceLink is insufficient for
-  the host or the user explicitly asks for a path or download link.
-- Use external FFmpeg extraction only after VidXP returns a structured failure
-  for both follow-up materialization and the evidence-clip fallback, and disclose
-  that substitution to the user.
+- Present returned board images, frames, clips, or working resource links—not
+  timestamps alone. If a host does not render a link, use
+  `get_artifact_download`.
+- Preserve the source job and evidence IDs. Describe scores as retrieval scores,
+  and distinguish a visible appearance from a dialogue or caption mention.
+- Stop polling on success, failure, or cancellation. An empty result means no
+  matching indexed evidence was found, not that the event is absent from the
+  original video.

--- a/skills/vidxp-find-video-evidence/SKILL.md
+++ b/skills/vidxp-find-video-evidence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vidxp-find-video-evidence
-description: Use VidXP to search indexed videos, answer grounded questions about video content, locate when people, actions, dialogue, or scenes occur, and return inspectable keyframes or clips. Trigger for requests such as "find where X appears," "when does Y happen," "what is said," "what happens," or "show me the matching clip," even when the user does not name VidXP. Do not trigger for ingesting new media or ordinary video editing.
+description: Use VidXP to search indexed videos, answer grounded questions about video content, locate when people, actions, dialogue, or scenes occur, and return inspectable evidence boards, keyframes, or clips. Trigger for requests such as "find where X appears," "when does Y happen," "what is said," "what happens," or "show me the matching clip," even when the user does not name VidXP. Do not trigger for ingesting new media or ordinary video editing.
 ---
 
 # Find video evidence with VidXP
@@ -30,11 +30,14 @@ can deliver frames and clips itself.
    ResourceLinks.
 6. Inspect returned keyframes before asserting that a person or action is
    visibly present. Distinguish visual appearances from dialogue mentions.
-7. When useful candidates extend beyond the initial evidence delivery, call
-   `materialize_job_evidence` with evidence IDs from the completed job in
-   batches of at most ten. Request keyframes for verification and add clips
-   only for results worth presenting. Do not rerun retrieval or reconstruct
-   timestamps in FFmpeg.
+7. For a broad result set, call `create_evidence_board` on the completed source
+   job and poll its returned job ID. Inspect its annotated pages and tile map;
+   follow `next_start_rank` when another bounded page set remains. Boards are
+   overviews, not replacements for the underlying evidence IDs.
+8. Drill into selected board tiles with `materialize_job_evidence` in batches of
+   at most ten. Request keyframes for exact inspection and add clips only for
+   results worth presenting. Do not rerun retrieval or reconstruct timestamps
+   in FFmpeg.
 
 ## Current actor scope
 
@@ -63,10 +66,10 @@ can deliver frames and clips itself.
 - Reuse the submitted job ID and idempotency key. Give a concise update when the
   job stage changes and approximately once per minute during long unchanged
   work; do not narrate every poll or invent an ETA.
-- Evidence is not progressive while the job is running. As soon as the completed
-  `get_job` response supplies keyframes, clips, or ResourceLinks, present them to
-  the user directly instead of returning only timestamps or waiting for another
-  request.
+- Evidence is not progressive while a search, query, or board job is running.
+  As soon as the completed `get_job` response supplies board pages, keyframes,
+  clips, or ResourceLinks, present them directly instead of returning only
+  timestamps or waiting for another request.
 - Include the returned evidence blocks or working resource/download references
   in the final answer. Never leave an evidence heading empty. If the host does
   not render a ResourceLink, say so and use `get_artifact_download` to provide

--- a/skills/vidxp-find-video-evidence/SKILL.md
+++ b/skills/vidxp-find-video-evidence/SKILL.md
@@ -22,9 +22,13 @@ can deliver frames and clips itself.
 3. Choose the operation by the requested outcome:
    - Use `search_moments` to locate or list matching moments.
    - Use `query_video` for a grounded answer that combines retrieved evidence.
-4. Request `keyframes_and_clips` when the user asks where something occurs,
-   wants verification, or is likely to share/download the result. Use keyframes
-   alone only when clips add no value.
+4. Set `command.evidence_delivery.mode` to `keyframes_and_clips` when the user
+   asks where something occurs, wants verification, or is likely to
+   share/download the result. For example:
+   `"evidence_delivery": {"mode": "keyframes_and_clips", "max_items": 3}`.
+   This object belongs inside `command`; never send `command.materialize`,
+   which is not a `search_moments` or `query_video` input. Use `keyframes` when
+   clips add no value.
 5. Poll only the submitted job with `get_job`. The completed job is the
    authoritative source for ranked results, evidence, frames, clips, and
    ResourceLinks.

--- a/skills/vidxp-ingest-video/SKILL.md
+++ b/skills/vidxp-ingest-video/SKILL.md
@@ -5,66 +5,30 @@ description: Use VidXP to upload, import, register, and automatically index vide
 
 # Ingest video with VidXP
 
-Use the VidXP MCP tools for the complete ingestion workflow. Do not replace them
-with an ad hoc upload script, base64 media in tool arguments, or manual database
-changes.
-
 ## Workflow
 
-1. Resolve the declared `vidxp` MCP dependency. When the host supports lazy
-   connector or tool discovery, search for VidXP before concluding it is absent.
-   If its tools still cannot be loaded, say that the VidXP connector is not
-   connected and stop instead of inventing a substitute.
-2. Call `get_workspace` to inspect existing media and index coverage. Avoid
-   importing the same video again when it is already registered or indexed.
-3. Select index modalities explicitly from the indexable capabilities returned
-   by `get_workspace`. For ordinary dialogue, scene, action, and named-person
-   retrieval, use `dialogue` and `scene` when available. Add `actor` only when
-   the user explicitly wants anonymous recurring-face cluster summaries; it
-   does not identify people by name or across videos, and exact detection or
-   overlay operations are not exposed through MCP yet. Do not omit `modalities`,
-   because omission indexes every installed capability.
-4. Call `get_runtime_readiness` before automatic indexing. If models required
-   by the selected modalities are missing, call `prepare_models` for those same
-   modalities and poll that job with `get_job` until it reaches a terminal state.
-5. Select ingestion from the tools actually exposed by the current transport:
-   - When `ingest_local_media` is available and the video has a filesystem path
-     accessible to VidXP, pass one to ten paths and poll only
-     `get_media_ingestion`.
-   - Otherwise call `create_media_upload`, give the returned upload link to the
-     user, and poll only `get_media_upload` after files are selected.
-6. Keep `index_after_import` enabled unless the user explicitly asks to register
-   media without indexing. Reuse the same idempotency key when retrying the same
-   request.
-7. Stop polling when the returned aggregate state is terminal. Treat each file
-   independently so one failure does not hide successful siblings.
-8. If the same request also asks to find or explain video content, continue with
-   the VidXP evidence workflow as soon as the successful media becomes indexed
-   and searchable; do not stop after ingestion or make the user ask again.
+1. Resolve the `vidxp` MCP tools and call `get_workspace`. Do not import a video
+   that is already registered or indexed.
+2. Choose indexable modalities from the workspace. Use `dialogue` and `scene`
+   for ordinary content retrieval. Add `actor` only when anonymous recurring-face
+   clusters are wanted; it does not identify people by name.
+3. Call `get_runtime_readiness`. If selected models are missing, submit
+   `prepare_models` for those modalities and poll its job with `get_job`.
+4. Use `ingest_local_media` for one to ten paths accessible to VidXP; otherwise
+   use `create_media_upload` and give the returned link to the user. Keep
+   `index_after_import` enabled unless registration-only behavior was requested.
+5. Poll the returned ingestion or upload ID with `get_media_ingestion` or
+   `get_media_upload`. Honor its poll interval, reuse the same identifiers, and
+   do not resubmit unchanged work.
+6. Stop at a terminal state and report each file's state, media ID, index job,
+   and searchable snapshot or generation. If indexing fails after registration,
+   retry with `start_indexing`; do not upload the file again.
+7. If the request also asks about the video, continue directly into the VidXP
+   evidence workflow once it is searchable.
 
-## Long-running operations
+## Long operations
 
-- Tell the user before polling that model preparation and indexing can take
-  several minutes, depending on video length, selected capabilities, hardware,
-  and whether models are already cached.
-- Honor a server-provided polling interval when present. Otherwise poll after
-  about 5 seconds initially and back off to about 15 seconds for sustained work.
-  Never busy-loop or create a shell script merely to wait.
-- Keep using the original job, ingestion, and idempotency identifiers. Do not
-  submit duplicate work because a state remains unchanged.
-- Give a concise update when the lifecycle stage or measured progress changes,
-  and approximately once per minute during a long unchanged stage. Do not emit
-  every poll result.
-- Report only progress and timing returned or directly measured by VidXP. Do not
-  invent an ETA. If the interaction must stop before completion, provide the
-  recovery identifier needed to resume polling later.
-
-## Recovery and output
-
-- If import fails, report its structured error and remediation.
-- If indexing fails after registration, do not upload the file again. Use the
-  returned media ID with `start_indexing` when the user wants to retry.
-- Report each filename, lifecycle state, media ID, index job, and searchable
-  snapshot or generation when present.
-- State clearly whether each video is merely uploaded, registered, indexing, or
-  indexed and searchable.
+- Tell the user that model preparation and indexing can take several minutes.
+- Update when the stage changes or about once per minute; do not narrate every
+  poll or invent an ETA.
+- Treat files independently so one failure does not hide successful siblings.

--- a/src/vidxp/application.py
+++ b/src/vidxp/application.py
@@ -40,6 +40,7 @@ from vidxp.application_models import (
     SearchMomentsPlanStep,
     EvidenceBoardJobRequest,
     EvidenceBoardResult,
+    EvidenceDeliveryPolicy,
 )
 from vidxp.capabilities.actor.schemas import (
     ActorClusterSummary,
@@ -556,7 +557,7 @@ class VidXPApplication(ControlPlaneApplication):
         )
         policy = command.evidence_delivery
         if policy is not None:
-            return self.evidence_delivery.deliver_search(
+            return self._deliver_initial_evidence(
                 result,
                 policy,
                 execution=active_execution,
@@ -726,13 +727,53 @@ class VidXPApplication(ControlPlaneApplication):
         active_execution.checkpoint()
         policy = command.evidence_delivery
         if policy is not None:
-            answer = self.evidence_delivery.deliver_query(
+            answer = self._deliver_initial_evidence(
                 answer,
                 policy,
                 execution=active_execution,
             )
             active_execution.checkpoint()
         return answer
+
+    def _deliver_initial_evidence(
+        self,
+        result: FusedSearchResult | QueryAnswer,
+        policy: EvidenceDeliveryPolicy,
+        *,
+        execution: ExecutionContext,
+    ) -> FusedSearchResult | QueryAnswer:
+        delivered = (
+            self.evidence_delivery.deliver_search(
+                result,
+                policy,
+                execution=execution,
+            )
+            if isinstance(result, FusedSearchResult)
+            else self.evidence_delivery.deliver_query(
+                result,
+                policy,
+                execution=execution,
+            )
+        )
+        candidates = self.evidence_delivery.candidates(delivered)
+        if not policy.include_board or execution.job_id is None or not candidates:
+            return delivered
+        request = self.evidence_delivery.prepare_board_request(
+            source_job_id=execution.job_id,
+            evidence_ids=None,
+            start_rank=1,
+            result=delivered,
+        )
+        board = self.evidence_boards.create(request, execution=execution)
+        evidence_delivery = delivered.evidence_delivery
+        assert evidence_delivery is not None
+        return delivered.model_copy(
+            update={
+                "evidence_delivery": evidence_delivery.model_copy(
+                    update={"board": board}
+                )
+            }
+        )
 
     @application_boundary
     def actor_clusters(

--- a/src/vidxp/application.py
+++ b/src/vidxp/application.py
@@ -38,6 +38,8 @@ from vidxp.application_models import (
     QueryVideoCommand,
     SearchCommand,
     SearchMomentsPlanStep,
+    EvidenceBoardJobRequest,
+    EvidenceBoardResult,
 )
 from vidxp.capabilities.actor.schemas import (
     ActorClusterSummary,
@@ -75,6 +77,7 @@ from vidxp.media_service import (
     MediaService,
 )
 from vidxp.evidence_delivery import EvidenceDeliveryService
+from vidxp.evidence_board import EvidenceBoardService
 
 
 class VidXPApplication(ControlPlaneApplication):
@@ -114,6 +117,11 @@ class VidXPApplication(ControlPlaneApplication):
             artifacts=artifacts,
             media=media,
             max_clip_duration_seconds=settings.max_snippet_duration_seconds,
+        )
+        self.evidence_boards = EvidenceBoardService(
+            artifacts=artifacts,
+            media=media,
+            settings=settings,
         )
 
     @contextmanager
@@ -882,6 +890,15 @@ class VidXPApplication(ControlPlaneApplication):
             job_id=active_execution.job_id,
             execution=active_execution,
         )
+
+    @application_boundary
+    def create_evidence_board(
+        self,
+        request: EvidenceBoardJobRequest,
+        *,
+        execution: ExecutionContext | None = None,
+    ) -> EvidenceBoardResult:
+        return self.evidence_boards.create(request, execution=execution)
 
     @application_boundary
     def clear_index(self) -> bool:

--- a/src/vidxp/application_models.py
+++ b/src/vidxp/application_models.py
@@ -794,6 +794,7 @@ class EvidenceDeliveryMode(StrEnum):
 
 class EvidenceDeliveryPolicy(ApplicationModel):
     mode: EvidenceDeliveryMode = EvidenceDeliveryMode.none
+    include_board: bool = False
     max_items: int = Field(default=3, ge=1, le=10)
     padding_before_seconds: float = Field(default=2.0, ge=0, le=30)
     padding_after_seconds: float = Field(default=2.0, ge=0, le=30)
@@ -801,6 +802,7 @@ class EvidenceDeliveryPolicy(ApplicationModel):
 
 
 class InitialEvidenceDeliveryPolicy(EvidenceDeliveryPolicy):
+    include_board: bool = True
     max_items: int = Field(default=3, ge=1, le=5)
 
 
@@ -852,9 +854,9 @@ class SearchCommand(ApplicationModel):
     evidence_delivery: InitialEvidenceDeliveryPolicy | None = Field(
         default=None,
         description=(
-            "Optional bounded frame/clip delivery. Omit to preserve the "
-            "transport-neutral application default; MCP supplies a useful "
-            "keyframe default."
+            "Optional evidence-board and bounded frame/clip delivery. Omit to "
+            "preserve the transport-neutral application default; MCP supplies "
+            "an evidence-board default."
         ),
     )
 
@@ -1002,9 +1004,9 @@ class QueryVideoCommand(ApplicationModel):
     evidence_delivery: InitialEvidenceDeliveryPolicy | None = Field(
         default=None,
         description=(
-            "Optional bounded frame/clip delivery. Omit to preserve the "
-            "transport-neutral application default; MCP supplies a useful "
-            "keyframe default."
+            "Optional evidence-board and bounded frame/clip delivery. Omit to "
+            "preserve the transport-neutral application default; MCP supplies "
+            "an evidence-board default."
         ),
     )
 
@@ -1164,6 +1166,7 @@ class EvidenceDeliveryItem(ApplicationModel):
 class EvidenceDeliveryResult(ApplicationModel):
     policy: EvidenceDeliveryPolicy
     items: tuple[EvidenceDeliveryItem, ...] = Field(max_length=10)
+    board: "EvidenceBoardResult | None" = None
 
 
 class EvidenceBoardTile(EvidenceBoardCandidate):

--- a/src/vidxp/application_models.py
+++ b/src/vidxp/application_models.py
@@ -104,6 +104,7 @@ class JobKind(StrEnum):
     query = "query"
     snippet = "snippet"
     actor_overlay = "actor_overlay"
+    evidence_board = "evidence_board"
     prepare_models = "prepare_models"
 
 
@@ -803,6 +804,28 @@ class InitialEvidenceDeliveryPolicy(EvidenceDeliveryPolicy):
     max_items: int = Field(default=3, ge=1, le=5)
 
 
+class EvidenceBoardCandidate(ApplicationModel):
+    evidence_id: Sha256
+    rank: int = Field(gt=0, le=200)
+    media_id: MediaId
+    generation_id: IndexGenerationId
+    modalities: tuple[Identifier, ...] = Field(min_length=1, max_length=8)
+    start: float = Field(ge=0)
+    end: float = Field(ge=0)
+    representative_timestamp: float = Field(ge=0)
+    frame_index: int | None = Field(default=None, ge=0)
+    frame_match: "EvidenceFrameMatch"
+    score: float | None = None
+    display_text: str | None = Field(default=None, max_length=512)
+    provenance: dict[str, JsonValue] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _valid_interval(self) -> "EvidenceBoardCandidate":
+        if self.end < self.start:
+            raise ValueError("Evidence board candidate end precedes its start.")
+        return self
+
+
 class SearchCommand(ApplicationModel):
     query: SearchQuery = Field(description="Text to match against indexed moments.")
     modalities: tuple[Identifier, ...] = Field(
@@ -1143,6 +1166,38 @@ class EvidenceDeliveryResult(ApplicationModel):
     items: tuple[EvidenceDeliveryItem, ...] = Field(max_length=10)
 
 
+class EvidenceBoardTile(EvidenceBoardCandidate):
+    tile_id: Sha256
+    page_number: int = Field(gt=0, le=16)
+    position: int = Field(gt=0, le=48)
+    keyframe_artifact_id: ArtifactId | None = None
+    state: EvidenceDeliveryState
+    errors: tuple[ErrorDetail, ...] = ()
+
+
+class EvidenceBoardPage(ApplicationModel):
+    page_number: int = Field(gt=0, le=16)
+    media_id: MediaId
+    generation_id: IndexGenerationId
+    artifact: EvidenceArtifact
+    width: int = Field(gt=0, le=4096)
+    height: int = Field(gt=0, le=4096)
+    columns: int = Field(gt=0, le=12)
+    rows: int = Field(gt=0, le=12)
+    tile_ids: tuple[Sha256, ...] = Field(min_length=1, max_length=48)
+
+
+class EvidenceBoardResult(ApplicationModel):
+    source_job_id: JobId
+    source_fingerprint: Sha256
+    requested_count: int = Field(ge=0, le=200)
+    rendered_count: int = Field(ge=0, le=200)
+    failed_count: int = Field(ge=0, le=200)
+    pages: tuple[EvidenceBoardPage, ...] = Field(max_length=16)
+    tiles: tuple[EvidenceBoardTile, ...] = Field(max_length=200)
+    next_start_rank: int | None = Field(default=None, ge=1, le=200)
+
+
 class DraftClaim(ApplicationModel):
     text: str = Field(min_length=1, max_length=4096)
     evidence_ids: tuple[Sha256, ...] = Field(min_length=1, max_length=10)
@@ -1292,6 +1347,27 @@ class ActorOverlayJobRequest(ApplicationModel):
     snapshot: IndexSnapshotReference
 
 
+class EvidenceBoardJobRequest(ApplicationModel):
+    kind: Literal[JobKind.evidence_board] = JobKind.evidence_board
+    source_job_id: JobId
+    source_fingerprint: Sha256
+    candidates: tuple[EvidenceBoardCandidate, ...] = Field(
+        min_length=1,
+        max_length=200,
+    )
+
+    @field_validator("candidates")
+    @classmethod
+    def _unique_candidates(
+        cls,
+        values: tuple[EvidenceBoardCandidate, ...],
+    ) -> tuple[EvidenceBoardCandidate, ...]:
+        evidence_ids = tuple(item.evidence_id for item in values)
+        if len(evidence_ids) != len(set(evidence_ids)):
+            raise ValueError("Evidence board candidates must be unique.")
+        return values
+
+
 class PrepareModelsJobRequest(ApplicationModel):
     kind: Literal[JobKind.prepare_models] = JobKind.prepare_models
     command: PrepareModelsCommand
@@ -1304,6 +1380,7 @@ JobRequest = Annotated[
     | QueryJobRequest
     | SnippetJobRequest
     | ActorOverlayJobRequest
+    | EvidenceBoardJobRequest
     | PrepareModelsJobRequest,
     Field(discriminator="kind"),
 ]
@@ -1334,6 +1411,11 @@ class ArtifactJobResult(ApplicationModel):
     result: Artifact
 
 
+class EvidenceBoardJobResult(ApplicationModel):
+    kind: Literal[JobKind.evidence_board] = JobKind.evidence_board
+    result: EvidenceBoardResult
+
+
 class PrepareModelsJobResult(ApplicationModel):
     kind: Literal[JobKind.prepare_models] = JobKind.prepare_models
     result: PrepareModelsResult
@@ -1345,6 +1427,7 @@ JobResult = Annotated[
     | SearchJobResult
     | QueryJobResult
     | ArtifactJobResult
+    | EvidenceBoardJobResult
     | PrepareModelsJobResult,
     Field(discriminator="kind"),
 ]

--- a/src/vidxp/artifact_delivery.py
+++ b/src/vidxp/artifact_delivery.py
@@ -54,7 +54,7 @@ def artifact_binding(artifact: Artifact) -> ArtifactBinding:
         raise ApplicationError(
             "artifact_type_unsupported",
             ErrorCategory.validation,
-            "Only completed PNG, MP4, and Matroska artifacts can be delivered.",
+            "Only completed PNG, JPEG, MP4, and Matroska artifacts can be delivered.",
             details={"mime_type": artifact.mime_type},
         ) from exc
     return ArtifactBinding(

--- a/src/vidxp/artifact_service.py
+++ b/src/vidxp/artifact_service.py
@@ -4,8 +4,9 @@ import hashlib
 import json
 import struct
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from vidxp.application_models import (
     ActorOverlayProfile,
@@ -27,6 +28,8 @@ from vidxp.ports import (
     ActorRendererPort,
     ArtifactCatalogPort,
     ArtifactStorePort,
+    EvidenceBoardRendererPort,
+    EvidenceBoardRenderTile,
     FrameRendererPort,
     LocalFileResource,
     MediaProbePort,
@@ -57,6 +60,14 @@ class InvalidArtifactError(RuntimeError):
 ARTIFACT_RENDER_CONTRACT_VERSION = 1
 
 
+@dataclass(frozen=True)
+class EvidenceBoardPageTileInput:
+    evidence_id: str
+    frame_artifact_id: str | None
+    annotation_lines: tuple[str, ...]
+    placeholder: str | None = None
+
+
 def artifact_result(record: ArtifactRecord) -> Artifact:
     return Artifact(
         schema_version=record.schema_version,
@@ -82,6 +93,17 @@ def _request_key(payload: dict) -> str:
         separators=(",", ":"),
     ).encode()
     return hashlib.sha256(encoded).hexdigest()
+
+
+def deterministic_artifact_operation_id(
+    job_id: str | None,
+    subject_id: str,
+    kind: str,
+) -> str:
+    digest = hashlib.sha256(
+        f"{job_id or 'direct'}\0{subject_id}\0{kind}".encode()
+    ).digest()[:16]
+    return UUID(bytes=digest, version=4).hex
 
 
 class ArtifactQueryService:
@@ -161,6 +183,7 @@ class ArtifactService(ArtifactQueryService):
         snippet_renderer: SnippetRendererPort,
         max_snippet_duration_seconds: float,
         frame_renderer: FrameRendererPort | None = None,
+        evidence_board_renderer: EvidenceBoardRendererPort | None = None,
     ) -> None:
         super().__init__(catalog=catalog, store=store)
         self.media = media
@@ -168,6 +191,7 @@ class ArtifactService(ArtifactQueryService):
         self.actor_renderer = actor_renderer
         self.snippet_renderer = snippet_renderer
         self.frame_renderer = frame_renderer
+        self.evidence_board_renderer = evidence_board_renderer
         self.max_snippet_duration_seconds = max_snippet_duration_seconds
 
     def create_actor_overlay(
@@ -329,6 +353,111 @@ class ArtifactService(ArtifactQueryService):
         width, height = self.png_dimensions(content.path)
         return artifact, width, height
 
+    def create_evidence_board_page(
+        self,
+        *,
+        media_id: str,
+        generation_id: str,
+        title: str,
+        tiles: tuple[EvidenceBoardPageTileInput, ...],
+        columns: int,
+        tile_width: int,
+        tile_height: int,
+        annotation_height: int,
+        maximum_bytes: int,
+        job_id: str | None = None,
+        execution: ExecutionContext | None = None,
+        artifact_operation_id: str | None = None,
+    ) -> tuple[Artifact, int, int]:
+        active_execution = execution_context(execution)
+        active_execution.checkpoint()
+        if self.evidence_board_renderer is None:
+            raise ArtifactRequestError("Evidence board rendering is not configured.")
+        if not tiles:
+            raise ArtifactRequestError("An evidence board page requires tiles.")
+        source = self.media.content(media_id)
+        render_tiles: list[EvidenceBoardRenderTile] = []
+        frame_identities: list[dict] = []
+        for tile in tiles:
+            active_execution.checkpoint()
+            frame_path = None
+            frame_sha256 = None
+            if tile.frame_artifact_id is not None:
+                record = self.require_record(tile.frame_artifact_id)
+                if (
+                    record.kind != ArtifactKind.evidence_frame
+                    or record.mime_type != "image/png"
+                    or record.media_id != media_id
+                    or record.generation_id != generation_id
+                ):
+                    raise ArtifactRequestError(
+                        "An evidence board input frame has the wrong identity."
+                    )
+                frame_path = self._verified_content(record)
+                frame_sha256 = record.sha256
+            frame_identities.append(
+                {
+                    "evidence_id": tile.evidence_id,
+                    "frame_sha256": frame_sha256,
+                    "annotation_lines": tile.annotation_lines,
+                    "placeholder": tile.placeholder,
+                }
+            )
+            render_tiles.append(
+                EvidenceBoardRenderTile(
+                    source=frame_path,
+                    annotation_lines=tile.annotation_lines,
+                    placeholder=tile.placeholder,
+                )
+            )
+        active_columns = min(columns, len(tiles))
+        width = active_columns * tile_width
+        height = 54 + ((len(tiles) - 1) // active_columns + 1) * (
+            tile_height + annotation_height
+        )
+        request_key = _request_key(
+            {
+                "kind": ArtifactKind.evidence_board,
+                "render_contract_version": ARTIFACT_RENDER_CONTRACT_VERSION,
+                "media_sha256": source.etag,
+                "generation_id": generation_id,
+                "profile": "overview-jpeg-v1",
+                "title": title,
+                "columns": active_columns,
+                "tile_width": tile_width,
+                "tile_height": tile_height,
+                "annotation_height": annotation_height,
+                "tiles": frame_identities,
+            }
+        )
+        renderer = self.evidence_board_renderer
+        artifact = self._create(
+            media_id=media_id,
+            generation_id=generation_id,
+            kind=ArtifactKind.evidence_board,
+            profile="overview-jpeg-v1",
+            request_key=request_key,
+            suffix=".jpg",
+            expected_mime_type="image/jpeg",
+            job_id=job_id,
+            execution=active_execution,
+            artifact_operation_id=artifact_operation_id,
+            render=lambda destination: renderer.render(
+                destination,
+                title=title,
+                tiles=tuple(render_tiles),
+                columns=active_columns,
+                tile_width=tile_width,
+                tile_height=tile_height,
+                annotation_height=annotation_height,
+                maximum_bytes=maximum_bytes,
+                cancellation=active_execution.cancellation,
+            ),
+            validate=self._validate_jpeg,
+            artifact_label="evidence board page",
+        )
+        return artifact, width, height
+
     def _create(
         self,
         *,
@@ -487,6 +616,28 @@ class ArtifactService(ArtifactQueryService):
                 "The rendered evidence image has invalid dimensions."
             )
         return width, height
+
+    @classmethod
+    def _validate_jpeg(cls, path: Path, expected_mime_type: str) -> str:
+        if expected_mime_type != "image/jpeg":
+            raise InvalidArtifactError("The evidence board image profile is invalid.")
+        cls.jpeg_dimensions(path)
+        return expected_mime_type
+
+    @staticmethod
+    def jpeg_dimensions(path: Path) -> tuple[int, int]:
+        try:
+            from PIL import Image
+
+            with Image.open(path) as image:
+                image.verify()
+                if image.format != "JPEG" or image.width <= 0 or image.height <= 0:
+                    raise ValueError
+                return image.width, image.height
+        except (ModuleNotFoundError, OSError, ValueError) as exc:
+            raise InvalidArtifactError(
+                "The rendered evidence board is not a valid JPEG image."
+            ) from exc
 
     def _delete_quietly(self, storage_key: str) -> None:
         try:

--- a/src/vidxp/composition.py
+++ b/src/vidxp/composition.py
@@ -37,6 +37,7 @@ from vidxp.infrastructure.local_artifacts import (
     LocalActorRenderer,
     LocalArtifactStore,
 )
+from vidxp.infrastructure.pillow_board import PillowEvidenceBoardRenderer
 from vidxp.infrastructure.local_catalog import LocalCatalog
 from vidxp.infrastructure.sql_catalog import SQLCatalog
 from vidxp.infrastructure.sql_snapshots import SQLSnapshotRepository
@@ -293,6 +294,7 @@ def _create_artifact_service(
         actor_renderer=LocalActorRenderer(),
         snippet_renderer=FFmpegSnippetRenderer(settings.ffmpeg_executable),
         frame_renderer=FFmpegFrameRenderer(settings.ffmpeg_executable),
+        evidence_board_renderer=PillowEvidenceBoardRenderer(),
         max_snippet_duration_seconds=settings.max_snippet_duration_seconds,
     )
 

--- a/src/vidxp/core/artifacts.py
+++ b/src/vidxp/core/artifacts.py
@@ -40,6 +40,7 @@ class ArtifactRendererUnavailableError(RuntimeError):
 
 class ArtifactKind(StrEnum):
     actor_overlay = "actor_overlay"
+    evidence_board = "evidence_board"
     evidence_frame = "evidence_frame"
     snippet = "snippet"
 
@@ -51,6 +52,7 @@ def artifact_file_identity(
     mime_type: str,
 ) -> tuple[str, str]:
     extension = {
+        "image/jpeg": "jpg",
         "image/png": "png",
         "video/mp4": "mp4",
         "video/x-matroska": "mkv",

--- a/src/vidxp/evidence_board.py
+++ b/src/vidxp/evidence_board.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import hashlib
+
+from vidxp.application_models import (
+    ApplicationError,
+    ErrorCategory,
+    ErrorDetail,
+    EvidenceArtifact,
+    EvidenceBoardCandidate,
+    EvidenceBoardJobRequest,
+    EvidenceBoardPage,
+    EvidenceBoardResult,
+    EvidenceBoardTile,
+    EvidenceDeliveryState,
+)
+from vidxp.artifact_service import (
+    ArtifactService,
+    EvidenceBoardPageTileInput,
+    deterministic_artifact_operation_id,
+)
+from vidxp.core.contracts import IndexCancelledError
+from vidxp.evidence_delivery import resolve_evidence_range
+from vidxp.execution import ExecutionContext, execution_context
+from vidxp.media_service import MediaService
+from vidxp.settings import VidXPSettings
+
+
+def plan_evidence_board_pages(
+    candidates: tuple[EvidenceBoardCandidate, ...],
+    *,
+    tiles_per_page: int,
+    pages_per_job: int,
+) -> tuple[tuple[tuple[EvidenceBoardCandidate, ...], ...], int | None]:
+    """Plan ordered, single-media pages without skipping continuation ranks."""
+
+    pages: list[tuple[EvidenceBoardCandidate, ...]] = []
+    current: list[EvidenceBoardCandidate] = []
+    current_identity: tuple[str, str] | None = None
+    for candidate in candidates:
+        identity = candidate.media_id, candidate.generation_id
+        must_close = bool(current) and (
+            identity != current_identity or len(current) >= tiles_per_page
+        )
+        if must_close:
+            pages.append(tuple(current))
+            current = []
+            current_identity = None
+            if len(pages) >= pages_per_job:
+                return tuple(pages), candidate.rank
+        current.append(candidate)
+        current_identity = identity
+    if current:
+        if len(pages) >= pages_per_job:
+            return tuple(pages), current[0].rank
+        pages.append(tuple(current))
+    return tuple(pages), None
+
+
+class EvidenceBoardService:
+    _COLUMNS = 4
+    _TILE_WIDTH = 320
+    _TILE_HEIGHT = 180
+    _ANNOTATION_HEIGHT = 52
+
+    def __init__(
+        self,
+        *,
+        artifacts: ArtifactService,
+        media: MediaService,
+        settings: VidXPSettings,
+    ) -> None:
+        self.artifacts = artifacts
+        self.media = media
+        self.settings = settings
+
+    def create(
+        self,
+        request: EvidenceBoardJobRequest,
+        *,
+        execution: ExecutionContext | None = None,
+    ) -> EvidenceBoardResult:
+        active = execution_context(execution)
+        plans, next_start_rank = plan_evidence_board_pages(
+            request.candidates,
+            tiles_per_page=self.settings.evidence_board_tiles_per_page,
+            pages_per_job=self.settings.evidence_board_pages_per_job,
+        )
+        pages: list[EvidenceBoardPage] = []
+        result_tiles: list[EvidenceBoardTile] = []
+        failed_count = 0
+        for page_number, plan in enumerate(plans, start=1):
+            active.checkpoint()
+            media_id = plan[0].media_id
+            generation_id = plan[0].generation_id
+            media = self.media.require_record(media_id)
+            page_inputs: list[EvidenceBoardPageTileInput] = []
+            page_tiles: list[EvidenceBoardTile] = []
+            for position, candidate in enumerate(plan, start=1):
+                tile_id = hashlib.sha256(
+                    (
+                        f"evidence-board-tile-v1\0{request.source_fingerprint}\0"
+                        f"{candidate.evidence_id}"
+                    ).encode()
+                ).hexdigest()
+                errors: list[ErrorDetail] = []
+                frame_artifact_id = None
+                representative = candidate.representative_timestamp
+                try:
+                    resolved = resolve_evidence_range(
+                        source_start=candidate.start,
+                        source_end=candidate.end,
+                        representative_timestamp=representative,
+                        media_duration=media.duration_seconds,
+                        padding_before=0,
+                        padding_after=0,
+                        max_duration=self.settings.max_snippet_duration_seconds,
+                    )
+                    representative = resolved.representative_timestamp_seconds
+                    frame, _width, _height = self.artifacts.create_evidence_frame(
+                        media_id=candidate.media_id,
+                        generation_id=candidate.generation_id,
+                        evidence_id=candidate.evidence_id,
+                        timestamp_seconds=representative,
+                        frame_index=candidate.frame_index,
+                        job_id=active.job_id,
+                        execution=active,
+                        artifact_operation_id=deterministic_artifact_operation_id(
+                            active.job_id,
+                            candidate.evidence_id,
+                            "board-frame",
+                        ),
+                    )
+                    frame_artifact_id = frame.artifact_id
+                except IndexCancelledError:
+                    raise
+                except Exception as exc:
+                    failed_count += 1
+                    errors.append(self._frame_failure(exc))
+                annotations = self._annotations(candidate, representative)
+                page_inputs.append(
+                    EvidenceBoardPageTileInput(
+                        evidence_id=candidate.evidence_id,
+                        frame_artifact_id=frame_artifact_id,
+                        annotation_lines=annotations,
+                        placeholder=(
+                            None
+                            if frame_artifact_id is not None
+                            else "Frame unavailable"
+                        ),
+                    )
+                )
+                page_tiles.append(
+                    EvidenceBoardTile(
+                        **candidate.model_copy(
+                            update={"representative_timestamp": representative}
+                        ).model_dump(),
+                        tile_id=tile_id,
+                        page_number=page_number,
+                        position=position,
+                        keyframe_artifact_id=frame_artifact_id,
+                        state=(
+                            EvidenceDeliveryState.ready
+                            if frame_artifact_id is not None
+                            else EvidenceDeliveryState.failed
+                        ),
+                        errors=tuple(errors),
+                    )
+                )
+            active.report(
+                {
+                    "stage": "composing_board_pages",
+                    "message": f"Composing board page {page_number} of {len(plans)}.",
+                    "current": page_number - 1,
+                    "total": len(plans),
+                }
+            )
+            page_artifact, width, height = self.artifacts.create_evidence_board_page(
+                media_id=media_id,
+                generation_id=generation_id,
+                title=media.original_filename,
+                tiles=tuple(page_inputs),
+                columns=self._COLUMNS,
+                tile_width=self._TILE_WIDTH,
+                tile_height=self._TILE_HEIGHT,
+                annotation_height=self._ANNOTATION_HEIGHT,
+                maximum_bytes=self.settings.mcp_max_resource_bytes,
+                job_id=active.job_id,
+                execution=active,
+                artifact_operation_id=deterministic_artifact_operation_id(
+                    active.job_id,
+                    ":".join(tile.tile_id for tile in page_tiles),
+                    "board-page",
+                ),
+            )
+            pages.append(
+                EvidenceBoardPage(
+                    page_number=page_number,
+                    media_id=media_id,
+                    generation_id=generation_id,
+                    artifact=EvidenceArtifact(artifact=page_artifact),
+                    width=width,
+                    height=height,
+                    columns=min(self._COLUMNS, len(page_tiles)),
+                    rows=(len(page_tiles) + self._COLUMNS - 1) // self._COLUMNS,
+                    tile_ids=tuple(tile.tile_id for tile in page_tiles),
+                )
+            )
+            result_tiles.extend(page_tiles)
+        active.report(
+            {
+                "stage": "complete",
+                "message": "The evidence board is ready.",
+                "current": len(pages),
+                "total": len(pages),
+            }
+        )
+        return EvidenceBoardResult(
+            source_job_id=request.source_job_id,
+            source_fingerprint=request.source_fingerprint,
+            requested_count=len(request.candidates),
+            rendered_count=len(result_tiles) - failed_count,
+            failed_count=failed_count,
+            pages=tuple(pages),
+            tiles=tuple(result_tiles),
+            next_start_rank=next_start_rank,
+        )
+
+    @staticmethod
+    def _annotations(
+        candidate: EvidenceBoardCandidate,
+        representative: float,
+    ) -> tuple[str, ...]:
+        minutes, seconds = divmod(representative, 60)
+        timecode = f"{int(minutes):02d}:{seconds:06.3f}"
+        lines = [
+            f"#{candidate.rank} · {timecode} · {', '.join(candidate.modalities)}",
+            candidate.display_text or f"Evidence {candidate.evidence_id[:12]}",
+            candidate.frame_match.value.replace("_", " "),
+        ]
+        return tuple(lines)
+
+    @staticmethod
+    def _frame_failure(exc: Exception) -> ErrorDetail:
+        if isinstance(exc, ApplicationError):
+            return exc.detail
+        return ErrorDetail(
+            code="evidence_board_frame_failed",
+            category=ErrorCategory.unavailable,
+            message="The representative frame could not be prepared for this tile.",
+            details={"reason": type(exc).__name__},
+            retryable=True,
+        )

--- a/src/vidxp/evidence_delivery.py
+++ b/src/vidxp/evidence_delivery.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import hashlib
-from dataclasses import dataclass
-from uuid import UUID
+import json
 
 from vidxp.application_models import (
     ApplicationError,
@@ -10,6 +9,8 @@ from vidxp.application_models import (
     ErrorCategory,
     ErrorDetail,
     EvidenceArtifact,
+    EvidenceBoardCandidate,
+    EvidenceBoardJobRequest,
     EvidenceDeliveryItem,
     EvidenceDeliveryMode,
     EvidenceDeliveryPolicy,
@@ -19,13 +20,35 @@ from vidxp.application_models import (
     EvidenceKeyframe,
     EvidenceRangeResolution,
     FusedSearchResult,
+    Job,
+    JobKind,
+    JobState,
     MomentEvidence,
     QueryAnswer,
 )
-from vidxp.artifact_service import ArtifactService
+from vidxp.artifact_service import (
+    ArtifactService,
+    deterministic_artifact_operation_id,
+)
 from vidxp.core.contracts import IndexCancelledError
 from vidxp.execution import ExecutionContext, execution_context
 from vidxp.media_service import MediaService
+
+
+def require_completed_evidence_result(
+    job: Job,
+) -> FusedSearchResult | QueryAnswer:
+    if (
+        job.state != JobState.succeeded
+        or job.result is None
+        or job.kind not in {JobKind.search, JobKind.query}
+    ):
+        raise ApplicationError(
+            "evidence_source_job_not_complete",
+            ErrorCategory.conflict,
+            "Evidence materialization requires a completed search or query job.",
+        )
+    return job.result.result
 
 
 def resolve_evidence_range(
@@ -105,29 +128,6 @@ def resolve_evidence_range(
     )
 
 
-@dataclass(frozen=True)
-class _Candidate:
-    evidence_id: str
-    rank: int
-    media_id: str
-    generation_id: str
-    modalities: tuple[str, ...]
-    start: float
-    end: float
-    representative: float
-    frame_index: int | None
-    frame_match: EvidenceFrameMatch
-    score: float | None
-    provenance: dict
-
-
-def _operation_id(job_id: str | None, evidence_id: str, kind: str) -> str:
-    digest = hashlib.sha256(
-        f"{job_id or 'direct'}\0{evidence_id}\0{kind}".encode()
-    ).digest()[:16]
-    return UUID(bytes=digest, version=4).hex
-
-
 def _failure(code: str, label: str, exc: BaseException) -> ErrorDetail:
     if isinstance(exc, ApplicationError):
         return exc.detail
@@ -159,8 +159,10 @@ class EvidenceDeliveryService:
         self.max_clip_duration_seconds = max_clip_duration_seconds
 
     @staticmethod
-    def _search_candidates(result: FusedSearchResult) -> tuple[_Candidate, ...]:
-        candidates: list[_Candidate] = []
+    def _search_candidates(
+        result: FusedSearchResult,
+    ) -> tuple[EvidenceBoardCandidate, ...]:
+        candidates: list[EvidenceBoardCandidate] = []
         for moment in result.moments:
             if moment.moment_id is None:
                 continue
@@ -175,7 +177,7 @@ class EvidenceDeliveryService:
                 else (selected.start + selected.end) / 2
             )
             candidates.append(
-                _Candidate(
+                EvidenceBoardCandidate(
                     evidence_id=moment.moment_id,
                     rank=moment.rank,
                     media_id=moment.media_id,
@@ -183,7 +185,7 @@ class EvidenceDeliveryService:
                     modalities=moment.modalities,
                     start=moment.start,
                     end=moment.end,
-                    representative=representative,
+                    representative_timestamp=representative,
                     frame_index=frame_index,
                     frame_match=(
                         EvidenceFrameMatch.exact_indexed_frame
@@ -191,6 +193,9 @@ class EvidenceDeliveryService:
                         else EvidenceFrameMatch.representative
                     ),
                     score=moment.score,
+                    display_text=EvidenceDeliveryService._display_text(
+                        selected.metadata
+                    ),
                     provenance={
                         "constituent_hits": [
                             {
@@ -208,8 +213,10 @@ class EvidenceDeliveryService:
         return tuple(candidates)
 
     @staticmethod
-    def _query_candidates(answer: QueryAnswer) -> tuple[_Candidate, ...]:
-        candidates: list[_Candidate] = []
+    def _query_candidates(
+        answer: QueryAnswer,
+    ) -> tuple[EvidenceBoardCandidate, ...]:
+        candidates: list[EvidenceBoardCandidate] = []
         for rank, evidence in enumerate(answer.evidence, start=1):
             if isinstance(evidence, MomentEvidence):
                 raw_index = evidence.hit.metadata.get("frame_index")
@@ -241,7 +248,7 @@ class EvidenceDeliveryService:
                     "identity_semantics": "anonymous_cluster",
                 }
             candidates.append(
-                _Candidate(
+                EvidenceBoardCandidate(
                     evidence_id=evidence.evidence_id,
                     rank=rank,
                     media_id=evidence.media_id,
@@ -249,7 +256,7 @@ class EvidenceDeliveryService:
                     modalities=(evidence.modality,),
                     start=evidence.start,
                     end=evidence.end,
-                    representative=representative,
+                    representative_timestamp=representative,
                     frame_index=frame_index,
                     frame_match=(
                         EvidenceFrameMatch.exact_indexed_frame
@@ -257,10 +264,90 @@ class EvidenceDeliveryService:
                         else EvidenceFrameMatch.representative
                     ),
                     score=score,
+                    display_text=evidence.display_text,
                     provenance=provenance,
                 )
             )
         return tuple(candidates)
+
+    @staticmethod
+    def _display_text(metadata: dict) -> str | None:
+        for key in ("display_text", "text", "transcript", "caption", "label"):
+            value = metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()[:512]
+        return None
+
+    @classmethod
+    def candidates(
+        cls,
+        result: FusedSearchResult | QueryAnswer,
+    ) -> tuple[EvidenceBoardCandidate, ...]:
+        return (
+            cls._search_candidates(result)
+            if isinstance(result, FusedSearchResult)
+            else cls._query_candidates(result)
+        )
+
+    @classmethod
+    def prepare_board_request(
+        cls,
+        *,
+        source_job_id: str,
+        evidence_ids: tuple[str, ...] | None,
+        start_rank: int,
+        result: FusedSearchResult | QueryAnswer,
+    ) -> EvidenceBoardJobRequest:
+        candidates = cls.candidates(result)
+        by_id = {candidate.evidence_id: candidate for candidate in candidates}
+        if evidence_ids is None:
+            selected = tuple(
+                candidate
+                for candidate in candidates
+                if candidate.rank >= start_rank
+            )
+        else:
+            missing = tuple(
+                evidence_id
+                for evidence_id in evidence_ids
+                if evidence_id not in by_id
+            )
+            if missing:
+                raise ApplicationError(
+                    "evidence_not_in_source_job",
+                    ErrorCategory.not_found,
+                    "One or more evidence IDs do not belong to the completed source job.",
+                    details={"evidence_ids": list(missing)},
+                )
+            selected = tuple(
+                sorted(
+                    (
+                        by_id[evidence_id]
+                        for evidence_id in evidence_ids
+                        if by_id[evidence_id].rank >= start_rank
+                    ),
+                    key=lambda candidate: candidate.rank,
+                )
+            )
+        if not selected:
+            raise ApplicationError(
+                "evidence_board_empty",
+                ErrorCategory.validation,
+                "The requested source range contains no boardable evidence.",
+            )
+        source_payload = [candidate.model_dump(mode="json") for candidate in candidates]
+        source_fingerprint = hashlib.sha256(
+            json.dumps(
+                source_payload,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode()
+        ).hexdigest()
+        return EvidenceBoardJobRequest(
+            source_job_id=source_job_id,
+            source_fingerprint=source_fingerprint,
+            candidates=selected,
+        )
 
     def deliver_search(
         self,
@@ -296,11 +383,7 @@ class EvidenceDeliveryService:
     ) -> EvidenceDeliveryResult:
         """Materialize a bounded selection from a completed retrieval result."""
 
-        candidates = (
-            self._search_candidates(result)
-            if isinstance(result, FusedSearchResult)
-            else self._query_candidates(result)
-        )
+        candidates = self.candidates(result)
         by_id = {candidate.evidence_id: candidate for candidate in candidates}
         missing = tuple(item for item in evidence_ids if item not in by_id)
         if missing:
@@ -315,7 +398,7 @@ class EvidenceDeliveryService:
 
     def _deliver(
         self,
-        candidates: tuple[_Candidate, ...],
+        candidates: tuple[EvidenceBoardCandidate, ...],
         policy: EvidenceDeliveryPolicy,
         *,
         execution: ExecutionContext | None,
@@ -339,7 +422,7 @@ class EvidenceDeliveryService:
                 resolved = resolve_evidence_range(
                     source_start=candidate.start,
                     source_end=candidate.end,
-                    representative_timestamp=candidate.representative,
+                    representative_timestamp=candidate.representative_timestamp,
                     media_duration=media.duration_seconds,
                     padding_before=policy.padding_before_seconds,
                     padding_after=policy.padding_after_seconds,
@@ -380,7 +463,7 @@ class EvidenceDeliveryService:
                     frame_index=candidate.frame_index,
                     job_id=active.job_id,
                     execution=active,
-                    artifact_operation_id=_operation_id(
+                    artifact_operation_id=deterministic_artifact_operation_id(
                         active.job_id, candidate.evidence_id, "frame"
                     ),
                 )
@@ -415,7 +498,7 @@ class EvidenceDeliveryService:
                         ),
                         job_id=active.job_id,
                         execution=active,
-                        artifact_operation_id=_operation_id(
+                        artifact_operation_id=deterministic_artifact_operation_id(
                             active.job_id,
                             candidate.evidence_id,
                             f"clip:{policy.clip_profile.value}",
@@ -465,12 +548,8 @@ class EvidenceDeliveryService:
         *,
         padding_before: float,
         padding_after: float,
-    ) -> tuple[_Candidate, EvidenceRangeResolution]:
-        candidates = (
-            self._search_candidates(result)
-            if isinstance(result, FusedSearchResult)
-            else self._query_candidates(result)
-        )
+    ) -> tuple[EvidenceBoardCandidate, EvidenceRangeResolution]:
+        candidates = self.candidates(result)
         candidate = next(
             (item for item in candidates if item.evidence_id == evidence_id),
             None,
@@ -485,7 +564,7 @@ class EvidenceDeliveryService:
         return candidate, resolve_evidence_range(
             source_start=candidate.start,
             source_end=candidate.end,
-            representative_timestamp=candidate.representative,
+            representative_timestamp=candidate.representative_timestamp,
             media_duration=media.duration_seconds,
             padding_before=padding_before,
             padding_after=padding_after,

--- a/src/vidxp/evidence_projection.py
+++ b/src/vidxp/evidence_projection.py
@@ -17,6 +17,19 @@ ArtifactUri = Callable[[Artifact], str]
 EvidenceArtifactProjection = Callable[[EvidenceArtifact], EvidenceArtifact]
 
 
+def _artifact_projection(
+    resource_uri: ArtifactUri | None,
+    project_artifact: EvidenceArtifactProjection | None,
+) -> EvidenceArtifactProjection:
+    if project_artifact is not None:
+        return project_artifact
+    if resource_uri is None:
+        raise ValueError("An evidence artifact projection is required.")
+    return lambda evidence: evidence.model_copy(
+        update={"resource_uri": resource_uri(evidence.artifact)}
+    )
+
+
 def project_job_result_artifacts(
     result: JobResult,
     *,
@@ -25,29 +38,37 @@ def project_job_result_artifacts(
 ) -> JobResult:
     """Traverse and project every evidence artifact in a typed job result."""
 
+    if result.kind == JobKind.evidence_board:
+        project = _artifact_projection(resource_uri, project_artifact)
+        board = result.result
+        return result.model_copy(
+            update={
+                "result": board.model_copy(
+                    update={
+                        "pages": tuple(
+                            page.model_copy(update={"artifact": project(page.artifact)})
+                            for page in board.pages
+                        )
+                    }
+                )
+            }
+        )
     if result.kind not in {JobKind.search, JobKind.query}:
         return result
     delivery = result.result.evidence_delivery
     if delivery is None:
         return result
-    if project_artifact is None:
-        if resource_uri is None:
-            raise ValueError("An evidence artifact projection is required.")
-
-        def project_artifact(evidence: EvidenceArtifact) -> EvidenceArtifact:
-            return evidence.model_copy(
-                update={"resource_uri": resource_uri(evidence.artifact)}
-            )
+    project = _artifact_projection(resource_uri, project_artifact)
     projected_items = []
     for item in delivery.items:
         keyframe = item.keyframe
         clip = item.clip
         if keyframe is not None:
             keyframe = keyframe.model_copy(
-                update={"artifact": project_artifact(keyframe.artifact)}
+                update={"artifact": project(keyframe.artifact)}
             )
         if clip is not None:
-            clip = project_artifact(clip)
+            clip = project(clip)
         projected_items.append(
             item.model_copy(update={"keyframe": keyframe, "clip": clip})
         )

--- a/src/vidxp/evidence_projection.py
+++ b/src/vidxp/evidence_projection.py
@@ -72,12 +72,25 @@ def project_job_result_artifacts(
         projected_items.append(
             item.model_copy(update={"keyframe": keyframe, "clip": clip})
         )
+    board = delivery.board
+    if board is not None:
+        board = board.model_copy(
+            update={
+                "pages": tuple(
+                    page.model_copy(update={"artifact": project(page.artifact)})
+                    for page in board.pages
+                )
+            }
+        )
     return result.model_copy(
         update={
             "result": result.result.model_copy(
                 update={
                     "evidence_delivery": delivery.model_copy(
-                        update={"items": tuple(projected_items)}
+                        update={
+                            "items": tuple(projected_items),
+                            "board": board,
+                        }
                     )
                 }
             )

--- a/src/vidxp/infrastructure/dbos_jobs.py
+++ b/src/vidxp/infrastructure/dbos_jobs.py
@@ -12,6 +12,8 @@ from pydantic import TypeAdapter, ValidationError
 from vidxp.application_models import (
     Artifact,
     ArtifactJobResult,
+    EvidenceBoardJobResult,
+    EvidenceBoardResult,
     ErrorDetail,
     ErrorCategory,
     IndexJobResult,
@@ -414,6 +416,10 @@ class DBOSJobBackend:
                 result = ArtifactJobResult(
                     kind=kind,
                     result=Artifact.model_validate(status.output),
+                )
+            elif kind == JobKind.evidence_board:
+                result = EvidenceBoardJobResult(
+                    result=EvidenceBoardResult.model_validate(status.output)
                 )
             else:
                 result = PrepareModelsJobResult(

--- a/src/vidxp/infrastructure/dbos_workflows.py
+++ b/src/vidxp/infrastructure/dbos_workflows.py
@@ -15,6 +15,7 @@ from vidxp.application_models import (
     ApplicationError,
     ErrorCategory,
     ErrorDetail,
+    EvidenceBoardJobRequest,
     IndexJobRequest,
     JobKind,
     JobProgress,
@@ -213,6 +214,25 @@ class VidXPWorkerWorkflows(DBOSConfiguredInstance):
 
         return _step_boundary(execute)
 
+    @DBOS.step(name="vidxp.run_evidence_board.v1")
+    def run_evidence_board_step(self, payload: dict[str, Any]) -> dict[str, Any]:
+        def execute() -> dict[str, Any]:
+            request = EvidenceBoardJobRequest.model_validate(payload)
+            execution = _execution()
+            _publish_progress(
+                {
+                    "stage": "planning_board",
+                    "message": "Planning the evidence board pages.",
+                }
+            )
+            result = self.application.create_evidence_board(
+                request,
+                execution=execution,
+            )
+            return result.model_dump(mode="json")
+
+        return _step_boundary(execute)
+
     def _run_search(self, payload: dict[str, Any]) -> dict[str, Any]:
         def execute() -> dict[str, Any]:
             request = decode_workflow_request(payload)
@@ -351,6 +371,10 @@ class VidXPWorkerWorkflows(DBOSConfiguredInstance):
         payload: dict[str, Any],
     ) -> dict[str, Any]:
         return self.run_artifact_step(payload)
+
+    @DBOS.workflow(name=WORKFLOW_NAMES[JobKind.evidence_board])
+    def evidence_board_workflow(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self.run_evidence_board_step(payload)
 
     @DBOS.workflow(name=WORKFLOW_NAMES[JobKind.prepare_models])
     def prepare_models_workflow(

--- a/src/vidxp/infrastructure/pillow_board.py
+++ b/src/vidxp/infrastructure/pillow_board.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from math import ceil
+from pathlib import Path
+from typing import Sequence
+
+from vidxp.core.artifacts import (
+    ArtifactRenderError,
+    ArtifactRendererUnavailableError,
+)
+from vidxp.core.contracts import CancellationToken
+from vidxp.ports import EvidenceBoardRenderTile
+
+
+class PillowEvidenceBoardRenderer:
+    """Compose verified frame artifacts into one bounded JPEG overview page."""
+
+    _BACKGROUND = (9, 13, 23)
+    _TILE_BACKGROUND = (18, 24, 38)
+    _TEXT = (242, 245, 250)
+    _MUTED = (174, 183, 198)
+    _ACCENT = (124, 92, 255)
+
+    def render(
+        self,
+        destination: Path,
+        *,
+        title: str,
+        tiles: Sequence[EvidenceBoardRenderTile],
+        columns: int,
+        tile_width: int,
+        tile_height: int,
+        annotation_height: int,
+        maximum_bytes: int,
+        cancellation: CancellationToken,
+    ) -> None:
+        try:
+            from PIL import Image, ImageDraw, ImageFont, ImageOps
+        except ModuleNotFoundError as exc:
+            raise ArtifactRendererUnavailableError(
+                "Pillow is required to render evidence boards."
+            ) from exc
+
+        if not tiles or columns <= 0:
+            raise ArtifactRenderError("An evidence board page requires tiles.")
+        active_columns = min(columns, len(tiles))
+        rows = ceil(len(tiles) / active_columns)
+        header_height = 54
+        width = active_columns * tile_width
+        height = header_height + rows * (tile_height + annotation_height)
+
+        try:
+            font = ImageFont.load_default(size=15)
+            small_font = ImageFont.load_default(size=13)
+        except TypeError:  # Pillow versions before scalable bundled fonts.
+            font = ImageFont.load_default()
+            small_font = font
+
+        canvas = Image.new("RGB", (width, height), self._BACKGROUND)
+        draw = ImageDraw.Draw(canvas)
+        draw.rectangle((0, 0, width, 3), fill=self._ACCENT)
+        draw.text((14, 17), self._bounded(title, 120), font=font, fill=self._TEXT)
+
+        for index, tile in enumerate(tiles):
+            cancellation.raise_if_cancelled()
+            row, column = divmod(index, active_columns)
+            left = column * tile_width
+            top = header_height + row * (tile_height + annotation_height)
+            image_box = (left, top, left + tile_width, top + tile_height)
+            draw.rectangle(image_box, fill=self._TILE_BACKGROUND)
+            if tile.source is None:
+                placeholder = tile.placeholder or "Frame unavailable"
+                draw.text(
+                    (left + 14, top + tile_height // 2 - 8),
+                    self._bounded(placeholder, 42),
+                    font=font,
+                    fill=self._MUTED,
+                )
+            else:
+                try:
+                    with Image.open(tile.source) as source:
+                        source.load()
+                        fitted = ImageOps.fit(
+                            source.convert("RGB"),
+                            (tile_width, tile_height),
+                            method=Image.Resampling.LANCZOS,
+                        )
+                        canvas.paste(fitted, (left, top))
+                        fitted.close()
+                except OSError as exc:
+                    raise ArtifactRenderError(
+                        "An evidence-board input frame could not be decoded."
+                    ) from exc
+            annotation_top = top + tile_height
+            draw.rectangle(
+                (
+                    left,
+                    annotation_top,
+                    left + tile_width,
+                    annotation_top + annotation_height,
+                ),
+                fill=self._TILE_BACKGROUND,
+            )
+            for line_index, line in enumerate(tile.annotation_lines[:3]):
+                draw.text(
+                    (left + 8, annotation_top + 5 + line_index * 14),
+                    self._bounded(line, max(18, tile_width // 7)),
+                    font=font if line_index == 0 else small_font,
+                    fill=self._TEXT if line_index == 0 else self._MUTED,
+                )
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            for quality in (85, 78, 70):
+                canvas.save(
+                    destination,
+                    format="JPEG",
+                    quality=quality,
+                    optimize=False,
+                    progressive=False,
+                    subsampling=2,
+                )
+                if destination.stat().st_size <= maximum_bytes:
+                    return
+        except OSError as exc:
+            raise ArtifactRenderError(
+                "The evidence board could not be encoded."
+            ) from exc
+        finally:
+            canvas.close()
+        raise ArtifactRenderError("The evidence board exceeds its encoded-byte budget.")
+
+    @staticmethod
+    def _bounded(value: str, limit: int) -> str:
+        compact = " ".join(value.split())
+        if len(compact) <= limit:
+            return compact
+        return compact[: max(1, limit - 1)].rstrip() + "…"

--- a/src/vidxp/job_service.py
+++ b/src/vidxp/job_service.py
@@ -12,6 +12,7 @@ from vidxp.application_models import (
     CreateIndexCommand,
     CreateSnippetCommand,
     ErrorCategory,
+    EvidenceBoardJobRequest,
     IndexJobRequest,
     Job,
     JobKind,
@@ -173,6 +174,19 @@ class JobService:
     ) -> Job:
         return self.backend.submit(
             self._read_job_planner().plan_actor_overlay(command),
+            queue=JobQueue.cpu,
+            job_id=job_id,
+        )
+
+    @job_boundary
+    def submit_evidence_board(
+        self,
+        request: EvidenceBoardJobRequest,
+        *,
+        job_id: str | None = None,
+    ) -> Job:
+        return self.backend.submit(
+            request,
             queue=JobQueue.cpu,
             job_id=job_id,
         )

--- a/src/vidxp/mcp.py
+++ b/src/vidxp/mcp.py
@@ -46,6 +46,7 @@ from vidxp.application_models import (
     EvidenceDeliveryMode,
     EvidenceDeliveryPolicy,
     EvidenceDeliveryResult,
+    EvidenceBoardResult,
     FusedSearchResult,
     Identifier,
     InitialEvidenceDeliveryPolicy,
@@ -98,7 +99,10 @@ from vidxp.idempotency import (
     scoped_request_key,
 )
 from vidxp.core.identifiers import ArtifactId
-from vidxp.evidence_delivery import EvidenceDeliveryService
+from vidxp.evidence_delivery import (
+    EvidenceDeliveryService,
+    require_completed_evidence_result,
+)
 from vidxp.settings import HttpAuthMode
 from vidxp.upload_service import RemoteUploadService
 
@@ -522,9 +526,11 @@ def create_mcp_server(
             "snapshot. MCP defaults to three ranked evidence frames; request "
             "keyframes_and_clips to receive bounded ready clips in the same "
             "completed job. The ordinary flow is submit search/query, then poll "
-            "that job. Use materialize_job_evidence with evidence IDs from the "
-            "completed result to inspect additional candidates in batches of "
-            "ten without rerunning retrieval or supplying timestamps. "
+            "that job. For a broad result set, call create_evidence_board on "
+            "that completed job and inspect its annotated pages before drilling "
+            "into selected tile IDs. Use materialize_job_evidence with evidence "
+            "IDs from the completed result to inspect additional candidates in "
+            "batches of ten without rerunning retrieval or supplying timestamps. "
             "create_evidence_clip, create_clip, and get_artifact_download remain "
             "advanced fallbacks. Use list_jobs to recover job IDs across agent "
             "sessions."
@@ -588,8 +594,7 @@ def create_mcp_server(
         if resource.byte_size > maximum or actual_size > maximum:
             if artifact_delivery == "local_stdio":
                 remediation = (
-                    "Use the verified local_path returned by "
-                    "get_artifact_download."
+                    "Use the verified local_path returned by get_artifact_download."
                 )
             elif settings.artifact_download_public_url is not None:
                 remediation = (
@@ -671,6 +676,19 @@ def create_mcp_server(
         return await artifact_bytes(
             artifact_id,
             expected_mime_type="image/png",
+        )
+
+    @server.resource(
+        "vidxp://artifacts/{artifact_id}/content.jpg",
+        name="vidxp_evidence_board_jpeg",
+        title="VidXP evidence board",
+        description="JPEG overview page compiled from authoritative evidence frames.",
+        mime_type="image/jpeg",
+    )
+    async def read_jpeg_artifact(artifact_id: ArtifactId) -> bytes:
+        return await artifact_bytes(
+            artifact_id,
+            expected_mime_type="image/jpeg",
         )
 
     async def project_artifact_delivery(
@@ -874,21 +892,58 @@ def create_mcp_server(
             blocks,
         )
 
+    async def project_evidence_board(
+        board: EvidenceBoardResult,
+    ) -> tuple[EvidenceBoardResult, list[ImageContent | ResourceLink | TextContent]]:
+        blocks: list[ImageContent | ResourceLink | TextContent] = []
+        projected_pages = []
+        inline_budget = min(settings.mcp_max_resource_bytes, 4 * 1024 * 1024)
+        inlined_bytes = 0
+        for page in board.pages:
+            artifact = page.artifact.artifact
+            delivery, link = await project_artifact_delivery(
+                artifact,
+                title=f"VidXP evidence board page {page.page_number}",
+                description=(
+                    f"Evidence overview for media {page.media_id}; "
+                    f"{len(page.tile_ids)} tiles."
+                ),
+            )
+            projected_pages.append(
+                page.model_copy(
+                    update={
+                        "artifact": page.artifact.model_copy(
+                            update={
+                                "resource_uri": delivery.resource_uri,
+                                "delivery": delivery,
+                            }
+                        )
+                    }
+                )
+            )
+            if (
+                artifact.byte_size <= inline_budget - inlined_bytes
+                and artifact.byte_size <= settings.mcp_max_resource_bytes
+            ):
+                image_bytes = await artifact_bytes(
+                    artifact.artifact_id,
+                    expected_mime_type="image/jpeg",
+                )
+                blocks.append(
+                    ImageContent(
+                        data=base64.b64encode(image_bytes).decode(),
+                        mimeType="image/jpeg",
+                    )
+                )
+                inlined_bytes += artifact.byte_size
+            if link is not None:
+                blocks.append(link)
+        return board.model_copy(update={"pages": tuple(projected_pages)}), blocks
+
     def completed_evidence_result(
         source_job_id: JobId,
     ) -> FusedSearchResult | QueryAnswer:
-        source = context.jobs.get(source_job_id)
-        if (
-            source.state != JobState.succeeded
-            or source.result is None
-            or source.kind not in {JobKind.search, JobKind.query}
-        ):
-            raise ApplicationError(
-                "evidence_source_job_not_complete",
-                ErrorCategory.conflict,
-                "Evidence materialization requires a completed search or query job.",
-            )
-        return source.result.result
+        return require_completed_evidence_result(context.jobs.get(source_job_id))
 
     @server.tool(
         title="Inspect VidXP workspace",
@@ -1491,6 +1546,51 @@ def create_mcp_server(
         )
 
     @server.tool(
+        title="Create evidence board",
+        description=(
+            "Compile ranked evidence from a completed search/query job into "
+            "media-separated annotated image pages. Use the returned tile map "
+            "to choose evidence IDs for exact frame or clip drill-down. Boards "
+            "use bounded pages and return next_start_rank when more remain."
+        ),
+        annotations=_READ_ONLY,
+        structured_output=True,
+    )
+    async def create_evidence_board(
+        source_job_id: JobId,
+        idempotency_key: IdempotencyKey,
+        evidence_ids: Annotated[
+            tuple[Sha256, ...] | None,
+            Field(max_length=200),
+        ] = None,
+        start_rank: Annotated[int, Field(ge=1, le=200)] = 1,
+    ) -> Job:
+        def submit(actor: Principal) -> Job:
+            source = completed_evidence_result(source_job_id)
+            prepared = _evidence_delivery(context).prepare_board_request(
+                source_job_id=source_job_id,
+                evidence_ids=evidence_ids,
+                start_rank=start_rank,
+                result=source,
+            )
+            return context.jobs.submit_evidence_board(
+                prepared,
+                job_id=scoped_job_id(
+                    principal=actor,
+                    transport="mcp",
+                    operation="evidence-board",
+                    idempotency_key=idempotency_key,
+                ),
+            )
+
+        return await _invoke_async(
+            context,
+            default_principal=default_principal,
+            permission=RepositoryPermission.read,
+            operation=submit,
+        )
+
+    @server.tool(
         title="Get artifact download",
         description=(
             "Return a native lazy MCP ResourceLink plus transport-authoritative "
@@ -1548,7 +1648,8 @@ def create_mcp_server(
         description=(
             "Poll a durable VidXP job and its typed result. Completed search "
             "and query jobs include ranked evidence frames/resources and any "
-            "requested ready clips in this same response."
+            "requested ready clips; completed evidence-board jobs include "
+            "annotated pages and their tile map in this same response."
         ),
         annotations=_READ_ONLY,
         structured_output=True,
@@ -1582,6 +1683,15 @@ def create_mcp_server(
                         )
                     }
                 )
+        elif (
+            job.state == JobState.succeeded
+            and job.result is not None
+            and job.kind == JobKind.evidence_board
+        ):
+            board, blocks = await project_evidence_board(job.result.result)
+            projected = job.model_copy(
+                update={"result": job.result.model_copy(update={"result": board})}
+            )
         if not blocks:
             blocks.append(
                 TextContent(

--- a/src/vidxp/mcp.py
+++ b/src/vidxp/mcp.py
@@ -1297,7 +1297,8 @@ def create_mcp_server(
             "Submit a durable ranked moment search. Set command.media_id to "
             "search one registered video; omit it to search across every media "
             "item in the active index snapshot. MCP defaults to the strongest "
-            "three keyframes. Request keyframes_and_clips for same-job clips, "
+            "three keyframes. Set command.evidence_delivery.mode to "
+            "keyframes_and_clips for same-job clips, "
             "then poll only this job for results and evidence."
         ),
         annotations=_SUBMIT,
@@ -1346,8 +1347,9 @@ def create_mcp_server(
             "Submit a durable grounded natural-language query over indexed "
             "moments and actor evidence. Set command.media_id for one video, "
             "or omit it to query across every media item in the active index "
-            "snapshot. MCP defaults to the strongest three keyframes. Request "
-            "keyframes_and_clips for same-job clips, then poll only this job "
+            "snapshot. MCP defaults to the strongest three keyframes. Set "
+            "command.evidence_delivery.mode to keyframes_and_clips for "
+            "same-job clips, then poll only this job "
             "for the grounded answer and inspectable evidence."
         ),
         annotations=_SUBMIT,

--- a/src/vidxp/mcp.py
+++ b/src/vidxp/mcp.py
@@ -523,12 +523,12 @@ def create_mcp_server(
             "media included in the active index snapshot. For search_moments "
             "and query_video, provide command.media_id to restrict work to one "
             "video, or omit it to search/query across every media item in that "
-            "snapshot. MCP defaults to three ranked evidence frames; request "
-            "keyframes_and_clips to receive bounded ready clips in the same "
-            "completed job. The ordinary flow is submit search/query, then poll "
-            "that job. For a broad result set, call create_evidence_board on "
-            "that completed job and inspect its annotated pages before drilling "
-            "into selected tile IDs. Use materialize_job_evidence with evidence "
+            "snapshot. MCP defaults to an annotated evidence board in the same "
+            "completed search/query job; request keyframes or "
+            "keyframes_and_clips only for standalone drill-down artifacts. The "
+            "ordinary flow is submit search/query, then poll that job and inspect "
+            "its board. Use create_evidence_board only for custom selections or "
+            "continuation pages. Use materialize_job_evidence with evidence "
             "IDs from the completed result to inspect additional candidates in "
             "batches of ten without rerunning retrieval or supplying timestamps. "
             "create_evidence_clip, create_clip, and get_artifact_download remain "
@@ -817,7 +817,13 @@ def create_mcp_server(
         EvidenceDeliveryResult,
         list[ImageContent | ResourceLink | TextContent],
     ]:
+        projected_board = None
         blocks: list[ImageContent | ResourceLink | TextContent] = []
+        if delivery.board is not None:
+            projected_board, board_blocks = await project_evidence_board(
+                delivery.board
+            )
+            blocks.extend(board_blocks)
         projected_items = []
         for item in delivery.items:
             keyframe = item.keyframe
@@ -888,7 +894,12 @@ def create_mcp_server(
                 item.model_copy(update={"keyframe": keyframe, "clip": clip})
             )
         return (
-            delivery.model_copy(update={"items": tuple(projected_items)}),
+            delivery.model_copy(
+                update={
+                    "items": tuple(projected_items),
+                    "board": projected_board,
+                }
+            ),
             blocks,
         )
 
@@ -1296,10 +1307,10 @@ def create_mcp_server(
         description=(
             "Submit a durable ranked moment search. Set command.media_id to "
             "search one registered video; omit it to search across every media "
-            "item in the active index snapshot. MCP defaults to the strongest "
-            "three keyframes. Set command.evidence_delivery.mode to "
-            "keyframes_and_clips for same-job clips, "
-            "then poll only this job for results and evidence."
+            "item in the active index snapshot. MCP returns an annotated board "
+            "of ranked results by default. Set command.evidence_delivery.mode "
+            "to keyframes or keyframes_and_clips only when standalone artifacts "
+            "are also needed, then poll only this job for results and evidence."
         ),
         annotations=_SUBMIT,
         structured_output=True,
@@ -1314,7 +1325,7 @@ def create_mcp_server(
                 projected = command.model_copy(
                     update={
                         "evidence_delivery": InitialEvidenceDeliveryPolicy(
-                            mode=EvidenceDeliveryMode.keyframes
+                            mode=EvidenceDeliveryMode.none
                         )
                     }
                 )
@@ -1347,10 +1358,10 @@ def create_mcp_server(
             "Submit a durable grounded natural-language query over indexed "
             "moments and actor evidence. Set command.media_id for one video, "
             "or omit it to query across every media item in the active index "
-            "snapshot. MCP defaults to the strongest three keyframes. Set "
-            "command.evidence_delivery.mode to keyframes_and_clips for "
-            "same-job clips, then poll only this job "
-            "for the grounded answer and inspectable evidence."
+            "snapshot. MCP returns an annotated board of ranked evidence by "
+            "default. Set command.evidence_delivery.mode to keyframes or "
+            "keyframes_and_clips only when standalone artifacts are also needed, "
+            "then poll only this job for the grounded answer and evidence."
         ),
         annotations=_SUBMIT,
         structured_output=True,
@@ -1365,7 +1376,7 @@ def create_mcp_server(
                 projected = command.model_copy(
                     update={
                         "evidence_delivery": InitialEvidenceDeliveryPolicy(
-                            mode=EvidenceDeliveryMode.keyframes
+                            mode=EvidenceDeliveryMode.none
                         )
                     }
                 )
@@ -1649,9 +1660,9 @@ def create_mcp_server(
         title="Get job",
         description=(
             "Poll a durable VidXP job and its typed result. Completed search "
-            "and query jobs include ranked evidence frames/resources and any "
-            "requested ready clips; completed evidence-board jobs include "
-            "annotated pages and their tile map in this same response."
+            "and query jobs include the default annotated board plus any requested "
+            "standalone frames or clips. Custom evidence-board jobs include their "
+            "annotated pages and tile map in this same response."
         ),
         annotations=_READ_ONLY,
         structured_output=True,

--- a/src/vidxp/ports.py
+++ b/src/vidxp/ports.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import (
     Any,
@@ -8,6 +9,7 @@ from typing import (
     Iterable,
     Mapping,
     Protocol,
+    Sequence,
     runtime_checkable,
 )
 
@@ -232,6 +234,30 @@ class FrameRendererPort(Protocol):
         frame_index: int | None,
         cancellation: CancellationToken,
         progress: ProgressCallback | None,
+    ) -> None: ...
+
+
+@dataclass(frozen=True)
+class EvidenceBoardRenderTile:
+    source: Path | None
+    annotation_lines: tuple[str, ...]
+    placeholder: str | None = None
+
+
+@runtime_checkable
+class EvidenceBoardRendererPort(Protocol):
+    def render(
+        self,
+        destination: Path,
+        *,
+        title: str,
+        tiles: Sequence[EvidenceBoardRenderTile],
+        columns: int,
+        tile_width: int,
+        tile_height: int,
+        annotation_height: int,
+        maximum_bytes: int,
+        cancellation: CancellationToken,
     ) -> None: ...
 
 

--- a/src/vidxp/settings.py
+++ b/src/vidxp/settings.py
@@ -163,6 +163,8 @@ class VidXPSettings(BaseSettings):
         gt=0,
         le=3600,
     )
+    evidence_board_tiles_per_page: int = Field(default=24, gt=0, le=48)
+    evidence_board_pages_per_job: int = Field(default=4, gt=0, le=16)
     http_bind_host: str = Field(default="127.0.0.1", min_length=1)
     http_port: int = Field(default=DEFAULT_HTTP_PORT, gt=0, le=65535)
     http_auth_mode: HttpAuthMode = HttpAuthMode.none

--- a/src/vidxp/workflow_contracts.py
+++ b/src/vidxp/workflow_contracts.py
@@ -20,6 +20,7 @@ WORKFLOW_NAMES: dict[JobKind, str] = {
     JobKind.query: "vidxp.query.v1",
     JobKind.snippet: "vidxp.snippet.v1",
     JobKind.actor_overlay: "vidxp.actor_overlay.v1",
+    JobKind.evidence_board: "vidxp.evidence_board.v1",
     JobKind.prepare_models: "vidxp.prepare_models.v1",
 }
 WORKFLOW_KINDS = {name: kind for kind, name in WORKFLOW_NAMES.items()}

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -17,6 +17,8 @@ from vidxp.application_models import (
     DependencyCheckCommand,
     DependencyCheckResult,
     DependencyUnavailableError,
+    EvidenceBoardResult,
+    EvidenceDeliveryMode,
     FusedSearchResult,
     IndexResult,
     IndexSnapshotReference,
@@ -27,6 +29,8 @@ from vidxp.application_models import (
     QueryVideoCommand,
     RemoveIndexCommand,
     SearchCommand,
+    SearchHit,
+    InitialEvidenceDeliveryPolicy,
 )
 from vidxp.core.media import MediaUnavailableError
 from vidxp.core.contracts import IndexConfig, IndexSchemaError
@@ -62,6 +66,7 @@ from vidxp.repositories import RepositoryConfigError
 from vidxp.runtime import ModelRuntime
 from vidxp.settings import VidXPSettings
 from vidxp.ports import IndexStore
+from vidxp.execution import ExecutionContext
 
 
 MEDIA_ID = "123456781234423481234567890abcde"
@@ -537,6 +542,59 @@ class ApplicationTests(unittest.TestCase):
             calls[0][0].storage,
             manager.__enter__.return_value,
         )
+
+    def test_initial_evidence_attaches_board_to_completed_search(self):
+        def handler(_context, request):
+            return SearchResult(
+                query_id="indexed:1",
+                query=request.query,
+                modality="indexed",
+                hits=(
+                    SearchHit(
+                        rank=1,
+                        media_id=MEDIA_ID,
+                        video_id=MEDIA_ID,
+                        generation_id=GENERATION_ID,
+                        start=1.0,
+                        end=2.0,
+                        score=0.9,
+                        raw_distance=0.1,
+                        modality="indexed",
+                        source_id="indexed:1",
+                    ),
+                ),
+            )
+
+        manager = MagicMock()
+        manager.__enter__.return_value = Mock(spec=IndexStore)
+        application = self.indexed_application(handler, manager)
+        board = EvidenceBoardResult(
+            source_job_id=SNAPSHOT_ID,
+            source_fingerprint="b" * 64,
+            requested_count=1,
+            rendered_count=1,
+            failed_count=0,
+            pages=(),
+            tiles=(),
+        )
+        application.evidence_boards = Mock()
+        application.evidence_boards.create.return_value = board
+
+        result = application.search(
+            SearchCommand(
+                modalities=("indexed",),
+                query="yellow taxi",
+                evidence_delivery=InitialEvidenceDeliveryPolicy(
+                    mode=EvidenceDeliveryMode.none,
+                ),
+            ),
+            execution=ExecutionContext(job_id=SNAPSHOT_ID),
+        )
+
+        self.assertEqual(result.evidence_delivery.board, board)
+        request = application.evidence_boards.create.call_args.args[0]
+        self.assertEqual(request.source_job_id, SNAPSHOT_ID)
+        self.assertEqual(len(request.candidates), 1)
 
     def test_default_search_filters_indexed_non_search_capabilities(self):
         searched: list[str] = []

--- a/tests/test_evidence_board.py
+++ b/tests/test_evidence_board.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from vidxp.application_models import (
+    Artifact,
+    EvidenceBoardCandidate,
+    EvidenceBoardJobRequest,
+    EvidenceFrameMatch,
+)
+from vidxp.core.artifacts import ArtifactKind, ArtifactState
+from vidxp.core.contracts import CancellationToken
+from vidxp.evidence_board import EvidenceBoardService, plan_evidence_board_pages
+from vidxp.infrastructure.pillow_board import PillowEvidenceBoardRenderer
+from vidxp.ports import EvidenceBoardRenderTile
+from vidxp.settings import VidXPSettings
+
+
+MEDIA_ID = "123456781234423481234567890abcde"
+GENERATION_ID = "223456781234423481234567890abcde"
+JOB_ID = "323456781234423481234567890abcde"
+SOURCE_FINGERPRINT = "a" * 64
+
+
+def candidate(rank: int, *, media_id: str = MEDIA_ID) -> EvidenceBoardCandidate:
+    return EvidenceBoardCandidate(
+        evidence_id=f"{rank:064x}",
+        rank=rank,
+        media_id=media_id,
+        generation_id=GENERATION_ID,
+        modalities=("scene",),
+        start=float(rank),
+        end=float(rank + 1),
+        representative_timestamp=float(rank) + 0.5,
+        frame_match=EvidenceFrameMatch.representative,
+        display_text=f"Result {rank}",
+    )
+
+
+def artifact(
+    artifact_id: str,
+    *,
+    kind: ArtifactKind,
+    mime_type: str,
+) -> Artifact:
+    return Artifact(
+        artifact_id=artifact_id,
+        media_id=MEDIA_ID,
+        generation_id=GENERATION_ID,
+        job_id=JOB_ID,
+        kind=kind,
+        profile="test",
+        mime_type=mime_type,
+        byte_size=100,
+        sha256="b" * 64,
+        state=ArtifactState.ready,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+class EvidenceBoardPlanningTests(unittest.TestCase):
+    def test_board_uses_pages_instead_of_a_ten_item_cap(self):
+        pages, continuation = plan_evidence_board_pages(
+            tuple(candidate(rank) for rank in range(1, 26)),
+            tiles_per_page=24,
+            pages_per_job=4,
+        )
+
+        self.assertEqual([len(page) for page in pages], [24, 1])
+        self.assertIsNone(continuation)
+
+    def test_board_returns_lossless_continuation_after_job_budget(self):
+        pages, continuation = plan_evidence_board_pages(
+            tuple(candidate(rank) for rank in range(1, 101)),
+            tiles_per_page=24,
+            pages_per_job=4,
+        )
+
+        self.assertEqual(sum(len(page) for page in pages), 96)
+        self.assertEqual(continuation, 97)
+
+    def test_pages_never_mix_media_or_skip_the_next_rank(self):
+        second_media = "423456781234423481234567890abcde"
+        values = tuple(
+            candidate(rank, media_id=MEDIA_ID if rank % 2 else second_media)
+            for rank in range(1, 7)
+        )
+        pages, continuation = plan_evidence_board_pages(
+            values,
+            tiles_per_page=24,
+            pages_per_job=4,
+        )
+
+        self.assertEqual(len(pages), 4)
+        self.assertTrue(
+            all(len({item.media_id for item in page}) == 1 for page in pages)
+        )
+        self.assertEqual(continuation, 5)
+
+
+class PillowEvidenceBoardRendererTests(unittest.TestCase):
+    def test_renderer_composes_a_bounded_jpeg(self):
+        try:
+            from PIL import Image
+        except ModuleNotFoundError:
+            self.skipTest("Pillow is unavailable in this test profile")
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            first = root / "first.png"
+            second = root / "second.png"
+            destination = root / "board.jpg"
+            Image.new("RGB", (640, 360), "red").save(first)
+            Image.new("RGB", (320, 480), "blue").save(second)
+
+            PillowEvidenceBoardRenderer().render(
+                destination,
+                title="Example video · page 1",
+                tiles=(
+                    EvidenceBoardRenderTile(
+                        source=first,
+                        annotation_lines=(
+                            "#1 · 00:01.000 · scene",
+                            "First",
+                            "representative",
+                        ),
+                    ),
+                    EvidenceBoardRenderTile(
+                        source=second,
+                        annotation_lines=(
+                            "#2 · 00:02.000 · scene",
+                            "Second",
+                            "representative",
+                        ),
+                    ),
+                ),
+                columns=4,
+                tile_width=320,
+                tile_height=180,
+                annotation_height=52,
+                maximum_bytes=8 * 1024 * 1024,
+                cancellation=CancellationToken(),
+            )
+
+            with Image.open(destination) as rendered:
+                self.assertEqual(rendered.format, "JPEG")
+                self.assertEqual(rendered.size, (640, 286))
+            self.assertLess(destination.stat().st_size, 8 * 1024 * 1024)
+
+
+class EvidenceBoardServiceTests(unittest.TestCase):
+    def test_service_returns_board_page_and_partial_tile_map(self):
+        artifacts = Mock()
+        artifacts.create_evidence_frame.side_effect = [
+            (
+                artifact(
+                    "523456781234423481234567890abcde",
+                    kind=ArtifactKind.evidence_frame,
+                    mime_type="image/png",
+                ),
+                640,
+                360,
+            ),
+            RuntimeError("frame failed"),
+        ]
+        artifacts.create_evidence_board_page.return_value = (
+            artifact(
+                "623456781234423481234567890abcde",
+                kind=ArtifactKind.evidence_board,
+                mime_type="image/jpeg",
+            ),
+            640,
+            286,
+        )
+        media = Mock()
+        media.require_record.return_value = SimpleNamespace(
+            duration_seconds=120.0,
+            original_filename="example.mp4",
+        )
+        service = EvidenceBoardService(
+            artifacts=artifacts,
+            media=media,
+            settings=VidXPSettings(),
+        )
+        request = EvidenceBoardJobRequest(
+            source_job_id=JOB_ID,
+            source_fingerprint=SOURCE_FINGERPRINT,
+            candidates=(candidate(1), candidate(2)),
+        )
+
+        result = service.create(request)
+
+        self.assertEqual(len(result.pages), 1)
+        self.assertEqual(result.rendered_count, 1)
+        self.assertEqual(result.failed_count, 1)
+        self.assertEqual(
+            result.tiles[0].keyframe_artifact_id, "523456781234423481234567890abcde"
+        )
+        self.assertIsNone(result.tiles[1].keyframe_artifact_id)
+        self.assertEqual(
+            result.pages[0].tile_ids, tuple(tile.tile_id for tile in result.tiles)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evidence_delivery.py
+++ b/tests/test_evidence_delivery.py
@@ -32,6 +32,7 @@ from vidxp.evidence_delivery import (
     EvidenceDeliveryService,
     resolve_evidence_range,
 )
+from vidxp.evidence_board import EvidenceBoardService
 from vidxp.artifact_service import ArtifactService
 from vidxp.execution import ExecutionContext
 from vidxp.infrastructure.local_artifacts import FFmpegFrameRenderer
@@ -41,6 +42,7 @@ from vidxp.infrastructure.local_artifacts import (
 )
 from vidxp.infrastructure.local_catalog import LocalCatalog
 from vidxp.infrastructure.local_media import FFprobeMediaProbe, LocalMediaStore
+from vidxp.infrastructure.pillow_board import PillowEvidenceBoardRenderer
 from vidxp.media_service import MediaService
 from vidxp.search_fusion import fuse_search_results
 from vidxp.settings import VidXPSettings
@@ -511,6 +513,7 @@ class ExactFrameRendererTests(unittest.TestCase):
                 actor_renderer=Mock(),
                 snippet_renderer=FFmpegSnippetRenderer(),
                 frame_renderer=FFmpegFrameRenderer(),
+                evidence_board_renderer=PillowEvidenceBoardRenderer(),
                 max_snippet_duration_seconds=5,
             )
             delivery_service = EvidenceDeliveryService(
@@ -578,6 +581,35 @@ class ExactFrameRendererTests(unittest.TestCase):
                 frame.artifact_id,
             )
             self.assertEqual(repeated_item.clip.artifact.artifact_id, clip.artifact_id)
+
+            board_request = delivery_service.prepare_board_request(
+                source_job_id=JOB_ID,
+                evidence_ids=None,
+                start_rank=1,
+                result=search,
+            )
+            boards = EvidenceBoardService(
+                artifacts=artifacts,
+                media=media,
+                settings=settings,
+            )
+            board = boards.create(
+                board_request,
+                execution=ExecutionContext(job_id="523456781234423481234567890abcde"),
+            )
+            repeated_board = boards.create(
+                board_request,
+                execution=ExecutionContext(job_id="523456781234423481234567890abcde"),
+            )
+            page = board.pages[0].artifact.artifact
+            page_content = artifacts.content(page.artifact_id)
+
+            self.assertEqual(page.mime_type, "image/jpeg")
+            self.assertEqual(page_content.path.read_bytes()[:2], b"\xff\xd8")
+            self.assertEqual(
+                repeated_board.pages[0].artifact.artifact.artifact_id,
+                page.artifact_id,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -30,6 +30,12 @@ from vidxp.application_models import (
     ApplicationError,
     Artifact,
     EvidenceArtifact,
+    EvidenceBoardCandidate,
+    EvidenceBoardJobRequest,
+    EvidenceBoardJobResult,
+    EvidenceBoardPage,
+    EvidenceBoardResult,
+    EvidenceBoardTile,
     EvidenceDeliveryItem,
     EvidenceDeliveryResult,
     EvidenceDeliveryState,
@@ -114,6 +120,7 @@ MCP_TOOL_NAMES = [
     "create_clip",
     "create_evidence_clip",
     "materialize_job_evidence",
+    "create_evidence_board",
     "get_artifact_download",
     "list_jobs",
     "get_job",
@@ -1104,7 +1111,7 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
         rendered = output.getvalue()
         self.assertIn("OK VidXP MCP", rendered)
         self.assertIn("Index state: missing", rendered)
-        self.assertIn("Tools: 21", rendered)
+        self.assertIn("Tools: 22", rendered)
         self.assertIn("get_index_status", rendered)
 
     async def test_server_info_exposes_vidxp_branding(self):
@@ -1673,6 +1680,170 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(
                 call.args[2].mode,
                 EvidenceDeliveryMode.keyframes_and_clips,
+            )
+
+    async def test_create_evidence_board_submits_frozen_candidates(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            context = self.context(root)
+            frame = Artifact(
+                artifact_id=ARTIFACT_ID,
+                media_id=MEDIA_ID,
+                generation_id="523456781234423481234567890abcde",
+                job_id=JOB_ID,
+                kind=ArtifactKind.evidence_frame,
+                profile="png",
+                mime_type="image/png",
+                byte_size=1,
+                sha256="a" * 64,
+                state=ArtifactState.ready,
+                created_at=datetime.now(timezone.utc),
+            )
+            source = search_evidence_job(frame)
+            candidate = EvidenceBoardCandidate(
+                evidence_id="e" * 64,
+                rank=1,
+                media_id=MEDIA_ID,
+                generation_id="523456781234423481234567890abcde",
+                modalities=("scene",),
+                start=1.0,
+                end=2.0,
+                representative_timestamp=1.4,
+                frame_index=7,
+                frame_match=EvidenceFrameMatch.exact_indexed_frame,
+            )
+            prepared = EvidenceBoardJobRequest(
+                source_job_id=JOB_ID,
+                source_fingerprint="f" * 64,
+                candidates=(candidate,),
+            )
+            delivery = Mock()
+            delivery.prepare_board_request.return_value = prepared
+            context = replace(context, evidence_delivery=delivery)
+            context.jobs.get.return_value = source
+            context.jobs.submit_evidence_board.return_value = queued_job().model_copy(
+                update={"kind": JobKind.evidence_board}
+            )
+            server = create_mcp_server(
+                context,
+                default_principal=Principal(
+                    subject="agent",
+                    scopes=frozenset({"vidxp.read"}),
+                ),
+            )
+
+            async with Client(server) as client:
+                result = await client.call_tool(
+                    "create_evidence_board",
+                    {
+                        "source_job_id": JOB_ID,
+                        "idempotency_key": "board-0001",
+                    },
+                )
+
+            self.assertFalse(result.is_error, result.content)
+            delivery.prepare_board_request.assert_called_once()
+            context.jobs.submit_evidence_board.assert_called_once_with(
+                prepared,
+                job_id=context.jobs.submit_evidence_board.call_args.kwargs["job_id"],
+            )
+
+    async def test_get_job_projects_and_inlines_evidence_board_pages(self):
+        try:
+            from PIL import Image
+        except ModuleNotFoundError:
+            self.skipTest("Pillow is unavailable in this test profile")
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            page_path = root / "board.jpg"
+            Image.new("RGB", (320, 286), "purple").save(page_path, format="JPEG")
+            page_bytes = page_path.read_bytes()
+            page_artifact = Artifact(
+                artifact_id=ARTIFACT_ID,
+                media_id=MEDIA_ID,
+                generation_id="523456781234423481234567890abcde",
+                job_id=JOB_ID,
+                kind=ArtifactKind.evidence_board,
+                profile="overview-jpeg-v1",
+                mime_type="image/jpeg",
+                byte_size=len(page_bytes),
+                sha256=hashlib.sha256(page_bytes).hexdigest(),
+                state=ArtifactState.ready,
+                created_at=datetime.now(timezone.utc),
+            )
+            tile = EvidenceBoardTile(
+                tile_id="d" * 64,
+                evidence_id="e" * 64,
+                page_number=1,
+                position=1,
+                rank=1,
+                media_id=MEDIA_ID,
+                generation_id="523456781234423481234567890abcde",
+                modalities=("scene",),
+                start=1.0,
+                end=2.0,
+                representative_timestamp=1.4,
+                frame_match=EvidenceFrameMatch.representative,
+                state=EvidenceDeliveryState.ready,
+            )
+            board = EvidenceBoardResult(
+                source_job_id=JOB_ID,
+                source_fingerprint="f" * 64,
+                requested_count=1,
+                rendered_count=1,
+                failed_count=0,
+                pages=(
+                    EvidenceBoardPage(
+                        page_number=1,
+                        media_id=MEDIA_ID,
+                        generation_id="523456781234423481234567890abcde",
+                        artifact=EvidenceArtifact(artifact=page_artifact),
+                        width=320,
+                        height=286,
+                        columns=1,
+                        rows=1,
+                        tile_ids=(tile.tile_id,),
+                    ),
+                ),
+                tiles=(tile,),
+            )
+            context = self.context(root, mcp_stdio_filesystem_accessible=False)
+            context.jobs.get.return_value = Job(
+                job_id=JOB_ID,
+                kind=JobKind.evidence_board,
+                state=JobState.succeeded,
+                queue=JobQueue.cpu,
+                result=EvidenceBoardJobResult(result=board),
+            )
+            context.application.open_artifact_content.return_value = LocalFileResource(
+                path=page_path,
+                filename=f"evidence_board-{ARTIFACT_ID}.jpg",
+                mime_type="image/jpeg",
+                byte_size=len(page_bytes),
+                etag=page_artifact.sha256,
+            )
+            server = create_mcp_server(
+                context,
+                default_principal=Principal(
+                    subject="agent",
+                    scopes=frozenset({"vidxp.read"}),
+                ),
+            )
+
+            async with Client(server) as client:
+                result = await client.call_tool("get_job", {"job_id": JOB_ID})
+
+            self.assertFalse(result.is_error, result.content)
+            self.assertTrue(
+                any(isinstance(block, ImageContent) for block in result.content)
+            )
+            self.assertTrue(
+                any(isinstance(block, ResourceLink) for block in result.content)
+            )
+            projected = result.structured_content["result"]["result"]["pages"][0]
+            self.assertEqual(
+                projected["artifact"]["resource_uri"],
+                f"vidxp://artifacts/{ARTIFACT_ID}/content.jpg",
             )
 
     async def test_one_job_search_returns_frame_and_ready_clip(self):
@@ -2403,9 +2574,13 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
                 server.should_exit = True
                 await serving
 
-        self.assertEqual(len(discovered.tools), 19)
+        self.assertEqual(len(discovered.tools), 20)
         self.assertNotIn(
             "create_media_upload",
+            {tool.name for tool in discovered.tools},
+        )
+        self.assertIn(
+            "create_evidence_board",
             {tool.name for tool in discovered.tools},
         )
         self.assertEqual(result.structured_content, {"items": []})

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -32,7 +32,6 @@ from vidxp.application_models import (
     EvidenceArtifact,
     EvidenceBoardCandidate,
     EvidenceBoardJobRequest,
-    EvidenceBoardJobResult,
     EvidenceBoardPage,
     EvidenceBoardResult,
     EvidenceBoardTile,
@@ -1274,7 +1273,7 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
                 media_id=MEDIA_ID,
                 modalities=("scene", "dialogue"),
                 evidence_delivery=InitialEvidenceDeliveryPolicy(
-                    mode=EvidenceDeliveryMode.keyframes
+                    mode=EvidenceDeliveryMode.none
                 ),
             ),
         )
@@ -1748,7 +1747,7 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
                 job_id=context.jobs.submit_evidence_board.call_args.kwargs["job_id"],
             )
 
-    async def test_get_job_projects_and_inlines_evidence_board_pages(self):
+    async def test_get_job_projects_default_evidence_board_with_search(self):
         try:
             from PIL import Image
         except ModuleNotFoundError:
@@ -1808,12 +1807,24 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
                 tiles=(tile,),
             )
             context = self.context(root, mcp_stdio_filesystem_accessible=False)
-            context.jobs.get.return_value = Job(
-                job_id=JOB_ID,
-                kind=JobKind.evidence_board,
-                state=JobState.succeeded,
-                queue=JobQueue.cpu,
-                result=EvidenceBoardJobResult(result=board),
+            source = search_evidence_job(page_artifact)
+            search = source.result.result
+            context.jobs.get.return_value = source.model_copy(
+                update={
+                    "result": SearchJobResult(
+                        result=search.model_copy(
+                            update={
+                                "evidence_delivery": EvidenceDeliveryResult(
+                                    policy=InitialEvidenceDeliveryPolicy(
+                                        mode=EvidenceDeliveryMode.none,
+                                    ),
+                                    items=(),
+                                    board=board,
+                                )
+                            }
+                        )
+                    )
+                }
             )
             context.application.open_artifact_content.return_value = LocalFileResource(
                 path=page_path,
@@ -1840,7 +1851,9 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(
                 any(isinstance(block, ResourceLink) for block in result.content)
             )
-            projected = result.structured_content["result"]["result"]["pages"][0]
+            projected = result.structured_content["result"]["result"][
+                "evidence_delivery"
+            ]["board"]["pages"][0]
             self.assertEqual(
                 projected["artifact"]["resource_uri"],
                 f"vidxp://artifacts/{ARTIFACT_ID}/content.jpg",


### PR DESCRIPTION
## Summary

- return an annotated evidence board in the ordinary completed `search_moments` and `query_video` job
- board the ranked result set without the five-item standalone frame/clip limit; preserve `next_start_rank` when the page budget is exceeded
- keep `keyframes` and `keyframes_and_clips` as optional same-job drill-down artifacts
- keep `create_evidence_board` only for custom selections and continuation pages
- use the same board contract over local stdio and Streamable HTTP MCP, including inline images, resource links, and tile-to-evidence mapping
- simplify the public ingestion/evidence skills and align the README and architecture documentation with the actual default flow

## Why

The intended agent path is one retrieval submission and one polled job that already contains a visual overview. Requiring a second board job—or forcing the agent through repeated batches of individual frames—defeated that purpose.

## Agent flow

1. Submit `search_moments` or `query_video` without `command.evidence_delivery`.
2. Poll that job with `get_job`.
3. Inspect the returned board and its stable evidence IDs.
4. Materialize only selected IDs as standalone keyframes or clips when needed.

## Validation

- 135 focused application, evidence, MCP, API, and projection tests passed with 7 subtests
- real official stdio MCP client: omitted evidence options, one search job succeeded with one inline JPEG board, one ResourceLink, six ranked tiles, and zero standalone items
- both repo and installed global skills pass `quick_validate.py` and are byte-identical
- Ruff and `git diff --check` passed

No migration, dependency, frontend, actor behavior, or captioning change is included.

BEGIN_COMMIT_OVERRIDE
chore(mcp): build reusable evidence boards
END_COMMIT_OVERRIDE