### PR TITLE
ci(release): isolate current candidate artifacts

### DIFF
--- a/.github/workflows/promotion-pr.yml
+++ b/.github/workflows/promotion-pr.yml
@@ -37,15 +37,9 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         shell: bash
         run: |
-          comparison="$(
-            gh api "repos/$REPOSITORY/compare/release...main" \
-              --jq '[.status, .ahead_by] | @tsv'
+          ahead="$(
+            gh api "repos/$REPOSITORY/compare/release...main" --jq .ahead_by
           )"
-          IFS=$'\t' read -r status ahead <<< "$comparison"
-          if [[ "$status" == "diverged" ]]; then
-            echo "release and main diverged; stable synchronization must finish first."
-            exit 0
-          fi
           if [[ "$ahead" == "0" ]]; then
             echo "main has no commits to promote."
             exit 0

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -112,12 +112,20 @@ jobs:
 
       - name: Prepare release assets and checksums
         id: source
+        env:
+          VERSION: ${{ steps.contract.outputs.version }}
         shell: bash
         run: |
           mkdir release-assets
-          find candidate-artifacts/vidxp-python-dist \
-            candidate-artifacts/vidxp-desktop-* \
-            -type f -exec cp '{}' release-assets/ ';'
+          find candidate-artifacts/vidxp-python-dist -type f \
+            \( -name '*.whl' -o -name '*.tar.gz' \) \
+            -exec cp '{}' release-assets/ ';'
+          cp "candidate-artifacts/vidxp-desktop-windows-x86_64/VidXP_${VERSION}_x64-setup.exe" \
+            release-assets/
+          cp "candidate-artifacts/vidxp-desktop-macos-aarch64/VidXP_${VERSION}_aarch64.dmg" \
+            release-assets/
+          cp "candidate-artifacts/vidxp-desktop-linux-x86_64/VidXP_${VERSION}_amd64.AppImage" \
+            release-assets/
           [[ "$(find release-assets -maxdepth 1 -name '*.whl' | wc -l)" == 1 ]]
           [[ "$(find release-assets -maxdepth 1 -name '*.tar.gz' | wc -l)" == 1 ]]
           [[ "$(find release-assets -maxdepth 1 -name '*.exe' | wc -l)" == 1 ]]

--- a/desktop/scripts/build-desktop.mjs
+++ b/desktop/scripts/build-desktop.mjs
@@ -1,19 +1,38 @@
 import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const bundles = {
-  darwin: "dmg",
-  linux: "appimage",
-  win32: "nsis",
+const bundleSpecs = {
+  darwin: {
+    bundle: "dmg",
+    directory: "dmg",
+    suffix: ".dmg",
+    filename: (version) => `VidXP_${version}_aarch64.dmg`,
+  },
+  linux: {
+    bundle: "appimage",
+    directory: "appimage",
+    suffix: ".AppImage",
+    filename: (version) => `VidXP_${version}_amd64.AppImage`,
+  },
+  win32: {
+    bundle: "nsis",
+    directory: "nsis",
+    suffix: "-setup.exe",
+    filename: (version) => `VidXP_${version}_x64-setup.exe`,
+  },
 };
 
-const bundle = bundles[process.platform];
-if (!bundle) {
+const bundleSpec = bundleSpecs[process.platform];
+if (!bundleSpec) {
   throw new Error(`Unsupported desktop build platform: ${process.platform}`);
 }
 
 const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const bundleRoot = resolve(desktopRoot, "src-tauri", "target", "release", "bundle");
+rmSync(bundleRoot, { force: true, recursive: true });
+
 const executable = resolve(
   desktopRoot,
   "node_modules",
@@ -22,11 +41,35 @@ const executable = resolve(
 );
 const result = spawnSync(
   executable,
-  ["build", "--bundles", bundle, "--ci", "--no-sign", "--", "--locked"],
+  ["build", "--bundles", bundleSpec.bundle, "--ci", "--no-sign", "--", "--locked"],
   { shell: process.platform === "win32", stdio: "inherit" },
 );
 
 if (result.error) {
   throw result.error;
 }
-process.exit(result.status ?? 1);
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}
+
+const { version } = JSON.parse(
+  readFileSync(resolve(desktopRoot, "package.json"), "utf8"),
+);
+const outputDirectory = resolve(bundleRoot, bundleSpec.directory);
+const expectedArtifact = resolve(outputDirectory, bundleSpec.filename(version));
+const packagedArtifacts = existsSync(outputDirectory)
+  ? readdirSync(outputDirectory, { withFileTypes: true })
+      .filter(
+        (entry) => entry.isFile() && entry.name.endsWith(bundleSpec.suffix),
+      )
+      .map((entry) => entry.name)
+  : [];
+if (
+  !existsSync(expectedArtifact) ||
+  packagedArtifacts.length !== 1 ||
+  packagedArtifacts[0] !== bundleSpec.filename(version)
+) {
+  throw new Error(
+    `Expected only ${expectedArtifact}, found: ${packagedArtifacts.join(", ") || "none"}`,
+  );
+}


### PR DESCRIPTION
## Summary
- clear cached desktop bundle outputs and require one exact-version installer per platform
- publish only the exact release-version artifacts, allowing the existing 0.4.0-b.2 candidate to be resumed safely
- keep the main-to-release promotion PR current even after the branches have naturally diverged

## Validation
- desktop ESLint
- Node syntax check
- Actionlint with ShellCheck
- git diff --check
- inspected candidate run 30855921624 and confirmed the exact 0.4.0-b.2 artifacts are present