### PR TITLE
feat(desktop): add guided setup and local service management

### DIFF
--- a/INSTALLATION_GUIDE.md
+++ b/INSTALLATION_GUIDE.md
@@ -357,8 +357,12 @@ does not install anything before that choice:
   contracts, and the installation stays selected and externally owned.
   For an isolated uv-tool installation, **Setup options** can change its search,
   local-processing, browser, AI-assistant, or app-integration features. Desktop recreates that app environment at
-  its reported VidXP and Python versions with the complete selected extra set,
-  then rechecks it. Other environment types stay with their original package
+  its compatible VidXP and Python versions with the complete selected extra set,
+  then rechecks it. If the saved installation predates the required management
+  contract, Desktop offers to update that same uv-tool environment to the runtime
+  version bundled with the Desktop release before applying the chosen features.
+  It does not interpret fields missing from an older probe as disabled features.
+  Other environment types stay with their original package
   manager. Desktop does not broadly stop an external installation. The
   compatibility probe reports installed search, processing, and integration features.
 - **Set up VidXP for me** creates a private Python and VidXP runtime owned by

--- a/INSTALLATION_GUIDE.md
+++ b/INSTALLATION_GUIDE.md
@@ -26,7 +26,7 @@ Local model work requires a capability or worker extra.
 |---|---|---|
 | CLI or MCP | [uv 0.12+](https://docs.astral.sh/uv/getting-started/installation/) | Python and the isolated VidXP environment |
 | Desktop-managed target | A supported OS, internet access for first setup, FFmpeg, ffprobe, `libx264`, and `aac` | uv, Python, VidXP, and selected model files |
-| Desktop with existing target | A compatible local `vidxp` executable and that installation's own media-runtime setup | Target discovery and launch coordination only |
+| Desktop with existing target | A compatible local `vidxp` executable and that installation's own media-runtime setup | Target discovery, service controls, and feature reinstallation for isolated uv tools |
 | Docker | Docker Engine or Docker Desktop | Python, VidXP, and FFmpeg inside the image |
 
 Native CLI and desktop processing require FFmpeg, ffprobe, `libx264`, and
@@ -354,27 +354,45 @@ does not install anything before that choice:
 
 - **Use an existing installation** discovers compatible `vidxp` executables or
   lets you browse to one. Desktop validates the versioned probe and launch
-  contracts, but the installation stays externally owned. Desktop never
-  installs, repairs, updates, removes, or broadly stops it. If its browser
-  surface is missing, enable the `frontend` extra with that installation's own
-  package-management workflow before Desktop can open it.
+  contracts, and the installation stays selected and externally owned.
+  For an isolated uv-tool installation, **Setup options** can change its search,
+  local-processing, browser, AI-assistant, or app-integration features. Desktop recreates that app environment at
+  its reported VidXP and Python versions with the complete selected extra set,
+  then rechecks it. Other environment types stay with their original package
+  manager. Desktop does not broadly stop an external installation. The
+  compatibility probe reports installed search, processing, and integration features.
 - **Set up VidXP for me** creates a private Python and VidXP runtime owned by
   Desktop. Python and uv do not need to be installed separately. Capability
-  code, the optional browser interface, model storage, and initial model
-  preparation are selected before applying the draft.
+  code, optional local video processing, browser interface, AI-assistant
+  integration, and app integration service,
+  model storage, and initial model preparation are selected before applying
+  the draft.
 
 A managed setup or update remains a draft until its candidate runtime passes
 the Desktop probe and launch contracts. Activation then replaces the previous
 managed target atomically; failed or cancelled work leaves the previous target
-authoritative. For an unchanged ready runtime, **Prepare / verify models**
+authoritative. For an unchanged ready runtime, **Check downloaded models**
 checks cached files and downloads only missing selected model material without
 requiring a configuration change.
+
+The active-target panel can run the selected installation's read-only
+`vidxp doctor --json` check, start/monitor/stop local video processing through
+the existing worker supervisor, generate `mcpServers` JSON bound to that exact
+installation and repository, and start/monitor/stop a Desktop-owned loopback
+`vidxp-api` process when the app integration service is installed. These controls remain
+available after installation; Desktop is not only a first-run installer or a
+browser launcher. It broadly stops only a Desktop-owned target and only
+reinstalls an existing isolated tool after the user confirms the feature change.
+Browser and app-service processes start private to the current computer.
+Desktop can also invoke each service's existing `--share` mode: it shows the
+resolved LAN port and URLs, warns that the shared browser has no authentication,
+and exposes the API/MCP bearer token behind the connection details.
 
 Starting Desktop, or starting it a second time, shows and focuses the control
 panel without opening a browser. **Open VidXP** explicitly starts or reuses the
 loopback browser service and opens one tab. Closing a configured window hides
 it to the tray. Tray actions are **Manage VidXP**, **Open VidXP**, and **Quit
-VidXP**. Quit stops the exact browser service Desktop launched; broad worker
+VidXP**. Quit stops the exact browser and API services Desktop launched; broad worker
 shutdown is limited to a Desktop-owned runtime.
 
 The NSIS, DMG, and AppImage packages do not bundle FFmpeg. Managed setup can

--- a/desktop/runtime-manifest.json
+++ b/desktop/runtime-manifest.json
@@ -7,11 +7,29 @@
   "python_version": "3.14.6",
   "uv_version": "0.12.0",
   "surfaces": {
+    "worker": {
+      "extra": "local-worker",
+      "label": "Process videos on this computer",
+      "description": "Run background indexing, search, and grounded questions locally. This includes all built-in search features and is the normal desktop setup.",
+      "default": true
+    },
     "browser": {
       "extra": "frontend",
       "label": "Browser interface",
-      "description": "Installs the local browser interface. Leave this off for a processing-only runtime.",
+      "description": "Use VidXP's visual workspace in your default browser. It stays private to this computer unless you explicitly share it without authentication.",
       "default": true
+    },
+    "mcp": {
+      "extra": "mcp",
+      "label": "AI assistant integration",
+      "description": "Use VidXP from an MCP-compatible AI assistant installed on this computer.",
+      "default": false
+    },
+    "server": {
+      "extra": "server",
+      "label": "App integration service",
+      "description": "Run an API and network-style MCP connection for other software. It is private by default and can be shared on your local network with bearer-token authentication.",
+      "default": false
     }
   },
   "capabilities": {

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -46,6 +46,8 @@ fn main() {
             "local-worker",
             "--extra",
             "frontend",
+            "--extra",
+            "server",
             "--no-dev",
             "--no-emit-project",
             "--no-hashes",

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -92,5 +92,23 @@ fn main() {
     println!("cargo:rerun-if-changed=../../uv.lock");
     println!("cargo:rerun-if-changed=../runtime-manifest.json");
 
-    tauri_build::build()
+    let mut attributes = tauri_build::Attributes::new();
+    #[cfg(windows)]
+    {
+        attributes = attributes
+            .windows_attributes(tauri_build::WindowsAttributes::new_without_app_manifest());
+        add_windows_manifest();
+    }
+    tauri_build::try_build(attributes).expect("Tauri build configuration must be valid")
+}
+
+#[cfg(windows)]
+fn add_windows_manifest() {
+    let manifest = std::path::PathBuf::from(
+        std::env::var_os("CARGO_MANIFEST_DIR").expect("Cargo must provide CARGO_MANIFEST_DIR"),
+    )
+    .join("windows-app-manifest.xml");
+    println!("cargo:rerun-if-changed={}", manifest.display());
+    println!("cargo:rustc-link-arg=/MANIFEST:EMBED");
+    println!("cargo:rustc-link-arg=/MANIFESTINPUT:{}", manifest.display());
 }

--- a/desktop/src-tauri/src/browser_readiness.rs
+++ b/desktop/src-tauri/src/browser_readiness.rs
@@ -22,6 +22,8 @@ struct ReadinessMarker {
     port: u16,
     #[serde(rename = "pid")]
     _pid: u32,
+    #[serde(default)]
+    network_url: Option<String>,
 }
 
 fn marker_matches(contents: &[u8], nonce: &str, port: u16) -> bool {
@@ -66,7 +68,7 @@ pub fn wait_for_browser_readiness(
     port: u16,
     deadline: Instant,
     cancellation: &CancellationToken,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     let address = SocketAddr::from(([127, 0, 0, 1], port));
     while Instant::now() < deadline {
         if cancellation.is_cancelled() {
@@ -83,11 +85,14 @@ pub fn wait_for_browser_readiness(
                 "The VidXP interface exited during startup ({status})."
             ));
         }
-        if fs::read(marker_path).is_ok_and(|contents| {
-            marker_matches(&contents, nonce, port) && streamlit_health_is_ready(address)
-        }) {
+        if let Ok(contents) = fs::read(marker_path)
+            && marker_matches(&contents, nonce, port)
+            && streamlit_health_is_ready(address)
+        {
+            let marker = serde_json::from_slice::<ReadinessMarker>(&contents)
+                .map_err(|error| format!("The interface readiness marker is invalid: {error}"))?;
             let _ = fs::remove_file(marker_path);
-            return Ok(());
+            return Ok(marker.network_url);
         }
         thread::sleep(Duration::from_millis(50));
     }
@@ -231,11 +236,12 @@ mod tests {
                 "nonce": "launch",
                 "port": port,
                 "pid": process.id() + 1,
+                "network_url": format!("http://192.168.1.20:{port}"),
             })
             .to_string(),
         )
         .expect("marker");
-        wait_for_browser_readiness(
+        let network_url = wait_for_browser_readiness(
             &mut process,
             &marker,
             "launch",
@@ -244,6 +250,7 @@ mod tests {
             &CancellationToken::default(),
         )
         .expect("ready");
+        assert_eq!(network_url, Some(format!("http://192.168.1.20:{port}")));
         assert!(!marker.exists());
         server.join().expect("server");
     }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tauri::{
     AppHandle, Manager, RunEvent, WindowEvent,
-    menu::{Menu, MenuItem},
+    menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
     tray::TrayIconBuilder,
 };
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
@@ -415,6 +415,22 @@ struct LocalWorkerStatus {
     detail: String,
 }
 
+#[derive(Clone)]
+struct TrayMenuItems {
+    installation: MenuItem<tauri::Wry>,
+    browser: Submenu<tauri::Wry>,
+    open_browser: MenuItem<tauri::Wry>,
+    share_browser: MenuItem<tauri::Wry>,
+    stop_browser: MenuItem<tauri::Wry>,
+    worker: Submenu<tauri::Wry>,
+    start_worker: MenuItem<tauri::Wry>,
+    stop_worker: MenuItem<tauri::Wry>,
+    server: Submenu<tauri::Wry>,
+    start_server: MenuItem<tauri::Wry>,
+    share_server: MenuItem<tauri::Wry>,
+    stop_server: MenuItem<tauri::Wry>,
+}
+
 struct DesktopState {
     ui_process: Mutex<Option<ManagedUi>>,
     api_process: Mutex<Option<ManagedApiService>>,
@@ -425,6 +441,8 @@ struct DesktopState {
     shutdown: background_process::CancellationToken,
     shutdown_started: AtomicBool,
     active_operations: Arc<ActiveOperations>,
+    worker_status: Mutex<Option<(String, Result<LocalWorkerStatus, String>)>>,
+    tray_menu: Mutex<Option<TrayMenuItems>>,
 }
 
 impl Default for DesktopState {
@@ -439,6 +457,8 @@ impl Default for DesktopState {
             shutdown: background_process::CancellationToken::default(),
             shutdown_started: AtomicBool::new(false),
             active_operations: Arc::new(ActiveOperations::default()),
+            worker_status: Mutex::new(None),
+            tray_menu: Mutex::new(None),
         }
     }
 }
@@ -2017,13 +2037,14 @@ async fn refresh_target_state(
     let desktop_version = manifest.desktop_version;
     let transition = TargetTransitionCoordinator::begin(&state, TransitionKind::Revalidate)?;
     let cancellation = state.shutdown.clone();
-    tauri::async_runtime::spawn_blocking(move || {
+    let worker_app = app.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
         let _transition = transition;
-        match target_profiles::selected_profile(&app) {
+        match target_profiles::selected_profile(&worker_app) {
             Ok(profile) => {
                 if profile.kind == target_profiles::TargetKind::Managed {
                     let validation = (|| {
-                        let paths = desktop_paths(&app).map_err(|message| {
+                        let paths = desktop_paths(&worker_app).map_err(|message| {
                             transition_error(
                                 target_profiles::TargetErrorCode::ManagedRuntimeUnavailable,
                                 message,
@@ -2051,10 +2072,10 @@ async fn refresh_target_state(
                             Some(&cancellation),
                         )
                     })();
-                    let _ = target_profiles::persist_selected_validation(&app, validation);
+                    let _ = target_profiles::persist_selected_validation(&worker_app, validation);
                 } else {
                     let _ = target_profiles::validated_selected_profile_with_cancellation(
-                        &app,
+                        &worker_app,
                         &desktop_version,
                         Some(&cancellation),
                     );
@@ -2064,13 +2085,15 @@ async fn refresh_target_state(
                 if error.code == target_profiles::TargetErrorCode::SelectedProfileMissing => {}
             Err(error) => return Err(error),
         }
-        target_profiles::current_state(&app)
+        target_profiles::current_state(&worker_app)
     })
     .await
     .map_err(|error| target_profiles::TargetError {
         code: target_profiles::TargetErrorCode::ValidationRequired,
         message: format!("Target revalidation stopped unexpectedly: {error}"),
-    })?
+    })??;
+    refresh_tray_for_selected_target(&app);
+    Ok(result)
 }
 
 #[tauri::command]
@@ -2144,7 +2167,8 @@ async fn adopt_local_target(
     let transition = TargetTransitionCoordinator::begin(&state, TransitionKind::Adopt)?;
     let desktop_version = manifest.desktop_version;
     let cancellation = state.shutdown.clone();
-    tauri::async_runtime::spawn_blocking(move || {
+    let worker_app = app.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
         let _transition = transition;
         let canonical =
             fs::canonicalize(Path::new(&executable)).unwrap_or_else(|_| PathBuf::from(&executable));
@@ -2154,9 +2178,9 @@ async fn adopt_local_target(
             Some(&cancellation),
             |path| Command::new(path),
         )?;
-        let setup = target_profiles::adopt_validated(&app, validated, display_name)?;
-        stop_ui_process(&app.state::<DesktopState>());
-        stop_api_process(&app.state::<DesktopState>());
+        let setup = target_profiles::adopt_validated(&worker_app, validated, display_name)?;
+        stop_ui_process(&worker_app.state::<DesktopState>());
+        stop_api_process(&worker_app.state::<DesktopState>());
         Ok(setup)
     })
     .await
@@ -2165,7 +2189,9 @@ async fn adopt_local_target(
             target_profiles::TargetErrorCode::ValidationRequired,
             format!("Target adoption stopped unexpectedly: {error}"),
         )
-    })?
+    })??;
+    refresh_tray_for_selected_target(&app);
+    Ok(result)
 }
 
 #[tauri::command]
@@ -2182,9 +2208,10 @@ async fn select_target_profile(
     let transition = TargetTransitionCoordinator::begin(&state, TransitionKind::Select)?;
     let desktop_version = manifest.desktop_version;
     let cancellation = state.shutdown.clone();
-    tauri::async_runtime::spawn_blocking(move || {
+    let worker_app = app.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
         let _transition = transition;
-        let candidate = target_profiles::current_state(&app)?
+        let candidate = target_profiles::current_state(&worker_app)?
             .profiles
             .into_iter()
             .find(|profile| profile.id == profile_id)
@@ -2195,7 +2222,7 @@ async fn select_target_profile(
                 )
             })?;
         let setup = if candidate.kind == target_profiles::TargetKind::Managed {
-            let paths = desktop_paths(&app).map_err(|message| {
+            let paths = desktop_paths(&worker_app).map_err(|message| {
                 transition_error(
                     target_profiles::TargetErrorCode::ManagedRuntimeUnavailable,
                     message,
@@ -2220,12 +2247,12 @@ async fn select_target_profile(
                 &desktop_version,
                 Some(&cancellation),
             )?;
-            target_profiles::select_validated_profile(&app, &profile_id, validated)?
+            target_profiles::select_validated_profile(&worker_app, &profile_id, validated)?
         } else {
-            target_profiles::select_profile(&app, &profile_id, &desktop_version)?
+            target_profiles::select_profile(&worker_app, &profile_id, &desktop_version)?
         };
-        stop_ui_process(&app.state::<DesktopState>());
-        stop_api_process(&app.state::<DesktopState>());
+        stop_ui_process(&worker_app.state::<DesktopState>());
+        stop_api_process(&worker_app.state::<DesktopState>());
         Ok(setup)
     })
     .await
@@ -2234,7 +2261,9 @@ async fn select_target_profile(
             target_profiles::TargetErrorCode::ValidationRequired,
             format!("Target selection stopped unexpectedly: {error}"),
         )
-    })?
+    })??;
+    refresh_tray_for_selected_target(&app);
+    Ok(result)
 }
 
 #[tauri::command]
@@ -2245,13 +2274,14 @@ async fn delete_target_profile(
 ) -> Result<target_profiles::TargetState, target_profiles::TargetError> {
     let _active = track_target_operation(&state)?;
     let transition = TargetTransitionCoordinator::begin(&state, TransitionKind::Delete)?;
-    tauri::async_runtime::spawn_blocking(move || {
+    let worker_app = app.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
         let _transition = transition;
-        let selected = target_profiles::current_state(&app)?.selected_profile_id;
-        let result = target_profiles::delete_profile(&app, &profile_id)?;
+        let selected = target_profiles::current_state(&worker_app)?.selected_profile_id;
+        let result = target_profiles::delete_profile(&worker_app, &profile_id)?;
         if selected.as_deref() == Some(&profile_id) {
-            stop_ui_process(&app.state::<DesktopState>());
-            stop_api_process(&app.state::<DesktopState>());
+            stop_ui_process(&worker_app.state::<DesktopState>());
+            stop_api_process(&worker_app.state::<DesktopState>());
         }
         Ok(result)
     })
@@ -2261,7 +2291,9 @@ async fn delete_target_profile(
             target_profiles::TargetErrorCode::ValidationRequired,
             format!("Target deletion stopped unexpectedly: {error}"),
         )
-    })?
+    })??;
+    refresh_tray_for_selected_target(&app);
+    Ok(result)
 }
 
 #[tauri::command]
@@ -2881,6 +2913,7 @@ async fn install_runtime(
     stop_ui_process(&state);
     stop_api_process(&state);
     transition.commit_draft();
+    refresh_tray_for_selected_target(&app);
 
     Ok(InstallTransitionResult {
         install: InstallResult {
@@ -3056,11 +3089,7 @@ fn stop_ui_process(state: &DesktopState) {
     }
 }
 
-#[tauri::command]
-fn browser_service_status(
-    state: tauri::State<'_, DesktopState>,
-) -> Result<BrowserServiceStatus, String> {
-    let _active = state.active_operations.register()?;
+fn inspect_browser_service(state: &DesktopState) -> Result<BrowserServiceStatus, String> {
     let mut active = state
         .ui_process
         .lock()
@@ -3081,25 +3110,46 @@ fn browser_service_status(
 }
 
 #[tauri::command]
-async fn start_shared_browser(
+fn browser_service_status(
     app: AppHandle,
     state: tauri::State<'_, DesktopState>,
 ) -> Result<BrowserServiceStatus, String> {
     let _active = state.active_operations.register()?;
-    tauri::async_runtime::spawn_blocking(move || {
-        let state = app.state::<DesktopState>();
-        start_ui(&app, &state, true)
+    let status = inspect_browser_service(&state)?;
+    refresh_tray_menu(&app);
+    Ok(status)
+}
+
+async fn start_browser_mode(app: AppHandle, shared: bool) -> Result<BrowserServiceStatus, String> {
+    let state = app.state::<DesktopState>();
+    let _active = state.active_operations.register()?;
+    let worker_app = app.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        let state = worker_app.state::<DesktopState>();
+        start_ui(&worker_app, &state, shared)
     })
     .await
-    .map_err(|error| format!("Browser sharing startup stopped unexpectedly: {error}"))?
+    .map_err(|error| format!("Browser sharing startup stopped unexpectedly: {error}"))?;
+    refresh_tray_menu(&app);
+    result
+}
+
+#[tauri::command]
+async fn start_shared_browser(
+    app: AppHandle,
+    _state: tauri::State<'_, DesktopState>,
+) -> Result<BrowserServiceStatus, String> {
+    start_browser_mode(app, true).await
 }
 
 #[tauri::command]
 fn stop_browser_service(
+    app: AppHandle,
     state: tauri::State<'_, DesktopState>,
 ) -> Result<BrowserServiceStatus, String> {
     let _active = state.active_operations.register()?;
     stop_ui_process(&state);
+    refresh_tray_menu(&app);
     Ok(stopped_browser_status("The browser interface was stopped."))
 }
 
@@ -3227,7 +3277,7 @@ async fn configure_external_installation(
         && selected_surfaces == profile.surfaces
         && selected_capabilities == profile.capabilities
     {
-        return Ok(target_profiles::current_state(&app).map_err(|error| error.to_string())?);
+        return target_profiles::current_state(&app).map_err(|error| error.to_string());
     }
     let runtime = profile.runtime.as_ref().ok_or_else(|| {
         "The selected installation did not report its Python environment.".to_string()
@@ -3286,7 +3336,9 @@ async fn configure_external_installation(
         Some(&state.shutdown),
     )
     .map_err(|error| error.to_string())?;
-    target_profiles::current_state(&app).map_err(|error| error.to_string())
+    let result = target_profiles::current_state(&app).map_err(|error| error.to_string())?;
+    refresh_tray_for_selected_target(&app);
+    Ok(result)
 }
 
 #[tauri::command]
@@ -3349,37 +3401,57 @@ fn execute_worker_action(app: &AppHandle, action: &str) -> Result<LocalWorkerSta
         .map_err(|error| format!("VidXP returned an invalid processing status: {error}"))
 }
 
+fn remember_worker_status(
+    state: &DesktopState,
+    profile_id: String,
+    status: &Result<LocalWorkerStatus, String>,
+) {
+    if let Ok(mut current) = state.worker_status.lock() {
+        *current = Some((profile_id, status.clone()));
+    }
+}
+
+async fn run_worker_action(
+    app: AppHandle,
+    action: &'static str,
+) -> Result<LocalWorkerStatus, String> {
+    let state = app.state::<DesktopState>();
+    let _active = state.active_operations.register()?;
+    let profile_id = target_profiles::selected_profile(&app)
+        .map_err(|error| error.to_string())?
+        .id;
+    let worker_app = app.clone();
+    let result =
+        tauri::async_runtime::spawn_blocking(move || execute_worker_action(&worker_app, action))
+            .await
+            .map_err(|error| format!("Local processing action stopped unexpectedly: {error}"))?;
+    remember_worker_status(&state, profile_id, &result);
+    refresh_tray_menu(&app);
+    result
+}
+
 #[tauri::command]
 async fn local_worker_status(
     app: AppHandle,
-    state: tauri::State<'_, DesktopState>,
+    _state: tauri::State<'_, DesktopState>,
 ) -> Result<LocalWorkerStatus, String> {
-    let _active = state.active_operations.register()?;
-    tauri::async_runtime::spawn_blocking(move || execute_worker_action(&app, "worker-status"))
-        .await
-        .map_err(|error| format!("Local processing status stopped unexpectedly: {error}"))?
+    run_worker_action(app, "worker-status").await
 }
 
 #[tauri::command]
 async fn start_local_worker(
     app: AppHandle,
-    state: tauri::State<'_, DesktopState>,
+    _state: tauri::State<'_, DesktopState>,
 ) -> Result<LocalWorkerStatus, String> {
-    let _active = state.active_operations.register()?;
-    tauri::async_runtime::spawn_blocking(move || execute_worker_action(&app, "start-worker"))
-        .await
-        .map_err(|error| format!("Local processing startup stopped unexpectedly: {error}"))?
+    run_worker_action(app, "start-worker").await
 }
 
 #[tauri::command]
 async fn stop_local_worker(
     app: AppHandle,
-    state: tauri::State<'_, DesktopState>,
+    _state: tauri::State<'_, DesktopState>,
 ) -> Result<LocalWorkerStatus, String> {
-    let _active = state.active_operations.register()?;
-    tauri::async_runtime::spawn_blocking(move || execute_worker_action(&app, "stop-worker"))
-        .await
-        .map_err(|error| format!("Local processing shutdown stopped unexpectedly: {error}"))?
+    run_worker_action(app, "stop-worker").await
 }
 
 fn http_health_is_ready(host: &str, port: u16) -> bool {
@@ -3449,9 +3521,7 @@ fn stop_api_process(state: &DesktopState) {
     }
 }
 
-#[tauri::command]
-fn local_server_status(state: tauri::State<'_, DesktopState>) -> Result<LocalServerStatus, String> {
-    let _active = state.active_operations.register()?;
+fn inspect_local_server(state: &DesktopState) -> Result<LocalServerStatus, String> {
     let mut active = state
         .api_process
         .lock()
@@ -3474,6 +3544,17 @@ fn local_server_status(state: tauri::State<'_, DesktopState>) -> Result<LocalSer
     }
     let healthy = http_health_is_ready(&service.health_host, service.port);
     Ok(running_server_status(service, healthy))
+}
+
+#[tauri::command]
+fn local_server_status(
+    app: AppHandle,
+    state: tauri::State<'_, DesktopState>,
+) -> Result<LocalServerStatus, String> {
+    let _active = state.active_operations.register()?;
+    let status = inspect_local_server(&state)?;
+    refresh_tray_menu(&app);
+    Ok(status)
 }
 
 fn api_service_command(
@@ -3608,40 +3689,44 @@ fn start_server_mode(
     Ok(status)
 }
 
-async fn start_server(
-    app: AppHandle,
-    state: tauri::State<'_, DesktopState>,
-    shared: bool,
-) -> Result<LocalServerStatus, String> {
+async fn start_server(app: AppHandle, shared: bool) -> Result<LocalServerStatus, String> {
+    let state = app.state::<DesktopState>();
     let _active = state.active_operations.register()?;
-    tauri::async_runtime::spawn_blocking(move || {
-        let state = app.state::<DesktopState>();
-        start_server_mode(&app, &state, shared)
+    let worker_app = app.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        let state = worker_app.state::<DesktopState>();
+        start_server_mode(&worker_app, &state, shared)
     })
     .await
-    .map_err(|error| format!("Local service startup stopped unexpectedly: {error}"))?
+    .map_err(|error| format!("Local service startup stopped unexpectedly: {error}"))?;
+    refresh_tray_menu(&app);
+    result
 }
 
 #[tauri::command]
 async fn start_local_server(
     app: AppHandle,
-    state: tauri::State<'_, DesktopState>,
+    _state: tauri::State<'_, DesktopState>,
 ) -> Result<LocalServerStatus, String> {
-    start_server(app, state, false).await
+    start_server(app, false).await
 }
 
 #[tauri::command]
 async fn start_shared_server(
     app: AppHandle,
-    state: tauri::State<'_, DesktopState>,
+    _state: tauri::State<'_, DesktopState>,
 ) -> Result<LocalServerStatus, String> {
-    start_server(app, state, true).await
+    start_server(app, true).await
 }
 
 #[tauri::command]
-fn stop_local_server(state: tauri::State<'_, DesktopState>) -> Result<LocalServerStatus, String> {
+fn stop_local_server(
+    app: AppHandle,
+    state: tauri::State<'_, DesktopState>,
+) -> Result<LocalServerStatus, String> {
     let _active = state.active_operations.register()?;
     stop_api_process(&state);
+    refresh_tray_menu(&app);
     Ok(stopped_server_status(
         "The Desktop-owned API and MCP service was stopped.",
     ))
@@ -3747,20 +3832,26 @@ async fn open_ui_in_browser(app: AppHandle) -> Result<(), String> {
     let _active = state.active_operations.register()?;
     let transition = TargetTransitionCoordinator::begin(&state, TransitionKind::OpenBrowser)
         .map_err(|error| error.to_string())?;
-    let worker_app = app.clone();
-    let status = tauri::async_runtime::spawn_blocking(move || {
-        let _transition = transition;
-        let state = worker_app.state::<DesktopState>();
-        start_ui(&worker_app, &state, false)
-    })
-    .await
-    .map_err(|error| format!("VidXP interface startup stopped unexpectedly: {error}"))??;
+    let current = inspect_browser_service(&state)?;
+    let status = if current.running {
+        current
+    } else {
+        let worker_app = app.clone();
+        tauri::async_runtime::spawn_blocking(move || {
+            let _transition = transition;
+            let state = worker_app.state::<DesktopState>();
+            start_ui(&worker_app, &state, false)
+        })
+        .await
+        .map_err(|error| format!("VidXP interface startup stopped unexpectedly: {error}"))??
+    };
     let url = status
         .local_url
         .ok_or_else(|| "VidXP did not report its local browser address.".to_string())?;
     app.opener()
         .open_url(&url, None::<&str>)
         .map_err(|error| format!("Could not open VidXP in the default browser: {error}"))?;
+    refresh_tray_menu(&app);
     hide_main_window(&app)
 }
 
@@ -3782,10 +3873,208 @@ fn open_browser_or_show_manager(app: &AppHandle) {
     });
 }
 
+fn current_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(u64::MAX)
+}
+
+fn tray_installation_label(profile: Option<&target_profiles::TargetProfile>, now: u64) -> String {
+    let Some(profile) = profile else {
+        return "No VidXP installation selected".into();
+    };
+    let state = match profile.validation_error.as_ref().map(|error| &error.code) {
+        Some(target_profiles::TargetErrorCode::RuntimeUpdateRequired) => "Update required",
+        Some(_) => "Needs attention",
+        None if !profile.is_ready(now) => "Check required",
+        None => "Ready",
+    };
+    format!("{} · {state}", profile.display_name)
+}
+
+fn tray_browser_label(status: &BrowserServiceStatus) -> String {
+    if !status.running {
+        return "Browser interface · Stopped".into();
+    }
+    if status.shared {
+        return format!(
+            "Browser interface · Shared · {}",
+            status
+                .network_url
+                .as_deref()
+                .unwrap_or("address unavailable")
+        );
+    }
+    format!(
+        "Browser interface · Private · {}",
+        status.local_url.as_deref().unwrap_or("address unavailable")
+    )
+}
+
+fn tray_server_label(status: &LocalServerStatus) -> String {
+    if !status.running {
+        return "App integration service · Stopped".into();
+    }
+    format!(
+        "App integration service · {} · {}",
+        if status.shared { "Shared" } else { "Private" },
+        status.origin.as_deref().unwrap_or("address unavailable")
+    )
+}
+
+fn refresh_tray_menu(app: &AppHandle) {
+    let state = app.state::<DesktopState>();
+    let items = state.tray_menu.lock().ok().and_then(|items| items.clone());
+    let Some(items) = items else {
+        return;
+    };
+    let target_state = target_profiles::current_state(app).ok();
+    let profile = target_state
+        .as_ref()
+        .and_then(target_profiles::TargetState::selected_profile);
+    let ready = profile.is_some_and(|profile| profile.is_ready(current_unix_seconds()));
+    let browser_available = ready && profile.is_some_and(|profile| profile.frontend.launchable);
+    let worker_available = ready
+        && profile
+            .is_some_and(|profile| profile.surfaces.iter().any(|surface| surface == "worker"));
+    let server_available = ready
+        && profile
+            .is_some_and(|profile| profile.surfaces.iter().any(|surface| surface == "server"));
+    let browser = inspect_browser_service(&state)
+        .unwrap_or_else(|error| stopped_browser_status(format!("Status unavailable: {error}")));
+    let server = inspect_local_server(&state)
+        .unwrap_or_else(|error| stopped_server_status(format!("Status unavailable: {error}")));
+    let worker = profile.and_then(|profile| {
+        state.worker_status.lock().ok().and_then(|cached| {
+            cached
+                .as_ref()
+                .filter(|(profile_id, _)| profile_id == &profile.id)
+                .map(|(_, status)| status.clone())
+        })
+    });
+
+    let _ = items
+        .installation
+        .set_text(tray_installation_label(profile, current_unix_seconds()));
+    let _ = items.browser.set_text(tray_browser_label(&browser));
+    let _ = items.browser.set_enabled(browser_available);
+    let _ = items.open_browser.set_enabled(browser_available);
+    let _ = items
+        .share_browser
+        .set_enabled(browser_available && !browser.shared);
+    let _ = items.stop_browser.set_enabled(browser.running);
+
+    let worker_label = match worker.as_ref() {
+        Some(Ok(status)) if status.running => "Local video processing · Running",
+        Some(Ok(_)) => "Local video processing · Stopped",
+        Some(Err(_)) => "Local video processing · Needs attention",
+        None => "Local video processing · Checking…",
+    };
+    let _ = items.worker.set_text(worker_label);
+    let _ = items.worker.set_enabled(worker_available);
+    let _ = items.start_worker.set_enabled(
+        worker_available
+            && worker
+                .as_ref()
+                .is_some_and(|status| status.as_ref().is_ok_and(|status| !status.running)),
+    );
+    let _ = items.stop_worker.set_enabled(
+        worker
+            .as_ref()
+            .is_some_and(|status| status.as_ref().is_ok_and(|status| status.running)),
+    );
+
+    let _ = items.server.set_text(tray_server_label(&server));
+    let _ = items.server.set_enabled(server_available);
+    let _ = items.start_server.set_text(if server.shared {
+        "Make private"
+    } else {
+        "Start privately"
+    });
+    let _ = items
+        .start_server
+        .set_enabled(server_available && (!server.running || server.shared));
+    let _ = items
+        .share_server
+        .set_enabled(server_available && !server.shared);
+    let _ = items.stop_server.set_enabled(server.running);
+}
+
+fn refresh_tray_for_selected_target(app: &AppHandle) {
+    let state = app.state::<DesktopState>();
+    if let Ok(mut worker) = state.worker_status.lock() {
+        *worker = None;
+    }
+    refresh_tray_menu(app);
+    let profile = target_profiles::selected_profile(app).ok();
+    if profile.is_some_and(|profile| {
+        profile.is_ready(current_unix_seconds())
+            && profile.surfaces.iter().any(|surface| surface == "worker")
+    }) {
+        let status_app = app.clone();
+        tauri::async_runtime::spawn(async move {
+            let _ = run_worker_action(status_app, "worker-status").await;
+        });
+    }
+}
+
+fn show_tray_action_error(app: &AppHandle, error: String) {
+    show_main_window(app);
+    app.dialog()
+        .message(error)
+        .title("VidXP action could not complete")
+        .kind(MessageDialogKind::Error)
+        .blocking_show();
+}
+
+fn perform_service_action(app: &AppHandle, action: DesktopAction) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let result = match action {
+            DesktopAction::ShareBrowser => start_browser_mode(app.clone(), true).await.map(|_| ()),
+            DesktopAction::StopBrowser => {
+                let state = app.state::<DesktopState>();
+                state.active_operations.register().map(|_active| {
+                    stop_ui_process(&state);
+                    refresh_tray_menu(&app);
+                })
+            }
+            DesktopAction::StartWorker => run_worker_action(app.clone(), "start-worker")
+                .await
+                .map(|_| ()),
+            DesktopAction::StopWorker => run_worker_action(app.clone(), "stop-worker")
+                .await
+                .map(|_| ()),
+            DesktopAction::StartServer => start_server(app.clone(), false).await.map(|_| ()),
+            DesktopAction::ShareServer => start_server(app.clone(), true).await.map(|_| ()),
+            DesktopAction::StopServer => {
+                let state = app.state::<DesktopState>();
+                state.active_operations.register().map(|_active| {
+                    stop_api_process(&state);
+                    refresh_tray_menu(&app);
+                })
+            }
+            DesktopAction::Manage | DesktopAction::OpenBrowser | DesktopAction::Quit => Ok(()),
+        };
+        if let Err(error) = result {
+            refresh_tray_menu(&app);
+            show_tray_action_error(&app, error);
+        }
+    });
+}
+
 fn perform_desktop_action(app: &AppHandle, action: DesktopAction) {
     match action {
         DesktopAction::Manage => show_main_window(app),
         DesktopAction::OpenBrowser => open_browser_or_show_manager(app),
+        DesktopAction::ShareBrowser
+        | DesktopAction::StopBrowser
+        | DesktopAction::StartWorker
+        | DesktopAction::StopWorker
+        | DesktopAction::StartServer
+        | DesktopAction::ShareServer
+        | DesktopAction::StopServer => perform_service_action(app, action),
         DesktopAction::Quit => begin_shutdown(app),
     }
 }
@@ -3831,10 +4120,95 @@ async fn launch_ui(app: AppHandle) -> Result<(), String> {
 }
 
 fn create_tray(app: &tauri::App) -> tauri::Result<()> {
+    let installation = MenuItem::with_id(
+        app,
+        "installation-status",
+        "VidXP installation",
+        false,
+        None::<&str>,
+    )?;
     let open = MenuItem::with_id(app, "open", "Open VidXP", true, None::<&str>)?;
+    let share_browser = MenuItem::with_id(
+        app,
+        "share-browser",
+        "Share on local network",
+        true,
+        None::<&str>,
+    )?;
+    let stop_browser = MenuItem::with_id(
+        app,
+        "stop-browser",
+        "Stop browser interface",
+        false,
+        None::<&str>,
+    )?;
+    let browser = Submenu::with_items(
+        app,
+        "Browser interface",
+        true,
+        &[&share_browser, &stop_browser],
+    )?;
+    let start_worker =
+        MenuItem::with_id(app, "start-worker", "Start processing", false, None::<&str>)?;
+    let stop_worker =
+        MenuItem::with_id(app, "stop-worker", "Stop processing", false, None::<&str>)?;
+    let worker = Submenu::with_items(
+        app,
+        "Local video processing",
+        true,
+        &[&start_worker, &stop_worker],
+    )?;
+    let start_server =
+        MenuItem::with_id(app, "start-server", "Start privately", true, None::<&str>)?;
+    let share_server = MenuItem::with_id(
+        app,
+        "share-server",
+        "Share on local network",
+        true,
+        None::<&str>,
+    )?;
+    let stop_server = MenuItem::with_id(app, "stop-server", "Stop service", false, None::<&str>)?;
+    let server = Submenu::with_items(
+        app,
+        "App integration service",
+        true,
+        &[&start_server, &share_server, &stop_server],
+    )?;
     let manage = MenuItem::with_id(app, "manage", "Manage VidXP", true, None::<&str>)?;
     let quit = MenuItem::with_id(app, "quit", "Quit VidXP", true, None::<&str>)?;
-    let menu = Menu::with_items(app, &[&open, &manage, &quit])?;
+    let separator = PredefinedMenuItem::separator(app)?;
+    let separator_two = PredefinedMenuItem::separator(app)?;
+    let menu = Menu::with_items(
+        app,
+        &[
+            &installation,
+            &separator,
+            &open,
+            &browser,
+            &worker,
+            &server,
+            &separator_two,
+            &manage,
+            &quit,
+        ],
+    )?;
+    let items = TrayMenuItems {
+        installation,
+        browser,
+        open_browser: open,
+        share_browser,
+        stop_browser,
+        worker,
+        start_worker,
+        stop_worker,
+        server,
+        start_server,
+        share_server,
+        stop_server,
+    };
+    if let Ok(mut current) = app.state::<DesktopState>().tray_menu.lock() {
+        *current = Some(items);
+    }
     let mut tray = TrayIconBuilder::with_id("vidxp")
         .tooltip("VidXP")
         .menu(&menu)
@@ -3850,6 +4224,7 @@ fn create_tray(app: &tauri::App) -> tauri::Result<()> {
         tray = tray.icon(icon.clone());
     }
     tray.build(app)?;
+    refresh_tray_for_selected_target(app.handle());
     Ok(())
 }
 
@@ -4777,7 +5152,7 @@ mod tests {
     }
 
     #[test]
-    fn tray_manage_browser_and_quit_actions_are_unambiguous() {
+    fn tray_service_actions_are_unambiguous() {
         assert_eq!(
             action_for_activation(DesktopActivation::Tray("manage")),
             Some(DesktopAction::Manage)
@@ -4786,6 +5161,20 @@ mod tests {
             action_for_activation(DesktopActivation::Tray("open")),
             Some(DesktopAction::OpenBrowser)
         );
+        for (id, expected) in [
+            ("share-browser", DesktopAction::ShareBrowser),
+            ("stop-browser", DesktopAction::StopBrowser),
+            ("start-worker", DesktopAction::StartWorker),
+            ("stop-worker", DesktopAction::StopWorker),
+            ("start-server", DesktopAction::StartServer),
+            ("share-server", DesktopAction::ShareServer),
+            ("stop-server", DesktopAction::StopServer),
+        ] {
+            assert_eq!(
+                action_for_activation(DesktopActivation::Tray(id)),
+                Some(expected)
+            );
+        }
         assert_eq!(
             action_for_activation(DesktopActivation::Tray("quit")),
             Some(DesktopAction::Quit)
@@ -4793,6 +5182,43 @@ mod tests {
         assert_eq!(
             action_for_activation(DesktopActivation::Tray("other")),
             None
+        );
+    }
+
+    #[test]
+    fn tray_service_labels_surface_scope_and_addresses() {
+        let browser = super::BrowserServiceStatus {
+            state: "ready",
+            running: true,
+            shared: true,
+            port: Some(43124),
+            local_url: Some("http://127.0.0.1:43124".into()),
+            network_url: Some("http://192.168.1.20:43124".into()),
+            detail: String::new(),
+        };
+        let server = super::LocalServerStatus {
+            state: "ready",
+            running: true,
+            shared: false,
+            port: Some(43125),
+            origin: Some("http://127.0.0.1:43125".into()),
+            health_url: Some("http://127.0.0.1:43125/health".into()),
+            mcp_url: Some("http://127.0.0.1:43125/mcp".into()),
+            bearer_token: None,
+            detail: String::new(),
+        };
+
+        assert_eq!(
+            super::tray_browser_label(&browser),
+            "Browser interface · Shared · http://192.168.1.20:43124"
+        );
+        assert_eq!(
+            super::tray_server_label(&server),
+            "App integration service · Private · http://127.0.0.1:43125"
+        );
+        assert_eq!(
+            super::tray_installation_label(None, 0),
+            "No VidXP installation selected"
         );
     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1107,6 +1107,25 @@ fn external_installation_arguments(
     ])
 }
 
+fn external_installation_version<'a>(
+    manifest: &'a RuntimeManifest,
+    runtime_update_required: bool,
+    reported_protocol_version: u32,
+    observed_package_version: &'a str,
+) -> Result<&'a str, String> {
+    if runtime_update_required {
+        return Ok(&manifest.package_version);
+    }
+    match reported_protocol_version.cmp(&target_profiles::SUPPORTED_PROBE_PROTOCOL_VERSION) {
+        std::cmp::Ordering::Less => Ok(&manifest.package_version),
+        std::cmp::Ordering::Equal => Ok(observed_package_version),
+        std::cmp::Ordering::Greater => Err(
+            "This VidXP installation is newer than this Desktop version. Update VidXP Desktop before changing its features."
+                .into(),
+        ),
+    }
+}
+
 fn base_package_specification(manifest: &RuntimeManifest) -> String {
     format!("{}=={}", manifest.package_name, manifest.package_version)
 }
@@ -3120,11 +3139,15 @@ fn selected_target_context(
     Ok((profile, paths))
 }
 
-fn execute_target_json(command: Command, operation: &str) -> Result<serde_json::Value, String> {
+fn execute_target_json(
+    command: Command,
+    operation: &str,
+    timeout: Duration,
+) -> Result<serde_json::Value, String> {
     let output = background_process::run(
         command,
         background_process::BackgroundPolicy {
-            timeout: Duration::from_secs(120),
+            timeout,
             max_output_bytes: MAX_SETUP_OUTPUT_BYTES,
         },
         None,
@@ -3159,7 +3182,7 @@ async fn target_doctor(
             .arg("--index-dir")
             .arg(&profile.repository_root)
             .args(["doctor", "--json"]);
-        execute_target_json(command, "VidXP doctor")
+        execute_target_json(command, "VidXP doctor", Duration::from_secs(180))
     })
     .await
     .map_err(|error| format!("VidXP doctor stopped unexpectedly: {error}"))?
@@ -3195,7 +3218,15 @@ async fn configure_external_installation(
     {
         return Err("Use the managed setup screen to change this VidXP installation.".into());
     }
-    if selected_surfaces == profile.surfaces && selected_capabilities == profile.capabilities {
+    let runtime_update_required = profile
+        .validation_error
+        .as_ref()
+        .is_some_and(|error| error.code == target_profiles::TargetErrorCode::RuntimeUpdateRequired);
+    if !runtime_update_required
+        && profile.probe_protocol_version == target_profiles::SUPPORTED_PROBE_PROTOCOL_VERSION
+        && selected_surfaces == profile.surfaces
+        && selected_capabilities == profile.capabilities
+    {
         return Ok(target_profiles::current_state(&app).map_err(|error| error.to_string())?);
     }
     let runtime = profile.runtime.as_ref().ok_or_else(|| {
@@ -3228,12 +3259,18 @@ async fn configure_external_installation(
     }
     stop_ui_process(&state);
     stop_api_process(&state);
+    let target_version = external_installation_version(
+        &manifest,
+        runtime_update_required,
+        profile.probe_protocol_version,
+        &profile.observed_vidxp_version,
+    )?;
     let arguments = external_installation_arguments(
         &manifest,
         &selected_capabilities,
         &selected_surfaces,
         &runtime.python_version,
-        &profile.observed_vidxp_version,
+        target_version,
     )?;
     uv_output(
         &app,
@@ -3307,7 +3344,7 @@ fn execute_worker_action(app: &AppHandle, action: &str) -> Result<LocalWorkerSta
         .arg("--index-dir")
         .arg(&profile.repository_root)
         .args(["jobs", action]);
-    let payload = execute_target_json(command, "VidXP local processing")?;
+    let payload = execute_target_json(command, "VidXP local processing", Duration::from_secs(120))?;
     serde_json::from_value(payload)
         .map_err(|error| format!("VidXP returned an invalid processing status: {error}"))
 }
@@ -3983,12 +4020,12 @@ mod tests {
         base_package_specification, capability_command_arguments, claim_browser_open,
         clean_environment_from, close_action, configure_ui_service_command,
         configured_runtime_status, dependency_installation_arguments, desktop_paths_from_roots,
-        display_command, external_installation_arguments, inventory_model_directory, manifest,
-        manifest_digest, normalize_line_endings, normalized_runtime_constraints,
-        package_acquisition_arguments, package_specification, read_active_runtime_snapshot,
-        reconcile_managed_runtime_storage, required_encoder_missing, restore_active_runtime,
-        selected_capabilities, selected_surfaces, ui_process_action, write_activation_journal,
-        write_active_runtime,
+        display_command, external_installation_arguments, external_installation_version,
+        inventory_model_directory, manifest, manifest_digest, normalize_line_endings,
+        normalized_runtime_constraints, package_acquisition_arguments, package_specification,
+        read_active_runtime_snapshot, reconcile_managed_runtime_storage, required_encoder_missing,
+        restore_active_runtime, selected_capabilities, selected_surfaces, ui_process_action,
+        write_activation_journal, write_active_runtime,
     };
     use std::{
         ffi::OsStr,
@@ -4578,6 +4615,32 @@ mod tests {
                 "0.4.0 @ https://example.invalid/package.whl",
             )
             .is_err()
+        );
+    }
+
+    #[test]
+    fn external_install_updates_old_contracts_and_preserves_compatible_versions() {
+        let manifest = manifest().expect("manifest");
+        let supported = crate::target_profiles::SUPPORTED_PROBE_PROTOCOL_VERSION;
+
+        assert_eq!(
+            external_installation_version(&manifest, false, supported - 1, "older-release")
+                .expect("older contract"),
+            manifest.package_version
+        );
+        assert_eq!(
+            external_installation_version(&manifest, true, supported, "older-release")
+                .expect("missing management contract"),
+            manifest.package_version
+        );
+        assert_eq!(
+            external_installation_version(&manifest, false, supported, "compatible-release")
+                .expect("compatible contract"),
+            "compatible-release"
+        );
+        assert!(
+            external_installation_version(&manifest, false, supported + 1, "newer-release")
+                .is_err()
         );
     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -2,14 +2,15 @@ use std::{
     borrow::Cow,
     collections::{BTreeMap, BTreeSet},
     env, fs,
-    io::{self, Write},
-    net::TcpListener,
+    io::{self, Read, Write},
+    net::{SocketAddr, TcpListener, TcpStream},
     path::{Path, PathBuf},
     process::Command,
     sync::{
         Arc, Mutex, OnceLock,
         atomic::{AtomicBool, AtomicU64, Ordering},
     },
+    thread,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
@@ -355,12 +356,68 @@ struct RuntimeReconciliation {
 
 struct ManagedUi {
     process: background_process::OwnedChild,
-    url: String,
+    port: u16,
+    local_url: String,
+    network_url: Option<String>,
+    shared: bool,
     profile_id: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct BrowserServiceStatus {
+    state: &'static str,
+    running: bool,
+    shared: bool,
+    port: Option<u16>,
+    local_url: Option<String>,
+    network_url: Option<String>,
+    detail: String,
+}
+
+struct ManagedApiService {
+    process: background_process::OwnedChild,
+    port: u16,
+    health_host: String,
+    origin: String,
+    health_url: String,
+    mcp_url: String,
+    bearer_token: Option<String>,
+    shared: bool,
+    profile_id: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct LocalServerStatus {
+    state: &'static str,
+    running: bool,
+    shared: bool,
+    port: Option<u16>,
+    origin: Option<String>,
+    health_url: Option<String>,
+    mcp_url: Option<String>,
+    bearer_token: Option<String>,
+    detail: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiShareDetails {
+    origin: String,
+    host: String,
+    port: u16,
+    health_url: String,
+    mcp_url: String,
+    bearer_token: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct LocalWorkerStatus {
+    running: bool,
+    detail: String,
 }
 
 struct DesktopState {
     ui_process: Mutex<Option<ManagedUi>>,
+    api_process: Mutex<Option<ManagedApiService>>,
     worker_stop: Arc<WorkerStopSupervisor>,
     operation_cancellation: Arc<Mutex<Option<background_process::CancellationToken>>>,
     transition: Arc<Mutex<TransitionState>>,
@@ -374,6 +431,7 @@ impl Default for DesktopState {
     fn default() -> Self {
         Self {
             ui_process: Mutex::new(None),
+            api_process: Mutex::new(None),
             worker_stop: Arc::new(WorkerStopSupervisor::default()),
             operation_cancellation: Arc::new(Mutex::new(None)),
             transition: Arc::new(Mutex::new(TransitionState::default())),
@@ -407,6 +465,7 @@ enum TransitionKind {
     Delete,
     InstallMedia,
     InstallRuntime,
+    ConfigureExternalInstallation,
     PrepareModels,
     RecoverActivation,
     OpenBrowser,
@@ -989,6 +1048,16 @@ fn package_specification(
     capabilities: &[String],
     surfaces: &[String],
 ) -> String {
+    package_specification_for_version(manifest, capabilities, surfaces, &manifest.package_version)
+}
+
+fn package_specification_for_version(
+    manifest: &RuntimeManifest,
+    capabilities: &[String],
+    surfaces: &[String],
+    version: &str,
+) -> String {
+    let local_worker_selected = surfaces.iter().any(|name| name == "worker");
     let extras: BTreeSet<_> = manifest
         .surfaces
         .iter()
@@ -997,15 +1066,45 @@ fn package_specification(
         .chain(
             capabilities
                 .iter()
+                .filter(|_| !local_worker_selected)
                 .map(|name| manifest.capabilities[name].extra.clone()),
         )
         .collect();
-    format!(
-        "{}[{}]=={}",
-        manifest.package_name,
-        extras.into_iter().collect::<Vec<_>>().join(","),
-        manifest.package_version
-    )
+    let extras = extras.into_iter().collect::<Vec<_>>().join(",");
+    if extras.is_empty() {
+        format!("{}=={}", manifest.package_name, version)
+    } else {
+        format!("{}[{}]=={}", manifest.package_name, extras, version)
+    }
+}
+
+fn external_installation_arguments(
+    manifest: &RuntimeManifest,
+    capabilities: &[String],
+    surfaces: &[String],
+    python_version: &str,
+    version: &str,
+) -> Result<Vec<String>, String> {
+    if version.is_empty()
+        || !version
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || ".!+_-".contains(character))
+    {
+        return Err("The selected installation reported an invalid package version.".into());
+    }
+    Ok(vec![
+        "tool".into(),
+        "install".into(),
+        "--force".into(),
+        "--python".into(),
+        python_version.into(),
+        "--no-config".into(),
+        "--default-index".into(),
+        manifest.dependency_index.clone(),
+        "--index-strategy".into(),
+        "first-index".into(),
+        package_specification_for_version(manifest, capabilities, surfaces, version),
+    ])
 }
 
 fn base_package_specification(manifest: &RuntimeManifest) -> String {
@@ -1816,6 +1915,31 @@ async fn uv_output(
     Ok(())
 }
 
+async fn uv_captured_output(
+    app: &AppHandle,
+    paths: &DesktopPaths,
+    arguments: Vec<String>,
+    cancellation: background_process::CancellationToken,
+    operation: &str,
+) -> Result<background_process::BackgroundOutput, String> {
+    let mut command = app
+        .shell()
+        .sidecar("uv")
+        .map_err(|error| format!("The bundled uv sidecar is unavailable: {error}"))?
+        .args(arguments)
+        .env_clear();
+    for (key, value) in clean_environment(paths) {
+        command = command.env(key, value);
+    }
+    command = command
+        .env("UV_CACHE_DIR", paths.cache.join("uv"))
+        .env("UV_PYTHON_INSTALL_DIR", &paths.python)
+        .env("UV_NO_CONFIG", "1")
+        .env("UV_MANAGED_PYTHON", "1");
+    let command: Command = command.into();
+    supervised_output(command, cancellation, operation).await
+}
+
 fn run_vidxp(
     runtime: &Path,
     paths: &DesktopPaths,
@@ -2013,6 +2137,7 @@ async fn adopt_local_target(
         )?;
         let setup = target_profiles::adopt_validated(&app, validated, display_name)?;
         stop_ui_process(&app.state::<DesktopState>());
+        stop_api_process(&app.state::<DesktopState>());
         Ok(setup)
     })
     .await
@@ -2081,6 +2206,7 @@ async fn select_target_profile(
             target_profiles::select_profile(&app, &profile_id, &desktop_version)?
         };
         stop_ui_process(&app.state::<DesktopState>());
+        stop_api_process(&app.state::<DesktopState>());
         Ok(setup)
     })
     .await
@@ -2106,6 +2232,7 @@ async fn delete_target_profile(
         let result = target_profiles::delete_profile(&app, &profile_id)?;
         if selected.as_deref() == Some(&profile_id) {
             stop_ui_process(&app.state::<DesktopState>());
+            stop_api_process(&app.state::<DesktopState>());
         }
         Ok(result)
     })
@@ -2733,6 +2860,7 @@ async fn install_runtime(
     .await
     .map_err(|error| format!("Managed activation stopped unexpectedly: {error}"))??;
     stop_ui_process(&state);
+    stop_api_process(&state);
     transition.commit_draft();
 
     Ok(InstallTransitionResult {
@@ -2750,7 +2878,39 @@ async fn install_runtime(
     })
 }
 
-fn start_ui(app: &AppHandle, state: &DesktopState) -> Result<String, String> {
+fn stopped_browser_status(detail: impl Into<String>) -> BrowserServiceStatus {
+    BrowserServiceStatus {
+        state: "stopped",
+        running: false,
+        shared: false,
+        port: None,
+        local_url: None,
+        network_url: None,
+        detail: detail.into(),
+    }
+}
+
+fn running_browser_status(ui: &ManagedUi) -> BrowserServiceStatus {
+    BrowserServiceStatus {
+        state: "ready",
+        running: true,
+        shared: ui.shared,
+        port: Some(ui.port),
+        local_url: Some(ui.local_url.clone()),
+        network_url: ui.network_url.clone(),
+        detail: if ui.shared {
+            "The browser interface is available on this local network.".into()
+        } else {
+            "The browser interface is available only on this computer.".into()
+        },
+    }
+}
+
+fn start_ui(
+    app: &AppHandle,
+    state: &DesktopState,
+    shared: bool,
+) -> Result<BrowserServiceStatus, String> {
     let manifest = manifest()?;
     let selected = target_profiles::selected_profile(app).map_err(|error| error.to_string())?;
     let mut paths = desktop_paths(app)?;
@@ -2801,8 +2961,10 @@ fn start_ui(app: &AppHandle, state: &DesktopState) -> Result<String, String> {
             .map_err(|error| format!("Could not inspect the interface process: {error}"))?
             .is_none();
         match ui_process_action(running, &ui.profile_id, &profile.id) {
-            UiProcessAction::Reuse => return Ok(ui.url.clone()),
-            UiProcessAction::Replace => {
+            UiProcessAction::Reuse if ui.shared == shared => {
+                return Ok(running_browser_status(ui));
+            }
+            UiProcessAction::Reuse | UiProcessAction::Replace => {
                 ui.process.terminate_and_reap();
             }
             UiProcessAction::Start => {}
@@ -2810,7 +2972,7 @@ fn start_ui(app: &AppHandle, state: &DesktopState) -> Result<String, String> {
         *active_process = None;
     }
 
-    let listener = TcpListener::bind(("127.0.0.1", 0))
+    let listener = TcpListener::bind((if shared { "0.0.0.0" } else { "127.0.0.1" }, 0))
         .map_err(|error| format!("Could not reserve a local interface port: {error}"))?;
     let port = listener
         .local_addr()
@@ -2829,29 +2991,18 @@ fn start_ui(app: &AppHandle, state: &DesktopState) -> Result<String, String> {
         ));
     }
 
-    let mut command = match profile.kind {
-        target_profiles::TargetKind::Managed => {
-            let active = active_runtime(&paths)?;
-            if profile.managed_runtime_profile.as_deref() != Some(active.profile.as_str()) {
-                return Err(
-                    "The selected managed target no longer matches the active desktop runtime."
-                        .into(),
-                );
-            }
-            configured_command(&profile.executable, &paths)
-        }
-        target_profiles::TargetKind::ExistingLocal => Command::new(&profile.executable),
-    };
+    let mut command = target_command(&profile, &paths, &profile.executable);
     configure_ui_service_command(
         &mut command,
         &profile.repository_root,
         port,
         &readiness_file,
         &nonce,
+        shared,
     );
     let mut process = background_process::spawn_service(command)
         .map_err(|error| format!("Could not start the VidXP interface: {}", error.detail))?;
-    browser_readiness::wait_for_browser_readiness(
+    let network_url = browser_readiness::wait_for_browser_readiness(
         &mut process,
         &readiness_file,
         &nonce,
@@ -2859,13 +3010,22 @@ fn start_ui(app: &AppHandle, state: &DesktopState) -> Result<String, String> {
         Instant::now() + Duration::from_secs(30),
         &state.shutdown,
     )?;
-    let url = format!("http://127.0.0.1:{port}");
-    *active_process = Some(ManagedUi {
+    if shared && network_url.is_none() {
+        process.terminate_and_reap();
+        return Err("The browser interface started, but VidXP could not determine its local-network address.".into());
+    }
+    let local_url = format!("http://127.0.0.1:{port}");
+    let ui = ManagedUi {
         process,
-        url: url.clone(),
+        port,
+        local_url,
+        network_url,
+        shared,
         profile_id: profile.id.clone(),
-    });
-    Ok(url)
+    };
+    let status = running_browser_status(&ui);
+    *active_process = Some(ui);
+    Ok(status)
 }
 
 fn stop_ui_process(state: &DesktopState) {
@@ -2875,6 +3035,579 @@ fn stop_ui_process(state: &DesktopState) {
     if let Some(mut ui) = active.take() {
         ui.process.terminate_and_reap();
     }
+}
+
+#[tauri::command]
+fn browser_service_status(
+    state: tauri::State<'_, DesktopState>,
+) -> Result<BrowserServiceStatus, String> {
+    let _active = state.active_operations.register()?;
+    let mut active = state
+        .ui_process
+        .lock()
+        .map_err(|_| "The browser process supervisor is unavailable.".to_string())?;
+    let Some(ui) = active.as_mut() else {
+        return Ok(stopped_browser_status("The browser interface is stopped."));
+    };
+    if ui
+        .process
+        .try_wait()
+        .map_err(|error| format!("Could not inspect the browser interface: {error}"))?
+        .is_some()
+    {
+        *active = None;
+        return Ok(stopped_browser_status("The browser interface exited."));
+    }
+    Ok(running_browser_status(ui))
+}
+
+#[tauri::command]
+async fn start_shared_browser(
+    app: AppHandle,
+    state: tauri::State<'_, DesktopState>,
+) -> Result<BrowserServiceStatus, String> {
+    let _active = state.active_operations.register()?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<DesktopState>();
+        start_ui(&app, &state, true)
+    })
+    .await
+    .map_err(|error| format!("Browser sharing startup stopped unexpectedly: {error}"))?
+}
+
+#[tauri::command]
+fn stop_browser_service(
+    state: tauri::State<'_, DesktopState>,
+) -> Result<BrowserServiceStatus, String> {
+    let _active = state.active_operations.register()?;
+    stop_ui_process(&state);
+    Ok(stopped_browser_status("The browser interface was stopped."))
+}
+
+fn target_companion_executable(profile: &target_profiles::TargetProfile, name: &str) -> PathBuf {
+    let filename = if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_owned()
+    };
+    profile
+        .executable
+        .parent()
+        .map_or_else(|| PathBuf::from(&filename), |parent| parent.join(&filename))
+}
+
+fn target_command(
+    profile: &target_profiles::TargetProfile,
+    paths: &DesktopPaths,
+    executable_path: &Path,
+) -> Command {
+    match profile.kind {
+        target_profiles::TargetKind::Managed => configured_command(executable_path, paths),
+        target_profiles::TargetKind::ExistingLocal => Command::new(executable_path),
+    }
+}
+
+fn selected_target_context(
+    app: &AppHandle,
+) -> Result<(target_profiles::TargetProfile, DesktopPaths), String> {
+    let profile = target_profiles::selected_profile(app).map_err(|error| error.to_string())?;
+    let mut paths = desktop_paths(app)?;
+    paths.data = profile.data_root.clone();
+    paths.repository = profile.repository_root.clone();
+    if let Some(model_directory) = &profile.model_directory {
+        paths.models = model_directory.clone();
+    }
+    Ok((profile, paths))
+}
+
+fn execute_target_json(command: Command, operation: &str) -> Result<serde_json::Value, String> {
+    let output = background_process::run(
+        command,
+        background_process::BackgroundPolicy {
+            timeout: Duration::from_secs(120),
+            max_output_bytes: MAX_SETUP_OUTPUT_BYTES,
+        },
+        None,
+    )
+    .map_err(|error| format!("{operation} failed: {}", error.detail))?;
+    let payload = serde_json::from_slice(&output.stdout).map_err(|error| {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+        format!(
+            "{operation} did not return valid JSON: {error}{}",
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(". {stderr}")
+            }
+        )
+    })?;
+    Ok(payload)
+}
+
+#[tauri::command]
+async fn target_doctor(
+    app: AppHandle,
+    state: tauri::State<'_, DesktopState>,
+) -> Result<serde_json::Value, String> {
+    let _active = state.active_operations.register()?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let (profile, paths) = selected_target_context(&app)?;
+        let mut command = target_command(&profile, &paths, &profile.executable);
+        command
+            .arg("--data-dir")
+            .arg(&profile.data_root)
+            .arg("--index-dir")
+            .arg(&profile.repository_root)
+            .args(["doctor", "--json"]);
+        execute_target_json(command, "VidXP doctor")
+    })
+    .await
+    .map_err(|error| format!("VidXP doctor stopped unexpectedly: {error}"))?
+}
+
+#[tauri::command]
+async fn configure_external_installation(
+    app: AppHandle,
+    state: tauri::State<'_, DesktopState>,
+    capabilities: Vec<String>,
+    surfaces: Vec<String>,
+) -> Result<target_profiles::TargetState, String> {
+    let cancellation = OperationCancellationGuard::register(&state)?;
+    let _transition =
+        TargetTransitionCoordinator::begin(&state, TransitionKind::ConfigureExternalInstallation)
+            .map_err(|error| error.to_string())?;
+    let manifest = manifest()?;
+    let selected_surfaces = selected_surfaces(&manifest, &surfaces)?;
+    let selected_capabilities: Vec<_> = capabilities
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    if let Some(unknown) = selected_capabilities
+        .iter()
+        .find(|name| !manifest.capabilities.contains_key(*name))
+    {
+        return Err(format!("Unknown VidXP search feature: {unknown}"));
+    }
+    let (profile, paths) = selected_target_context(&app)?;
+    if profile.kind != target_profiles::TargetKind::ExistingLocal
+        || profile.lifecycle_ownership != target_profiles::LifecycleOwnership::External
+    {
+        return Err("Use the managed setup screen to change this VidXP installation.".into());
+    }
+    if selected_surfaces == profile.surfaces && selected_capabilities == profile.capabilities {
+        return Ok(target_profiles::current_state(&app).map_err(|error| error.to_string())?);
+    }
+    let runtime = profile.runtime.as_ref().ok_or_else(|| {
+        "The selected installation did not report its Python environment.".to_string()
+    })?;
+    if !runtime.python_executable.is_file() {
+        return Err(
+            "The selected installation's Python environment is no longer available.".into(),
+        );
+    }
+    let tool_directory_output = uv_captured_output(
+        &app,
+        &paths,
+        vec!["tool".into(), "dir".into()],
+        cancellation.token(),
+        "VidXP installation lookup",
+    )
+    .await?;
+    let tool_directory = PathBuf::from(
+        String::from_utf8_lossy(&tool_directory_output.stdout)
+            .trim()
+            .to_owned(),
+    );
+    let expected_environment = tool_directory.join(&manifest.package_name);
+    if !same_path(&runtime.prefix, &expected_environment) {
+        return Err(
+            "This VidXP installation is not an isolated uv tool installation. Use its package manager to change installed features, then check it again."
+                .into(),
+        );
+    }
+    stop_ui_process(&state);
+    stop_api_process(&state);
+    let arguments = external_installation_arguments(
+        &manifest,
+        &selected_capabilities,
+        &selected_surfaces,
+        &runtime.python_version,
+        &profile.observed_vidxp_version,
+    )?;
+    uv_output(
+        &app,
+        &paths,
+        arguments,
+        cancellation.token(),
+        "VidXP feature update",
+    )
+    .await?;
+    target_profiles::validated_selected_profile_with_cancellation(
+        &app,
+        &manifest.desktop_version,
+        Some(&state.shutdown),
+    )
+    .map_err(|error| error.to_string())?;
+    target_profiles::current_state(&app).map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+async fn mcp_client_config(
+    app: AppHandle,
+    state: tauri::State<'_, DesktopState>,
+) -> Result<String, String> {
+    let _active = state.active_operations.register()?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let (profile, paths) = selected_target_context(&app)?;
+        if !profile
+            .surfaces
+            .iter()
+            .any(|surface| surface == "mcp" || surface == "server")
+        {
+            return Err(
+                "The selected VidXP installation does not expose an installed MCP surface.".into(),
+            );
+        }
+        let executable_path = target_companion_executable(&profile, "vidxp-mcp");
+        if !executable_path.is_file() {
+            return Err(format!(
+                "The selected installation did not provide {}.",
+                executable_path.display()
+            ));
+        }
+        let mut command = target_command(&profile, &paths, &executable_path);
+        command
+            .arg("--print-config")
+            .arg("--repository")
+            .arg("default")
+            .arg("--index-directory")
+            .arg(&profile.repository_root)
+            .arg("--data-dir")
+            .arg(&profile.data_root);
+        let output = checked_output(command, "VidXP MCP configuration")?;
+        let payload: serde_json::Value = serde_json::from_slice(&output.stdout)
+            .map_err(|error| format!("VidXP returned invalid MCP configuration JSON: {error}"))?;
+        serde_json::to_string_pretty(&payload)
+            .map_err(|error| format!("Could not format the MCP configuration: {error}"))
+    })
+    .await
+    .map_err(|error| format!("MCP configuration stopped unexpectedly: {error}"))?
+}
+
+fn execute_worker_action(app: &AppHandle, action: &str) -> Result<LocalWorkerStatus, String> {
+    let (profile, paths) = selected_target_context(app)?;
+    if !profile.surfaces.iter().any(|surface| surface == "worker") {
+        return Err("Local video processing is not installed for this VidXP setup.".into());
+    }
+    let mut command = target_command(&profile, &paths, &profile.executable);
+    command
+        .arg("--data-dir")
+        .arg(&profile.data_root)
+        .arg("--index-dir")
+        .arg(&profile.repository_root)
+        .args(["jobs", action]);
+    let payload = execute_target_json(command, "VidXP local processing")?;
+    serde_json::from_value(payload)
+        .map_err(|error| format!("VidXP returned an invalid processing status: {error}"))
+}
+
+#[tauri::command]
+async fn local_worker_status(
+    app: AppHandle,
+    state: tauri::State<'_, DesktopState>,
+) -> Result<LocalWorkerStatus, String> {
+    let _active = state.active_operations.register()?;
+    tauri::async_runtime::spawn_blocking(move || execute_worker_action(&app, "worker-status"))
+        .await
+        .map_err(|error| format!("Local processing status stopped unexpectedly: {error}"))?
+}
+
+#[tauri::command]
+async fn start_local_worker(
+    app: AppHandle,
+    state: tauri::State<'_, DesktopState>,
+) -> Result<LocalWorkerStatus, String> {
+    let _active = state.active_operations.register()?;
+    tauri::async_runtime::spawn_blocking(move || execute_worker_action(&app, "start-worker"))
+        .await
+        .map_err(|error| format!("Local processing startup stopped unexpectedly: {error}"))?
+}
+
+#[tauri::command]
+async fn stop_local_worker(
+    app: AppHandle,
+    state: tauri::State<'_, DesktopState>,
+) -> Result<LocalWorkerStatus, String> {
+    let _active = state.active_operations.register()?;
+    tauri::async_runtime::spawn_blocking(move || execute_worker_action(&app, "stop-worker"))
+        .await
+        .map_err(|error| format!("Local processing shutdown stopped unexpectedly: {error}"))?
+}
+
+fn http_health_is_ready(host: &str, port: u16) -> bool {
+    let Ok(address) = format!("{host}:{port}").parse::<SocketAddr>() else {
+        return false;
+    };
+    let Ok(mut stream) = TcpStream::connect_timeout(&address, Duration::from_millis(200)) else {
+        return false;
+    };
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(300)));
+    if stream
+        .write_all(
+            format!("GET /health HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n").as_bytes(),
+        )
+        .is_err()
+    {
+        return false;
+    }
+    let mut response = [0_u8; 128];
+    stream
+        .read(&mut response)
+        .is_ok_and(|read| String::from_utf8_lossy(&response[..read]).starts_with("HTTP/1.1 200"))
+}
+
+fn stopped_server_status(detail: impl Into<String>) -> LocalServerStatus {
+    LocalServerStatus {
+        state: "stopped",
+        running: false,
+        shared: false,
+        port: None,
+        origin: None,
+        health_url: None,
+        mcp_url: None,
+        bearer_token: None,
+        detail: detail.into(),
+    }
+}
+
+fn running_server_status(service: &ManagedApiService, healthy: bool) -> LocalServerStatus {
+    LocalServerStatus {
+        state: if healthy { "ready" } else { "starting" },
+        running: true,
+        shared: service.shared,
+        port: Some(service.port),
+        health_url: Some(service.health_url.clone()),
+        mcp_url: Some(service.mcp_url.clone()),
+        origin: Some(service.origin.clone()),
+        bearer_token: service.bearer_token.clone(),
+        detail: if healthy {
+            if service.shared {
+                "The API and MCP service is available on this local network.".into()
+            } else {
+                "The API and MCP service is available only on this computer.".into()
+            }
+        } else {
+            "The service process is running but its health endpoint is not ready.".into()
+        },
+    }
+}
+
+fn stop_api_process(state: &DesktopState) {
+    let Ok(mut active) = state.api_process.lock() else {
+        return;
+    };
+    if let Some(mut service) = active.take() {
+        service.process.terminate_and_reap();
+    }
+}
+
+#[tauri::command]
+fn local_server_status(state: tauri::State<'_, DesktopState>) -> Result<LocalServerStatus, String> {
+    let _active = state.active_operations.register()?;
+    let mut active = state
+        .api_process
+        .lock()
+        .map_err(|_| "The API process supervisor is unavailable.".to_string())?;
+    let Some(service) = active.as_mut() else {
+        return Ok(stopped_server_status(
+            "The local API and MCP service is stopped.",
+        ));
+    };
+    if service
+        .process
+        .try_wait()
+        .map_err(|error| format!("Could not inspect the local service process: {error}"))?
+        .is_some()
+    {
+        *active = None;
+        return Ok(stopped_server_status(
+            "The local API and MCP service exited.",
+        ));
+    }
+    let healthy = http_health_is_ready(&service.health_host, service.port);
+    Ok(running_server_status(service, healthy))
+}
+
+fn api_service_command(
+    profile: &target_profiles::TargetProfile,
+    paths: &DesktopPaths,
+    executable_path: &Path,
+    port: u16,
+    shared: bool,
+) -> Command {
+    let mut command = target_command(profile, paths, executable_path);
+    command
+        .env("VIDXP_REPOSITORY_ROOT", &profile.repository_root)
+        .env("VIDXP_MODEL_CACHE", &paths.models)
+        .arg("--data-dir")
+        .arg(&profile.data_root)
+        .arg("--port")
+        .arg(port.to_string());
+    if shared {
+        command.arg("--share");
+    }
+    command
+}
+
+fn start_server_mode(
+    app: &AppHandle,
+    state: &DesktopState,
+    shared: bool,
+) -> Result<LocalServerStatus, String> {
+    let (profile, paths) = selected_target_context(app)?;
+    if !profile.surfaces.iter().any(|surface| surface == "server") {
+        return Err(
+            "The selected VidXP installation does not include the app integration service.".into(),
+        );
+    }
+    let mut active = state
+        .api_process
+        .lock()
+        .map_err(|_| "The API process supervisor is unavailable.".to_string())?;
+    if let Some(service) = active.as_mut() {
+        let running = service
+            .process
+            .try_wait()
+            .map_err(|error| format!("Could not inspect the local service process: {error}"))?
+            .is_none();
+        if running && service.profile_id == profile.id && service.shared == shared {
+            let healthy = http_health_is_ready(&service.health_host, service.port);
+            return Ok(running_server_status(service, healthy));
+        }
+        service.process.terminate_and_reap();
+        *active = None;
+    }
+    let listener = TcpListener::bind((if shared { "0.0.0.0" } else { "127.0.0.1" }, 0))
+        .map_err(|error| format!("Could not reserve a local API port: {error}"))?;
+    let port = listener
+        .local_addr()
+        .map_err(|error| format!("Could not identify the local API port: {error}"))?
+        .port();
+    drop(listener);
+    let executable_path = target_companion_executable(&profile, "vidxp-api");
+    if !executable_path.is_file() {
+        return Err(format!(
+            "The selected installation did not provide {}.",
+            executable_path.display()
+        ));
+    }
+    let (health_host, origin, health_url, mcp_url, bearer_token) = if shared {
+        let mut details_command =
+            api_service_command(&profile, &paths, &executable_path, port, true);
+        details_command.arg("--print-share-details");
+        let output = checked_output(details_command, "VidXP network sharing setup")?;
+        let details: ApiShareDetails = serde_json::from_slice(&output.stdout)
+            .map_err(|error| format!("VidXP returned invalid network sharing details: {error}"))?;
+        if details.port != port {
+            return Err("VidXP reported the wrong network sharing port.".into());
+        }
+        (
+            details.host,
+            details.origin,
+            details.health_url,
+            details.mcp_url,
+            Some(details.bearer_token),
+        )
+    } else {
+        let origin = format!("http://127.0.0.1:{port}");
+        (
+            "127.0.0.1".into(),
+            origin.clone(),
+            format!("{origin}/health"),
+            format!("{origin}/mcp"),
+            None,
+        )
+    };
+    let command = api_service_command(&profile, &paths, &executable_path, port, shared);
+    let mut process = background_process::spawn_service(command).map_err(|error| {
+        format!(
+            "Could not start the local API and MCP service: {}",
+            error.detail
+        )
+    })?;
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if http_health_is_ready(&health_host, port) {
+            break;
+        }
+        if process
+            .try_wait()
+            .map_err(|error| format!("Could not inspect the local service: {error}"))?
+            .is_some()
+        {
+            return Err("The local API and MCP service exited before becoming healthy.".into());
+        }
+        if Instant::now() >= deadline {
+            return Err(
+                "The local API and MCP service did not become healthy within 30 seconds.".into(),
+            );
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    let service = ManagedApiService {
+        process,
+        port,
+        health_host,
+        origin,
+        health_url,
+        mcp_url,
+        bearer_token,
+        shared,
+        profile_id: profile.id,
+    };
+    let status = running_server_status(&service, true);
+    *active = Some(service);
+    Ok(status)
+}
+
+async fn start_server(
+    app: AppHandle,
+    state: tauri::State<'_, DesktopState>,
+    shared: bool,
+) -> Result<LocalServerStatus, String> {
+    let _active = state.active_operations.register()?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<DesktopState>();
+        start_server_mode(&app, &state, shared)
+    })
+    .await
+    .map_err(|error| format!("Local service startup stopped unexpectedly: {error}"))?
+}
+
+#[tauri::command]
+async fn start_local_server(
+    app: AppHandle,
+    state: tauri::State<'_, DesktopState>,
+) -> Result<LocalServerStatus, String> {
+    start_server(app, state, false).await
+}
+
+#[tauri::command]
+async fn start_shared_server(
+    app: AppHandle,
+    state: tauri::State<'_, DesktopState>,
+) -> Result<LocalServerStatus, String> {
+    start_server(app, state, true).await
+}
+
+#[tauri::command]
+fn stop_local_server(state: tauri::State<'_, DesktopState>) -> Result<LocalServerStatus, String> {
+    let _active = state.active_operations.register()?;
+    stop_api_process(&state);
+    Ok(stopped_server_status(
+        "The Desktop-owned API and MCP service was stopped.",
+    ))
 }
 
 fn browser_readiness_nonce() -> String {
@@ -2895,6 +3628,7 @@ fn configure_ui_service_command(
     port: u16,
     readiness_file: &Path,
     nonce: &str,
+    shared: bool,
 ) {
     command
         // The desktop owns the one intentional browser open after readiness. Without
@@ -2904,9 +3638,16 @@ fn configure_ui_service_command(
         .env("VIDXP_DESKTOP_READINESS_FILE", readiness_file)
         .env("VIDXP_DESKTOP_READINESS_NONCE", nonce)
         .env("VIDXP_DESKTOP_UI_PORT", port.to_string())
+        .env("VIDXP_DESKTOP_UI_SHARED", if shared { "1" } else { "0" })
         .arg("--index-dir")
         .arg(repository_root)
-        .args(["ui", "--host", "127.0.0.1", "--port", &port.to_string()]);
+        .arg("ui");
+    if shared {
+        command.arg("--share");
+    } else {
+        command.args(["--host", "127.0.0.1"]);
+    }
+    command.args(["--port", &port.to_string()]);
 }
 
 fn hide_main_window(app: &AppHandle) -> Result<(), String> {
@@ -2970,13 +3711,16 @@ async fn open_ui_in_browser(app: AppHandle) -> Result<(), String> {
     let transition = TargetTransitionCoordinator::begin(&state, TransitionKind::OpenBrowser)
         .map_err(|error| error.to_string())?;
     let worker_app = app.clone();
-    let url = tauri::async_runtime::spawn_blocking(move || {
+    let status = tauri::async_runtime::spawn_blocking(move || {
         let _transition = transition;
         let state = worker_app.state::<DesktopState>();
-        start_ui(&worker_app, &state)
+        start_ui(&worker_app, &state, false)
     })
     .await
     .map_err(|error| format!("VidXP interface startup stopped unexpectedly: {error}"))??;
+    let url = status
+        .local_url
+        .ok_or_else(|| "VidXP did not report its local browser address.".to_string())?;
     app.opener()
         .open_url(&url, None::<&str>)
         .map_err(|error| format!("Could not open VidXP in the default browser: {error}"))?;
@@ -3021,6 +3765,7 @@ fn begin_shutdown(app: &AppHandle) {
     cancel_active_operation(&state);
     log::info!("VidXP supervised shutdown requested");
     stop_ui_process(&state);
+    stop_api_process(&state);
     let app = app.clone();
     let operations = state.active_operations.clone();
     tauri::async_runtime::spawn(async move {
@@ -3097,6 +3842,7 @@ fn shutdown(app: &AppHandle, deadline: Instant) {
     let state = app.state::<DesktopState>();
     cancel_active_operation(&state);
     stop_ui_process(&state);
+    stop_api_process(&state);
     let Ok(mut paths) = desktop_paths(app) else {
         log::warn!("Could not resolve desktop paths during shutdown");
         return;
@@ -3182,7 +3928,20 @@ pub fn run() {
             model_directory_inventory,
             prepare_managed_models,
             install_runtime,
-            launch_ui
+            launch_ui,
+            target_doctor,
+            configure_external_installation,
+            mcp_client_config,
+            local_worker_status,
+            start_local_worker,
+            stop_local_worker,
+            browser_service_status,
+            start_shared_browser,
+            stop_browser_service,
+            local_server_status,
+            start_local_server,
+            start_shared_server,
+            stop_local_server
         ]);
     let app = builder
         .build(tauri::generate_context!())
@@ -3224,11 +3983,12 @@ mod tests {
         base_package_specification, capability_command_arguments, claim_browser_open,
         clean_environment_from, close_action, configure_ui_service_command,
         configured_runtime_status, dependency_installation_arguments, desktop_paths_from_roots,
-        display_command, inventory_model_directory, manifest, manifest_digest,
-        normalize_line_endings, normalized_runtime_constraints, package_acquisition_arguments,
-        package_specification, read_active_runtime_snapshot, reconcile_managed_runtime_storage,
-        required_encoder_missing, restore_active_runtime, selected_capabilities, selected_surfaces,
-        ui_process_action, write_activation_journal, write_active_runtime,
+        display_command, external_installation_arguments, inventory_model_directory, manifest,
+        manifest_digest, normalize_line_endings, normalized_runtime_constraints,
+        package_acquisition_arguments, package_specification, read_active_runtime_snapshot,
+        reconcile_managed_runtime_storage, required_encoder_missing, restore_active_runtime,
+        selected_capabilities, selected_surfaces, ui_process_action, write_activation_journal,
+        write_active_runtime,
     };
     use std::{
         ffi::OsStr,
@@ -3772,11 +4532,53 @@ mod tests {
             format!("vidxp[scene]=={version}")
         );
         assert_eq!(
+            package_specification(
+                &manifest,
+                &["actor".into(), "dialogue".into(), "scene".into()],
+                &["worker".into()],
+            ),
+            format!("vidxp[local-worker]=={version}")
+        );
+        assert_eq!(
             selected_surfaces(&manifest, &["browser".into(), "browser".into()])
                 .expect("surface selection"),
             ["browser"]
         );
         assert!(selected_surfaces(&manifest, &["unknown".into()]).is_err());
+    }
+
+    #[test]
+    fn external_install_recreates_the_reported_version_with_the_selected_features() {
+        let manifest = manifest().expect("manifest");
+        let arguments = external_installation_arguments(
+            &manifest,
+            &["scene".into()],
+            &["server".into(), "mcp".into()],
+            "3.14.6",
+            "0.4.0-b.1",
+        )
+        .expect("external surface arguments");
+
+        assert_eq!(&arguments[..3], ["tool", "install", "--force"]);
+        assert!(
+            arguments
+                .windows(2)
+                .any(|items| items == ["--python", "3.14.6"])
+        );
+        assert_eq!(
+            arguments.last().expect("package"),
+            "vidxp[mcp,scene,server]==0.4.0-b.1"
+        );
+        assert!(
+            external_installation_arguments(
+                &manifest,
+                &[],
+                &["mcp".into()],
+                "3.14.6",
+                "0.4.0 @ https://example.invalid/package.whl",
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -3846,6 +4648,7 @@ mod tests {
             43123,
             Path::new("readiness.json"),
             "nonce",
+            false,
         );
 
         assert!(command.get_envs().any(|(key, value)| {
@@ -3867,6 +4670,33 @@ mod tests {
                 "127.0.0.1",
                 "--port",
                 "43123",
+            ]
+        );
+
+        let mut shared = Command::new("vidxp");
+        configure_ui_service_command(
+            &mut shared,
+            Path::new("repository"),
+            43124,
+            Path::new("shared-readiness.json"),
+            "shared-nonce",
+            true,
+        );
+        assert!(shared.get_envs().any(|(key, value)| {
+            key == OsStr::new("VIDXP_DESKTOP_UI_SHARED") && value == Some(OsStr::new("1"))
+        }));
+        assert_eq!(
+            shared
+                .get_args()
+                .map(|argument| argument.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            [
+                "--index-dir",
+                "repository",
+                "ui",
+                "--share",
+                "--port",
+                "43124"
             ]
         );
     }

--- a/desktop/src-tauri/src/lifecycle.rs
+++ b/desktop/src-tauri/src/lifecycle.rs
@@ -14,6 +14,13 @@ pub(crate) enum UiProcessAction {
 pub(crate) enum DesktopAction {
     Manage,
     OpenBrowser,
+    ShareBrowser,
+    StopBrowser,
+    StartWorker,
+    StopWorker,
+    StartServer,
+    ShareServer,
+    StopServer,
     Quit,
 }
 
@@ -37,6 +44,13 @@ pub(crate) fn action_for_activation(activation: DesktopActivation<'_>) -> Option
         }
         DesktopActivation::Tray("manage") => Some(DesktopAction::Manage),
         DesktopActivation::Tray("open") => Some(DesktopAction::OpenBrowser),
+        DesktopActivation::Tray("share-browser") => Some(DesktopAction::ShareBrowser),
+        DesktopActivation::Tray("stop-browser") => Some(DesktopAction::StopBrowser),
+        DesktopActivation::Tray("start-worker") => Some(DesktopAction::StartWorker),
+        DesktopActivation::Tray("stop-worker") => Some(DesktopAction::StopWorker),
+        DesktopActivation::Tray("start-server") => Some(DesktopAction::StartServer),
+        DesktopActivation::Tray("share-server") => Some(DesktopAction::ShareServer),
+        DesktopActivation::Tray("stop-server") => Some(DesktopAction::StopServer),
         DesktopActivation::Tray("quit") => Some(DesktopAction::Quit),
         DesktopActivation::Tray(_) => None,
     }

--- a/desktop/src-tauri/src/target_profiles.rs
+++ b/desktop/src-tauri/src/target_profiles.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     fs,
     path::{Path, PathBuf},
     process::Command,
@@ -196,6 +196,8 @@ pub struct ValidatedTarget {
     pub repository_root: PathBuf,
     pub model_root: PathBuf,
     pub frontend: FrontendCapability,
+    pub capabilities: Vec<String>,
+    pub surfaces: Vec<String>,
     pub validated_at: u64,
 }
 
@@ -262,6 +264,10 @@ struct ProbeDocument {
     model_root: PathBuf,
     #[serde(default)]
     capabilities: ProbeCapabilities,
+    #[serde(default)]
+    search_capabilities: Vec<String>,
+    #[serde(default)]
+    surfaces: BTreeMap<String, FrontendCapability>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -537,6 +543,12 @@ fn validate_probe_document(
             ));
         }
     }
+    let surfaces = document
+        .surfaces
+        .iter()
+        .filter(|(_, capability)| capability.available)
+        .map(|(name, _)| name.clone())
+        .collect();
     Ok(ValidatedTarget {
         executable: canonical.to_path_buf(),
         product_version: document.product_version,
@@ -554,6 +566,8 @@ fn validate_probe_document(
         repository_root: document.repository_root,
         model_root: document.model_root,
         frontend: document.capabilities.frontend,
+        capabilities: document.search_capabilities,
+        surfaces,
         validated_at: now,
     })
 }
@@ -817,8 +831,8 @@ fn local_profile(validated: ValidatedTarget, display_name: Option<String>) -> Ta
         last_successful_validation_at: Some(validated.validated_at),
         validation_error: None,
         managed_runtime_profile: None,
-        capabilities: Vec::new(),
-        surfaces: Vec::new(),
+        capabilities: validated.capabilities,
+        surfaces: validated.surfaces,
         model_directory: None,
     }
 }
@@ -1175,6 +1189,10 @@ fn apply_validation(profile: &mut TargetProfile, validated: ValidatedTarget) {
     profile.launch_protocol_version = validated.launch_protocol_version;
     profile.runtime = Some(validated.runtime);
     profile.frontend = validated.frontend;
+    if profile.kind == TargetKind::ExistingLocal {
+        profile.capabilities = validated.capabilities;
+    }
+    profile.surfaces = validated.surfaces;
     profile.last_successful_validation_at = Some(validated.validated_at);
     profile.validation_error = None;
 }
@@ -1576,6 +1594,8 @@ mod tests {
             repository_root: root.join("data").join("repositories").join("default"),
             model_root: root.join("data").join("models"),
             capabilities: ProbeCapabilities::default(),
+            search_capabilities: Vec::new(),
+            surfaces: BTreeMap::new(),
         }
     }
 
@@ -1589,6 +1609,36 @@ mod tests {
 
         assert!(!validated.frontend.available);
         assert!(!validated.frontend.launchable);
+    }
+
+    #[test]
+    fn probe_projects_installed_product_surfaces() {
+        let executable = std::env::current_exe().expect("current executable");
+        let canonical = fs::canonicalize(executable).expect("canonical executable");
+        let mut probe = document(&canonical, "nonce");
+        probe.search_capabilities = vec!["scene".into()];
+        probe.surfaces.insert(
+            "mcp".into(),
+            FrontendCapability {
+                available: true,
+                launchable: false,
+                optional: true,
+                code: "mcp_available".into(),
+                message: "Available".into(),
+                remediation: String::new(),
+            },
+        );
+        probe
+            .surfaces
+            .insert("server".into(), FrontendCapability::default());
+
+        let validated =
+            validate_probe_document(&canonical, "nonce", probe, 100).expect("valid probe");
+
+        assert_eq!(validated.surfaces, ["mcp"]);
+        let profile = local_profile(validated, None);
+        assert_eq!(profile.capabilities, ["scene"]);
+        assert_eq!(profile.surfaces, ["mcp"]);
     }
 
     #[test]
@@ -2010,6 +2060,8 @@ mod tests {
                 message: "Available".into(),
                 remediation: String::new(),
             },
+            capabilities: vec!["scene".into()],
+            surfaces: vec!["browser".into(), "mcp".into(), "server".into()],
             validated_at: 200,
         }
     }

--- a/desktop/src-tauri/src/target_profiles.rs
+++ b/desktop/src-tauri/src/target_profiles.rs
@@ -23,7 +23,7 @@ const SELECTED_PROFILE_KEY: &str = "selected_profile_id";
 const CURRENT_STORE_SCHEMA_VERSION: u32 = 1;
 pub const CURRENT_PROFILE_SCHEMA_VERSION: u32 = 1;
 const SUPPORTED_PROBE_SCHEMA_VERSION: u32 = 1;
-const SUPPORTED_PROBE_PROTOCOL_VERSION: u32 = 1;
+pub const SUPPORTED_PROBE_PROTOCOL_VERSION: u32 = 1;
 const SUPPORTED_LAUNCH_PROTOCOL_VERSION: u32 = 2;
 const PRODUCT_ID: &str = "dev.grayhat.vidxp";
 const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -67,6 +67,7 @@ pub enum TargetErrorCode {
     LauncherIdentityMismatch,
     UnsupportedProbeSchema,
     UnsupportedProbeProtocol,
+    RuntimeUpdateRequired,
     UnsupportedLaunchProtocol,
     UnsupportedLaunchContract,
     InvalidDataRoot,
@@ -264,10 +265,8 @@ struct ProbeDocument {
     model_root: PathBuf,
     #[serde(default)]
     capabilities: ProbeCapabilities,
-    #[serde(default)]
-    search_capabilities: Vec<String>,
-    #[serde(default)]
-    surfaces: BTreeMap<String, FrontendCapability>,
+    search_capabilities: Option<Vec<String>>,
+    surfaces: Option<BTreeMap<String, FrontendCapability>>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -503,13 +502,16 @@ fn validate_probe_document(
             ),
         ));
     }
-    if document.protocol_version != SUPPORTED_PROBE_PROTOCOL_VERSION {
+    if document.protocol_version < SUPPORTED_PROBE_PROTOCOL_VERSION {
+        return Err(TargetError::new(
+            TargetErrorCode::RuntimeUpdateRequired,
+            "This VidXP installation must be updated before this Desktop version can manage its features and services.",
+        ));
+    }
+    if document.protocol_version > SUPPORTED_PROBE_PROTOCOL_VERSION {
         return Err(TargetError::new(
             TargetErrorCode::UnsupportedProbeProtocol,
-            format!(
-                "This executable uses desktop probe protocol {}; VidXP desktop supports protocol {}.",
-                document.protocol_version, SUPPORTED_PROBE_PROTOCOL_VERSION
-            ),
+            "This VidXP installation is newer than this Desktop version. Update VidXP Desktop before connecting it.",
         ));
     }
     if document.launch_contract.protocol_version != SUPPORTED_LAUNCH_PROTOCOL_VERSION {
@@ -543,8 +545,19 @@ fn validate_probe_document(
             ));
         }
     }
-    let surfaces = document
-        .surfaces
+    let search_capabilities = document.search_capabilities.ok_or_else(|| {
+        TargetError::new(
+            TargetErrorCode::RuntimeUpdateRequired,
+            "This VidXP installation must be updated before this Desktop version can manage its features and services.",
+        )
+    })?;
+    let surface_capabilities = document.surfaces.ok_or_else(|| {
+        TargetError::new(
+            TargetErrorCode::RuntimeUpdateRequired,
+            "This VidXP installation must be updated before this Desktop version can manage its features and services.",
+        )
+    })?;
+    let surfaces = surface_capabilities
         .iter()
         .filter(|(_, capability)| capability.available)
         .map(|(name, _)| name.clone())
@@ -566,7 +579,7 @@ fn validate_probe_document(
         repository_root: document.repository_root,
         model_root: document.model_root,
         frontend: document.capabilities.frontend,
-        capabilities: document.search_capabilities,
+        capabilities: search_capabilities,
         surfaces,
         validated_at: now,
     })
@@ -1575,7 +1588,7 @@ mod tests {
             product: PRODUCT_ID.into(),
             product_version: "0.4.0-b".into(),
             schema_version: 1,
-            protocol_version: 1,
+            protocol_version: SUPPORTED_PROBE_PROTOCOL_VERSION,
             launch_contract: ProbeLaunchContract {
                 protocol_version: 2,
                 surface: "browser".into(),
@@ -1594,8 +1607,8 @@ mod tests {
             repository_root: root.join("data").join("repositories").join("default"),
             model_root: root.join("data").join("models"),
             capabilities: ProbeCapabilities::default(),
-            search_capabilities: Vec::new(),
-            surfaces: BTreeMap::new(),
+            search_capabilities: Some(Vec::new()),
+            surfaces: Some(BTreeMap::new()),
         }
     }
 
@@ -1616,8 +1629,8 @@ mod tests {
         let executable = std::env::current_exe().expect("current executable");
         let canonical = fs::canonicalize(executable).expect("canonical executable");
         let mut probe = document(&canonical, "nonce");
-        probe.search_capabilities = vec!["scene".into()];
-        probe.surfaces.insert(
+        probe.search_capabilities = Some(vec!["scene".into()]);
+        probe.surfaces.as_mut().expect("surfaces").insert(
             "mcp".into(),
             FrontendCapability {
                 available: true,
@@ -1630,6 +1643,8 @@ mod tests {
         );
         probe
             .surfaces
+            .as_mut()
+            .expect("surfaces")
             .insert("server".into(), FrontendCapability::default());
 
         let validated =
@@ -1639,6 +1654,22 @@ mod tests {
         let profile = local_profile(validated, None);
         assert_eq!(profile.capabilities, ["scene"]);
         assert_eq!(profile.surfaces, ["mcp"]);
+    }
+
+    #[test]
+    fn probe_requires_feature_and_service_inventory() {
+        let executable = std::env::current_exe().expect("current executable");
+        let canonical = fs::canonicalize(executable).expect("canonical executable");
+        let mut probe = document(&canonical, "nonce");
+        probe.search_capabilities = None;
+        probe.surfaces = None;
+
+        assert_eq!(
+            validate_probe_document(&canonical, "nonce", probe, 100)
+                .expect_err("older management contract")
+                .code,
+            TargetErrorCode::RuntimeUpdateRequired
+        );
     }
 
     #[test]
@@ -1729,10 +1760,19 @@ mod tests {
         );
 
         let mut wrong_protocol = document(&canonical, "nonce");
-        wrong_protocol.protocol_version = 2;
+        wrong_protocol.protocol_version = SUPPORTED_PROBE_PROTOCOL_VERSION - 1;
         assert_eq!(
             validate_probe_document(&canonical, "nonce", wrong_protocol, 100)
                 .expect_err("protocol")
+                .code,
+            TargetErrorCode::RuntimeUpdateRequired
+        );
+
+        let mut newer_protocol = document(&canonical, "nonce");
+        newer_protocol.protocol_version = SUPPORTED_PROBE_PROTOCOL_VERSION + 1;
+        assert_eq!(
+            validate_probe_document(&canonical, "nonce", newer_protocol, 100)
+                .expect_err("newer protocol")
                 .code,
             TargetErrorCode::UnsupportedProbeProtocol
         );
@@ -1950,8 +1990,20 @@ mod tests {
 
         assert_eq!(inspected.state, InspectionState::ReadyToUse);
         assert!(inspected.adoptable);
-        assert_eq!(validated.product_version, "0.4.0b0");
-        assert_eq!(validated.probe_protocol_version, 1);
+        if let Some(expected_version) =
+            std::env::var_os("VIDXP_DESKTOP_INTEGRATION_EXPECTED_VERSION")
+        {
+            assert_eq!(
+                validated.product_version,
+                expected_version.to_string_lossy()
+            );
+        } else {
+            assert!(!validated.product_version.trim().is_empty());
+        }
+        assert_eq!(
+            validated.probe_protocol_version,
+            SUPPORTED_PROBE_PROTOCOL_VERSION
+        );
         assert_eq!(validated.launch_protocol_version, 2);
         assert_eq!(validated.runtime.python_version, "3.14.0");
         assert!(validated.frontend.launchable);
@@ -2040,7 +2092,7 @@ mod tests {
             executable: PathBuf::from("/runtime/bin/vidxp"),
             product_version: "0.5.0".into(),
             probe_schema_version: 1,
-            probe_protocol_version: 1,
+            probe_protocol_version: SUPPORTED_PROBE_PROTOCOL_VERSION,
             launch_protocol_version: 2,
             runtime: RuntimeIdentity {
                 python_executable: PathBuf::from("/runtime/bin/python"),

--- a/desktop/src-tauri/windows-app-manifest.xml
+++ b/desktop/src-tauri/windows-app-manifest.xml
@@ -1,0 +1,14 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
   prepareManagedModels: vi.fn(),
   runtimeManifest: vi.fn(), runtimeStatus: vi.fn(), launchUi: vi.fn(),
   chooseModelDirectory: vi.fn(), modelDirectoryInventory: vi.fn(),
+  targetDoctor: vi.fn(), mcpClientConfig: vi.fn(), localServerStatus: vi.fn(), localWorkerStatus: vi.fn(), browserServiceStatus: vi.fn(),
+  startLocalServer: vi.fn(), startSharedServer: vi.fn(), stopLocalServer: vi.fn(), startSharedBrowser: vi.fn(), stopBrowserService: vi.fn(), startLocalWorker: vi.fn(), stopLocalWorker: vi.fn(), configureExternalInstallation: vi.fn(),
 }));
 
 const windowMocks = vi.hoisted(() => ({
@@ -36,7 +38,7 @@ const localProfile = {
   repository_root: 'C:\\Data\\repositories\\default', display_repository_root: 'C:\\Data\\repositories\\default',
   observed_vidxp_version: '0.4.0', probe_schema_version: 1, probe_protocol_version: 1,
   launch_protocol_version: 1, runtime: null, frontend, last_successful_validation_at: 1,
-  last_validated_at: '2026-08-01T10:00:00Z', validation_error: null, capabilities: [], surfaces: ['browser'],
+  last_validated_at: '2026-08-01T10:00:00Z', validation_error: null, capabilities: [], surfaces: ['worker', 'browser'],
 };
 const managedProfile = {
   ...localProfile, id: 'managed-a', display_name: 'Managed VidXP', kind: 'managed',
@@ -58,17 +60,17 @@ function renderApp() {
 }
 
 async function enterLocal(user: ReturnType<typeof userEvent.setup>) {
-  await screen.findByRole('heading', { name: 'Where should VidXP run?' });
+  await screen.findByRole('heading', { name: 'How would you like to set up VidXP?' });
   await user.click(screen.getByRole('radio', { name: /Use an existing installation/i }));
   await user.click(screen.getByRole('button', { name: 'Continue' }));
 }
 
 async function enterManaged(user: ReturnType<typeof userEvent.setup>) {
-  await screen.findByRole('heading', { name: 'Where should VidXP run?' });
+  await screen.findByRole('heading', { name: 'How would you like to set up VidXP?' });
   await user.click(screen.getByRole('radio', { name: /Set up VidXP for me/i }));
   await user.click(screen.getByRole('button', { name: 'Continue' }));
-  await user.click(screen.getByRole('button', { name: 'Continue to setup' }));
-  await screen.findByRole('heading', { name: 'Set up local processing' });
+  await user.click(screen.getByRole('button', { name: 'Choose features' }));
+  await screen.findByRole('heading', { name: 'Choose your VidXP features' });
 }
 
 describe('desktop target lifecycle', () => {
@@ -87,16 +89,34 @@ describe('desktop target lifecycle', () => {
     mocks.beginManagedSetup.mockResolvedValue({ id: 'draft-1', previous_profile_id: null });
     mocks.cancelManagedSetup.mockResolvedValue(emptyState);
     mocks.confirmForgetTarget.mockResolvedValue(true);
-    mocks.runtimeManifest.mockResolvedValue({ package_version: '0.4.0', capabilities: { scene: { extra: 'scene', label: 'Visual scene search' } }, surfaces: { browser: { extra: 'frontend', label: 'Browser interface', description: 'Browser UI', default: true } } });
+    mocks.runtimeManifest.mockResolvedValue({ package_version: '0.4.0', capabilities: { scene: { extra: 'scene', label: 'Visual scene search' } }, surfaces: {
+      worker: { extra: 'local-worker', label: 'Process videos on this computer', description: 'Run video work locally.', default: true },
+      browser: { extra: 'frontend', label: 'Browser interface', description: 'Open VidXP in your browser.', default: true },
+      mcp: { extra: 'mcp', label: 'AI assistant integration', description: 'Connect a compatible AI app.', default: false },
+      server: { extra: 'server', label: 'App integration service', description: 'Let other local apps connect.', default: false },
+    } });
     mocks.runtimeStatus.mockResolvedValue({ state: 'never_configured', ready: false, runtime_profile: null, package_version: '0.4.0', capabilities: [], surfaces: [], model_directory: 'C:\\Models', detail: 'No managed runtime yet.' });
     mocks.modelDirectoryInventory.mockResolvedValue({ directory: 'C:\\Models', exists: false, readable: true, total_bytes: 0, file_count: 0, recognized_models: [], empty: true, verification_required: false, truncated: false, detail: 'Empty.' });
     mocks.installMediaRuntime.mockResolvedValue({ ready: true });
     mocks.installRuntime.mockResolvedValue({
-      install: { package_version: '0.4.0', capabilities: ['scene'], surfaces: ['browser'], model_directory: 'C:\\Models', prepared: true },
+      install: { package_version: '0.4.0', capabilities: ['scene'], surfaces: ['worker', 'browser'], model_directory: 'C:\\Models', prepared: true },
       setup: { profiles: [managedProfile], selected_profile_id: managedProfile.id, issues: [] },
     });
     mocks.prepareManagedModels.mockResolvedValue({ profiles: [managedProfile], selected_profile_id: managedProfile.id, issues: [] });
     mocks.launchUi.mockResolvedValue(undefined);
+    mocks.targetDoctor.mockResolvedValue({ ok: true, modalities: ['scene'], checks: [{ capability: 'media', kind: 'distribution', name: 'ffmpeg', ok: true }] });
+    mocks.mcpClientConfig.mockResolvedValue('{"mcpServers":{"vidxp":{"command":"vidxp-mcp"}}}');
+    mocks.browserServiceStatus.mockResolvedValue({ state: 'stopped', running: false, shared: false, port: null, local_url: null, network_url: null, detail: 'Stopped.' });
+    mocks.startSharedBrowser.mockResolvedValue({ state: 'ready', running: true, shared: true, port: 8501, local_url: 'http://127.0.0.1:8501', network_url: 'http://192.168.1.20:8501', detail: 'Shared.' });
+    mocks.stopBrowserService.mockResolvedValue({ state: 'stopped', running: false, shared: false, port: null, local_url: null, network_url: null, detail: 'Stopped.' });
+    mocks.localServerStatus.mockResolvedValue({ state: 'stopped', running: false, shared: false, port: null, origin: null, health_url: null, mcp_url: null, bearer_token: null, detail: 'Stopped.' });
+    mocks.startLocalServer.mockResolvedValue({ state: 'ready', running: true, shared: false, port: 32191, origin: 'http://127.0.0.1:32191', health_url: 'http://127.0.0.1:32191/health', mcp_url: 'http://127.0.0.1:32191/mcp', bearer_token: null, detail: 'Healthy.' });
+    mocks.startSharedServer.mockResolvedValue({ state: 'ready', running: true, shared: true, port: 32191, origin: 'http://192.168.1.20:32191', health_url: 'http://192.168.1.20:32191/health', mcp_url: 'http://192.168.1.20:32191/mcp', bearer_token: 'secret-token', detail: 'Shared.' });
+    mocks.stopLocalServer.mockResolvedValue({ state: 'stopped', running: false, shared: false, port: null, origin: null, health_url: null, mcp_url: null, bearer_token: null, detail: 'Stopped.' });
+    mocks.localWorkerStatus.mockResolvedValue({ running: false, detail: 'Stopped.' });
+    mocks.startLocalWorker.mockResolvedValue({ running: true, detail: 'Ready.' });
+    mocks.stopLocalWorker.mockResolvedValue({ running: false, detail: 'Stopped.' });
+    mocks.configureExternalInstallation.mockResolvedValue(localState);
   });
 
   it('shows the target-first choice without a remote placeholder', async () => {
@@ -112,10 +132,10 @@ describe('desktop target lifecycle', () => {
     mocks.recheckTargetState.mockReturnValue(new Promise((done) => { resolve = done; }));
     renderApp();
     expect(await screen.findByRole('heading', { name: 'Studio VidXP' })).toBeVisible();
-    expect(screen.getByRole('button', { name: 'Recheck target' })).toHaveAttribute('data-loading');
+    expect(screen.getByRole('button', { name: 'Check connection' })).toHaveAttribute('data-loading');
     expect(mocks.recheckTargetState).toHaveBeenCalledTimes(1);
     resolve(localState);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Recheck target' })).not.toHaveAttribute('data-loading'));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Check connection' })).not.toHaveAttribute('data-loading'));
   });
 
   it('opens the browser once and settles its loading state', async () => {
@@ -126,6 +146,71 @@ describe('desktop target lifecycle', () => {
     await user.click(open);
     expect(mocks.launchUi).toHaveBeenCalledTimes(1);
     await waitFor(() => expect(open).not.toHaveAttribute('data-loading'));
+  });
+
+  it('uses doctor, exact MCP config, and supervised server controls for installed surfaces', async () => {
+    const operational = {
+      ...managedProfile,
+      frontend,
+      surfaces: ['worker', 'browser', 'mcp', 'server'],
+      validation_error: null,
+    };
+    const state = { profiles: [operational], selected_profile_id: operational.id, issues: [] };
+    mocks.targetSetupState.mockResolvedValue(state);
+    mocks.recheckTargetState.mockResolvedValue(state);
+    const user = userEvent.setup();
+    renderApp();
+
+    await screen.findByRole('heading', { name: 'Managed VidXP' });
+    await waitFor(() => expect(mocks.localServerStatus).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.localWorkerStatus).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.browserServiceStatus).toHaveBeenCalled());
+
+    await user.click(screen.getByRole('button', { name: 'Start processing' }));
+    expect(mocks.startLocalWorker).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'Stop processing' }));
+    expect(mocks.stopLocalWorker).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'Check readiness' }));
+    expect(await screen.findByText('VidXP is ready')).toBeVisible();
+    expect(mocks.targetDoctor).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'Set up connection' }));
+    expect(await screen.findByRole('heading', { name: 'Connect an AI assistant' })).toBeVisible();
+    expect(mocks.mcpClientConfig).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'Share browser' }));
+    expect(await screen.findByText('http://192.168.1.20:8501')).toBeVisible();
+    expect(mocks.startSharedBrowser).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'Stop sharing' }));
+    expect(mocks.stopBrowserService).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'Start locally' }));
+    expect(await screen.findByText('http://127.0.0.1:32191/mcp')).toBeVisible();
+    expect(mocks.startLocalServer).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'Share service' }));
+    expect(await screen.findByText('http://192.168.1.20:32191/mcp')).toBeVisible();
+    expect(mocks.startSharedServer).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'Stop service' }));
+    expect(mocks.stopLocalServer).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds optional features to the selected existing installation', async () => {
+    const updated = { ...localProfile, surfaces: ['worker', 'browser', 'mcp'] };
+    const updatedState = { profiles: [updated], selected_profile_id: updated.id, issues: [] };
+    mocks.targetSetupState.mockResolvedValue(localState);
+    mocks.recheckTargetState.mockResolvedValue(localState);
+    mocks.configureExternalInstallation.mockResolvedValue(updatedState);
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.click(await screen.findByRole('button', { name: 'Setup options' }));
+    expect(await screen.findByRole('heading', { name: 'Change features for this installation' })).toBeVisible();
+    await user.click(screen.getByRole('checkbox', { name: /AI assistant integration/i }));
+    await user.click(screen.getByRole('button', { name: 'Apply changes' }));
+
+    await waitFor(() => expect(mocks.configureExternalInstallation).toHaveBeenCalledWith([], ['worker', 'browser', 'mcp']));
+    expect(await screen.findByRole('button', { name: 'Set up connection' })).toBeVisible();
   });
 
   it('uses the parent exclusive operation while browser startup is pending', async () => {
@@ -143,9 +228,9 @@ describe('desktop target lifecycle', () => {
     const open = await screen.findByRole('button', { name: 'Open VidXP' });
     await user.click(open);
     expect(open).toHaveAttribute('data-loading');
-    expect(screen.getByRole('button', { name: 'Manage targets' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Recheck target' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Manage setup' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Switch installation' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Check connection' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Setup options' })).toBeDisabled();
     opening.resolve();
     await waitFor(() => expect(open).not.toHaveAttribute('data-loading'));
   });
@@ -153,22 +238,24 @@ describe('desktop target lifecycle', () => {
   it('adopts the inspected candidate without an installation action', async () => {
     mocks.activateLocalTarget.mockResolvedValue(localState);
     const user = userEvent.setup(); renderApp(); await enterLocal(user);
-    await user.click(await screen.findByRole('radio', { name: /VidXP executable/i }));
+    await user.click(await screen.findByRole('radio', { name: /VidXP installation/i }));
     await user.click(await screen.findByRole('button', { name: 'Use this installation' }));
     expect(mocks.inspectLocalTarget).toHaveBeenCalledTimes(1);
     expect(mocks.activateLocalTarget).toHaveBeenCalledTimes(1);
     expect(mocks.installRuntime).not.toHaveBeenCalled();
+    expect(mocks.configureExternalInstallation).not.toHaveBeenCalled();
   });
 
   it('keeps fresh discovery fields authoritative while retaining inspection UI', async () => {
     const user = userEvent.setup(); renderApp(); await enterLocal(user);
-    await user.click(await screen.findByRole('radio', { name: /VidXP executable/i }));
-    await screen.findByText('Compatible contracts.');
+    await user.click(await screen.findByRole('radio', { name: /VidXP installation/i }));
+    await screen.findByText('This VidXP installation is ready to connect.');
     mocks.discoverLocalTargets.mockResolvedValue([{ executable: 'C:\\Tools\\VidXP\\vidxp.exe', display_path: 'C:\\New\\display.exe', source: 'Fresh scan' }]);
     await user.click(screen.getByRole('button', { name: 'Scan again' }));
+    await user.click(await screen.findByText('Technical details'));
     expect(await screen.findByText('C:\\New\\display.exe')).toBeVisible();
-    expect(screen.getByText('Compatible contracts.')).toBeVisible();
-    expect(screen.getByText('Discovered via Fresh scan')).toBeVisible();
+    expect(screen.getByText('This VidXP installation is ready to connect.')).toBeVisible();
+    expect(screen.getAllByText('Found on this computer')).toHaveLength(2);
   });
 
   it('cancels managed setup back to the still-selected target', async () => {
@@ -177,10 +264,10 @@ describe('desktop target lifecycle', () => {
     mocks.beginManagedSetup.mockResolvedValue({ id: 'draft-1', previous_profile_id: localProfile.id });
     mocks.cancelManagedSetup.mockResolvedValue(localState);
     const user = userEvent.setup(); renderApp();
-    await user.click(await screen.findByRole('button', { name: 'Manage targets' }));
+    await user.click(await screen.findByRole('button', { name: 'Switch installation' }));
     await user.click(screen.getByRole('radio', { name: /Set up VidXP for me/i }));
     await user.click(screen.getByRole('button', { name: 'Continue' }));
-    await user.click(screen.getByRole('button', { name: 'Continue to setup' }));
+    await user.click(screen.getByRole('button', { name: 'Choose features' }));
     await user.click(await screen.findByRole('button', { name: 'Back' }));
     expect(mocks.cancelManagedSetup).toHaveBeenCalledWith('draft-1');
     expect(await screen.findByRole('heading', { name: 'Studio VidXP' })).toBeVisible();
@@ -193,10 +280,10 @@ describe('desktop target lifecycle', () => {
     mocks.selectTargetProfile.mockResolvedValue({ ...state, selected_profile_id: saved.id });
     mocks.deleteTargetProfile.mockResolvedValue({ profiles: [saved], selected_profile_id: saved.id, issues: [] });
     const user = userEvent.setup(); renderApp();
-    await user.click(await screen.findByRole('button', { name: 'Manage targets' }));
+    await user.click(await screen.findByRole('button', { name: 'Switch installation' }));
     await user.click(screen.getAllByRole('button', { name: 'Select' }).find((button) => !button.hasAttribute('disabled'))!);
     expect(mocks.selectTargetProfile).toHaveBeenCalledWith(saved.id);
-    await user.click(screen.getByRole('button', { name: 'Manage targets' }));
+    await user.click(screen.getByRole('button', { name: 'Switch installation' }));
     await user.click(screen.getAllByRole('button', { name: 'Forget' })[0]);
     expect(mocks.deleteTargetProfile).toHaveBeenCalled();
   });
@@ -207,7 +294,7 @@ describe('desktop target lifecycle', () => {
     mocks.targetSetupState.mockResolvedValue(invalidState); mocks.recheckTargetState.mockResolvedValue(invalidState);
     const user = userEvent.setup(); renderApp();
     expect(await screen.findByText('Timed out.')).toBeVisible();
-    await user.click(screen.getByRole('button', { name: 'Recheck target' }));
+    await user.click(screen.getByRole('button', { name: 'Check connection' }));
     expect(mocks.recheckTargetState).toHaveBeenCalledTimes(2);
   });
 
@@ -215,8 +302,8 @@ describe('desktop target lifecycle', () => {
     const setup = { profiles: [managedProfile], selected_profile_id: managedProfile.id, issues: [] };
     mocks.targetSetupState.mockResolvedValue(setup); mocks.recheckTargetState.mockResolvedValue(setup);
     renderApp();
-    expect(await screen.findByText('Unavailable · return to managed setup to enable the browser surface')).toBeVisible();
-    expect(screen.getByRole('button', { name: 'Manage setup' })).toBeEnabled();
+    expect(await screen.findByText('The browser interface is not enabled')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Setup options' })).toBeEnabled();
   });
 
   it('keeps ready managed settings read-only until a draft is dirty, then offers Apply and Reset', async () => {
@@ -224,9 +311,9 @@ describe('desktop target lifecycle', () => {
     const user = userEvent.setup(); renderApp(); await enterManaged(user);
     const apply = await screen.findByRole('button', { name: 'Apply update' });
     expect(apply).toBeDisabled();
-    await user.click(screen.getByRole('checkbox', { name: /Browser interface/i }));
+    await user.click(screen.getByRole('checkbox', { name: /VidXP app|Browser interface/i }));
     expect(apply).toBeEnabled();
-    expect(screen.getByText(/installed runtime remains active while Desktop creates/i)).toBeVisible();
+    expect(screen.getByText(/switches to the updated setup only after/i)).toBeVisible();
     await user.click(screen.getByRole('button', { name: 'Reset changes' }));
     expect(apply).toBeDisabled();
     await waitFor(() => expect(mocks.modelDirectoryInventory).toHaveBeenCalledTimes(2));
@@ -248,7 +335,8 @@ describe('desktop target lifecycle', () => {
     const user = userEvent.setup(); renderApp(); await enterManaged(user);
     expect(screen.getByRole('checkbox', { name: /Visual scene search/i })).toBeChecked();
     expect(screen.getByRole('checkbox', { name: /Actor recognition/i })).not.toBeChecked();
-    expect(screen.getByRole('checkbox', { name: /Browser interface/i })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /VidXP app|Browser interface/i })).not.toBeChecked();
+    await user.click(screen.getByText('Storage location'));
     expect(screen.getByText('D:\\CustomModels')).toBeVisible();
     expect(screen.getByRole('button', { name: 'Repair VidXP' })).toBeEnabled();
   });
@@ -269,20 +357,34 @@ describe('desktop target lifecycle', () => {
     const user = userEvent.setup(); renderApp(); await enterManaged(user);
     expect(screen.getByRole('checkbox', { name: /Actor recognition/i })).toBeChecked();
     expect(screen.getByRole('checkbox', { name: /Visual scene search/i })).toBeChecked();
-    expect(screen.getByRole('checkbox', { name: /Browser interface/i })).toBeChecked();
-    expect(screen.getByText(/cannot recover settings from the unreadable pointer/i)).toBeVisible();
-    await user.click(screen.getByRole('button', { name: 'Configure replacement' }));
+    expect(screen.getByRole('checkbox', { name: /VidXP app|Browser interface/i })).toBeChecked();
+    expect(screen.getByText(/could not read the saved setup/i)).toBeVisible();
+    await user.click(screen.getByRole('button', { name: 'Rebuild VidXP' }));
     await waitFor(() => expect(mocks.installRuntime).toHaveBeenCalledWith(expect.objectContaining({
       capabilities: expect.arrayContaining(['actor', 'scene']),
       surfaces: ['browser'],
       draft_id: 'draft-1',
     })));
-    expect(screen.queryByText('Select at least one capability.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Select at least one search feature.')).not.toBeInTheDocument();
+  });
+
+  it('optionally includes MCP and local sharing in a managed installation', async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await enterManaged(user);
+
+    await user.click(screen.getByRole('checkbox', { name: /AI assistant integration/i }));
+    await user.click(screen.getByRole('checkbox', { name: /App integration service/i }));
+    await user.click(screen.getByRole('button', { name: 'Install VidXP' }));
+
+    expect(mocks.installRuntime).toHaveBeenCalledWith(expect.objectContaining({
+      surfaces: ['worker', 'browser', 'mcp', 'server'],
+    }));
   });
 
   it('passes the scoped draft through first-time installation and does not auto-open the browser', async () => {
     const user = userEvent.setup(); renderApp(); await enterManaged(user);
-    await user.click(await screen.findByRole('button', { name: 'Configure VidXP' }));
+    await user.click(await screen.findByRole('button', { name: 'Install VidXP' }));
     await waitFor(() => expect(mocks.installRuntime).toHaveBeenCalledWith(expect.objectContaining({ draft_id: 'draft-1' })));
     expect(mocks.installMediaRuntime).toHaveBeenCalledWith('draft-1');
     expect(mocks.launchUi).not.toHaveBeenCalled();
@@ -292,14 +394,14 @@ describe('desktop target lifecycle', () => {
     const pending = deferred<{ id: string; previous_profile_id: null }>();
     mocks.beginManagedSetup.mockReturnValue(pending.promise);
     const user = userEvent.setup(); renderApp();
-    await screen.findByRole('heading', { name: 'Where should VidXP run?' });
+    await screen.findByRole('heading', { name: 'How would you like to set up VidXP?' });
     await user.click(screen.getByRole('radio', { name: /Set up VidXP for me/i }));
     await user.click(screen.getByRole('button', { name: 'Continue' }));
-    const continueButton = screen.getByRole('button', { name: 'Continue to setup' });
+    const continueButton = screen.getByRole('button', { name: 'Choose features' });
     await user.dblClick(continueButton);
     expect(mocks.beginManagedSetup).toHaveBeenCalledTimes(1);
     pending.resolve({ id: 'draft-1', previous_profile_id: null });
-    expect(await screen.findByRole('heading', { name: 'Set up local processing' })).toBeVisible();
+    expect(await screen.findByRole('heading', { name: 'Choose your VidXP features' })).toBeVisible();
   });
 
   it('freezes managed controls and coalesces Apply while a replacement is running', async () => {
@@ -307,16 +409,16 @@ describe('desktop target lifecycle', () => {
     const media = deferred<{ ready: boolean }>();
     mocks.installMediaRuntime.mockReturnValue(media.promise);
     const user = userEvent.setup(); renderApp(); await enterManaged(user);
-    const browser = screen.getByRole('checkbox', { name: /Browser interface/i });
+    const browser = screen.getByRole('checkbox', { name: /VidXP app|Browser interface/i });
     await user.click(browser);
     const apply = screen.getByRole('button', { name: 'Apply update' });
     await user.dblClick(apply);
     expect(mocks.installMediaRuntime).toHaveBeenCalledTimes(1);
     expect(screen.getByRole('button', { name: 'Back' })).toBeDisabled();
     expect(browser).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Choose folder…' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Change location…' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Reset changes' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Prepare / verify models' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Check downloaded models' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Open VidXP' })).toBeDisabled();
     media.resolve({ ready: true });
     expect(await screen.findByRole('heading', { name: 'Managed VidXP' })).toBeVisible();
@@ -328,11 +430,11 @@ describe('desktop target lifecycle', () => {
     mocks.recheckTargetState.mockResolvedValue(setup);
     mocks.runtimeStatus.mockResolvedValue({ state: 'ready', ready: true, runtime_profile: 'runtime-a', package_version: '0.4.0', capabilities: ['scene'], surfaces: [], model_directory: 'C:\\Models', detail: 'Ready.' });
     const user = userEvent.setup(); renderApp();
-    await user.click(await screen.findByRole('button', { name: 'Manage setup' }));
-    await user.click(screen.getByRole('button', { name: 'Continue to setup' }));
-    await screen.findByRole('heading', { name: 'Set up local processing' });
+    await user.click(await screen.findByRole('button', { name: 'Setup options' }));
+    await user.click(screen.getByRole('button', { name: 'Choose features' }));
+    await screen.findByRole('heading', { name: 'Choose your VidXP features' });
     expect(screen.getByRole('button', { name: 'Apply update' })).toBeDisabled();
-    await user.click(screen.getByRole('button', { name: 'Prepare / verify models' }));
+    await user.click(screen.getByRole('button', { name: 'Check downloaded models' }));
     expect(mocks.prepareManagedModels).toHaveBeenCalledWith('draft-1');
   });
 
@@ -346,10 +448,10 @@ describe('desktop target lifecycle', () => {
     mocks.recheckTargetState.mockResolvedValue(setup);
     mocks.runtimeStatus.mockResolvedValue({ state: 'ready', ready: true, runtime_profile: 'runtime-a', package_version: '0.4.0', capabilities: ['scene'], surfaces: ['browser'], model_directory: 'C:\\Models', detail: 'Ready.' });
     const user = userEvent.setup(); renderApp();
-    await user.click(await screen.findByRole('button', { name: 'Manage targets' }));
+    await user.click(await screen.findByRole('button', { name: 'Switch installation' }));
     await enterManaged(user);
-    expect(screen.getByText(/another target is currently selected/i)).toBeVisible();
-    expect(screen.getByRole('button', { name: 'Prepare / verify models' })).toBeDisabled();
+    expect(screen.getByText(/not your active installation/i)).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Check downloaded models' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Open VidXP' })).toBeDisabled();
     expect(mocks.prepareManagedModels).not.toHaveBeenCalled();
     expect(mocks.launchUi).not.toHaveBeenCalled();
@@ -357,7 +459,7 @@ describe('desktop target lifecycle', () => {
 
   it('uses the committed install state without a fallible status refresh', async () => {
     const user = userEvent.setup(); renderApp(); await enterManaged(user);
-    await user.click(screen.getByRole('button', { name: 'Configure VidXP' }));
+    await user.click(screen.getByRole('button', { name: 'Install VidXP' }));
     expect(await screen.findByRole('heading', { name: 'Managed VidXP' })).toBeVisible();
     expect(mocks.runtimeStatus).toHaveBeenCalledTimes(1);
     expect(mocks.targetSetupState).toHaveBeenCalledTimes(1);
@@ -371,7 +473,7 @@ describe('desktop target lifecycle', () => {
     mocks.recheckTargetState.mockResolvedValue(state);
     mocks.selectTargetProfile.mockReturnValue(selection.promise);
     const user = userEvent.setup(); renderApp();
-    await user.click(await screen.findByRole('button', { name: 'Manage targets' }));
+    await user.click(await screen.findByRole('button', { name: 'Switch installation' }));
     const select = screen.getAllByRole('button', { name: 'Select' }).find((button) => !button.hasAttribute('disabled'))!;
     await user.dblClick(select);
     expect(mocks.selectTargetProfile).toHaveBeenCalledTimes(1);

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -213,6 +213,63 @@ describe('desktop target lifecycle', () => {
     expect(await screen.findByRole('button', { name: 'Set up connection' })).toBeVisible();
   });
 
+  it('offers an in-place manifest update when the selected runtime contract is too old', async () => {
+    const updateRequired = {
+      ...localProfile,
+      observed_vidxp_version: 'installed-release',
+      probe_protocol_version: 1,
+      capabilities: [],
+      surfaces: [],
+      validation_error: {
+        code: 'runtime_update_required',
+        message: 'This VidXP installation must be updated before Desktop can manage it.',
+      },
+    };
+    const state = { profiles: [updateRequired], selected_profile_id: updateRequired.id, issues: [] };
+    mocks.targetSetupState.mockResolvedValue(state);
+    mocks.recheckTargetState.mockResolvedValue(state);
+    mocks.runtimeManifest.mockResolvedValue({
+      package_version: 'required-release',
+      capabilities: { scene: { extra: 'scene', label: 'Visual scene search' } },
+      surfaces: {
+        worker: { extra: 'local-worker', label: 'Process videos on this computer', description: 'Run video work locally.', default: true },
+        browser: { extra: 'frontend', label: 'Browser interface', description: 'Open VidXP in your browser.', default: true },
+        mcp: { extra: 'mcp', label: 'AI assistant integration', description: 'Connect a compatible AI app.', default: false },
+        server: { extra: 'server', label: 'App integration service', description: 'Let other local apps connect.', default: false },
+      },
+    });
+    mocks.configureExternalInstallation.mockResolvedValue(localState);
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.click(await screen.findByRole('button', { name: 'Update this installation' }));
+    expect(await screen.findByText(/from installed-release to required-release/i)).toBeVisible();
+    expect(screen.getByRole('checkbox', { name: /Visual scene search/i })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Process videos on this computer/i })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Browser interface/i })).toBeChecked();
+    await user.click(screen.getByRole('button', { name: 'Update and apply' }));
+
+    await waitFor(() => expect(mocks.configureExternalInstallation).toHaveBeenCalledWith(['scene'], ['worker', 'browser']));
+  });
+
+  it('shows readiness progress and names the scope returned by doctor', async () => {
+    const report = deferred<{ ok: boolean; modalities: string[]; checks: { capability: string; kind: string; name: string; ok: boolean }[] }>();
+    mocks.targetSetupState.mockResolvedValue(localState);
+    mocks.recheckTargetState.mockResolvedValue(localState);
+    mocks.targetDoctor.mockReturnValue(report.promise);
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.click(await screen.findByRole('button', { name: 'Check readiness' }));
+    expect(await screen.findByRole('heading', { name: 'Checking VidXP readiness' })).toBeVisible();
+    expect(screen.getByText(/does not download or change anything/i)).toBeVisible();
+    report.resolve({ ok: true, modalities: [], checks: [{ capability: 'media', kind: 'distribution', name: 'FFmpeg', ok: true }] });
+
+    expect(await screen.findByText('No search features were checked')).toBeVisible();
+    expect(screen.getByText('FFmpeg')).toBeVisible();
+    expect(screen.getByText('Video tools are ready')).toBeVisible();
+  });
+
   it('uses the parent exclusive operation while browser startup is pending', async () => {
     const browserManaged = {
       ...managedProfile,

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,4 +1,4 @@
-import { Alert, Badge, Button, Group, Loader, Stack, Text, ThemeIcon, Title } from '@mantine/core';
+import { Alert, Badge, Button, Code, Group, Loader, Stack, Text, ThemeIcon, Title } from '@mantine/core';
 import { IconAlertCircle, IconArrowLeft, IconDownload, IconTrash } from '@tabler/icons-react';
 import { useCallback, useEffect, useReducer, useRef } from 'react';
 
@@ -104,7 +104,7 @@ export function App() {
     } catch (error) {
       settleOperation(current, {
         type: 'operationFailed',
-        failure: errorMessage(error, 'The active target could not be checked.'),
+        failure: errorMessage(error, 'VidXP could not check the active installation.'),
       });
     }
   }, [settleOperation, startOperation]);
@@ -123,7 +123,7 @@ export function App() {
         if (!mounted) return;
         dispatch({
           type: 'loadFailed',
-          failure: errorMessage(error, 'VidXP Desktop could not load its target profiles.'),
+          failure: errorMessage(error, 'VidXP Desktop could not load your installations.'),
         });
       });
     return () => {
@@ -172,7 +172,7 @@ export function App() {
     } catch (error) {
       settleOperation(current, {
         type: 'operationFailed',
-        failure: errorMessage(error, 'The saved target could not be selected.'),
+        failure: errorMessage(error, 'The saved installation could not be selected.'),
       });
     }
   }
@@ -187,7 +187,7 @@ export function App() {
     } catch (error) {
       settleOperation(current, {
         type: 'operationFailed',
-        failure: errorMessage(error, 'The saved target could not be forgotten.'),
+        failure: errorMessage(error, 'The saved installation could not be removed.'),
       });
     }
   }
@@ -214,23 +214,23 @@ export function App() {
         <div className="mainScroller"><main className="appShell"><div className="contentFrame">
           {state.failure && <Alert icon={<IconAlertCircle />} color="red" title="Desktop issue" role="alert" mb="lg">{state.failure}</Alert>}
           {state.setup?.issues.map((issue) => <Alert key={`${issue.code}-${issue.message}`} color="yellow" title={issue.code} mb="md">{issue.message}</Alert>)}
-          {state.stage === 'loading' && <div className="loadingState" role="status"><Loader size="sm" /> Restoring your VidXP target…</div>}
+          {state.stage === 'loading' && <div className="loadingState" role="status"><Loader size="sm" /> Loading your VidXP setup…</div>}
           {state.stage === 'choice' && <>
-            {profile && <Button variant="subtle" leftSection={<IconArrowLeft size={17} />} disabled={operationPending} onClick={() => dispatch({ type: 'navigate', stage: 'summary' })}>Back to active target</Button>}
+            {profile && <Button variant="subtle" leftSection={<IconArrowLeft size={17} />} disabled={operationPending} onClick={() => dispatch({ type: 'navigate', stage: 'summary' })}>Back to VidXP</Button>}
             {state.setup && state.setup.profiles.length > 0 && <section className="setupPanel" aria-labelledby="saved-targets-title">
-              <Group justify="space-between"><Title id="saved-targets-title" order={2} className="panelTitle">Saved targets</Title><Badge variant="light">{state.setup.profiles.length}</Badge></Group>
+              <Group justify="space-between"><Title id="saved-targets-title" order={2} className="panelTitle">Saved installations</Title><Badge variant="light">{state.setup.profiles.length}</Badge></Group>
               <Stack gap="xs" mt="md">{state.setup.profiles.map((saved) => <Group key={saved.id} justify="space-between" className="savedTargetRow">
-                <div><Text fw={650}>{saved.display_name}{saved.id === state.setup?.selected_profile_id ? ' · Active' : ''}</Text><Text size="xs" className="mutedText">{saved.kind === 'managed' ? 'Desktop managed' : 'Externally managed'} · {saved.display_executable}</Text></div>
+                <div><Text fw={650}>{saved.display_name}{saved.id === state.setup?.selected_profile_id ? ' · Active' : ''}</Text><Text size="xs" className="mutedText">{saved.kind === 'managed' ? 'Managed by VidXP' : 'Managed by you'}</Text><details className="technicalDetails"><summary>Location</summary><Code className="pathCode">{saved.display_executable}</Code></details></div>
                 <Group><Button size="xs" variant="light" loading={state.operationProfile === saved.id && state.operation === 'select-profile'} disabled={operationPending || saved.id === state.setup?.selected_profile_id} onClick={() => void selectSaved(saved.id)}>Select</Button>{saved.kind !== 'managed' && <Button size="xs" color="red" variant="subtle" leftSection={<IconTrash size={14} />} loading={state.operationProfile === saved.id && state.operation === 'forget-profile'} disabled={operationPending} onClick={() => void forgetSaved(saved.id, saved.display_name)}>Forget</Button>}</Group>
               </Group>)}</Stack>
             </section>}
             <TargetChoice value={state.choice} disabled={operationPending} onChange={(choice) => dispatch({ type: 'choice', choice })} onContinue={() => dispatch({ type: 'navigate', stage: state.choice === 'existing_local' ? 'local' : 'managed-confirm' })} />
           </>}
           {state.stage === 'local' && <LocalSetup onBack={() => dispatch({ type: 'navigate', stage: 'choice' })} onActivated={(setup) => dispatch({ type: 'operationSettled', setup, stage: 'summary' })} />}
-          {state.stage === 'managed-confirm' && <section aria-labelledby="managed-confirm-title"><Button variant="subtle" leftSection={<IconArrowLeft size={17} />} disabled={operationPending} onClick={() => dispatch({ type: 'navigate', stage: 'choice' })}>Back</Button><div className="confirmationPanel"><ThemeIcon size={54} radius="xl" variant="light"><IconDownload size={28} /></ThemeIcon><Text className="eyebrow" mt="xl">CONFIRM MANAGED SETUP</Text><Title id="managed-confirm-title" order={1} className="pageTitle">Let VidXP Desktop manage a private runtime?</Title><Text className="lede centeredCopy">Your active target stays available until the replacement is installed, validated, and activated.</Text><Group justify="center" mt="xl"><Button variant="default" disabled={operationPending} onClick={() => dispatch({ type: 'navigate', stage: 'choice' })}>Cancel</Button><Button loading={state.operation === 'begin-managed'} disabled={operationPending} onClick={() => void beginManaged()}>Continue to setup</Button></Group></div></section>}
+          {state.stage === 'managed-confirm' && <section aria-labelledby="managed-confirm-title"><Button variant="subtle" leftSection={<IconArrowLeft size={17} />} disabled={operationPending} onClick={() => dispatch({ type: 'navigate', stage: 'choice' })}>Back</Button><div className="confirmationPanel"><ThemeIcon size={54} radius="xl" variant="light"><IconDownload size={28} /></ThemeIcon><Text className="eyebrow" mt="xl">SET UP VIDXP</Text><Title id="managed-confirm-title" order={1} className="pageTitle">Install and manage VidXP on this computer?</Title><Text className="lede centeredCopy">You choose the features. VidXP checks the new setup before switching to it, so your current installation stays available.</Text><Group justify="center" mt="xl"><Button variant="default" disabled={operationPending} onClick={() => dispatch({ type: 'navigate', stage: 'choice' })}>Cancel</Button><Button loading={state.operation === 'begin-managed'} disabled={operationPending} onClick={() => void beginManaged()}>Choose features</Button></Group></div></section>}
           {state.stage === 'managed' && state.draft && <ManagedSetup draftId={state.draft.id} selectedManagedRuntimeProfile={profile?.kind === 'managed' ? profile.managed_runtime_profile ?? null : null} onBack={cancelManaged} onCommitted={(setup) => dispatch({ type: 'operationSettled', setup, draft: null, stage: 'summary' })} />}
-          {state.stage === 'summary' && profile && <TargetSummary profile={profile} validationError={profile.validation_error} checking={state.operation === 'startup-check' || state.operation === 'recheck'} opening={state.operation === 'open-browser'} operationPending={operationPending} onRecheck={() => recheck()} onManageManaged={() => dispatch({ type: 'navigate', stage: 'managed-confirm' })} onChooseAnother={() => dispatch({ type: 'navigate', stage: 'choice', choice: null })} onOpen={openBrowser} />}
-        </div><footer className="appFooter"><span>Target metadata stays private to VidXP Desktop.</span><span>Credentials are never stored in this setup profile.</span></footer></main></div>
+          {state.stage === 'summary' && profile && <TargetSummary profile={profile} validationError={profile.validation_error} checking={state.operation === 'startup-check' || state.operation === 'recheck'} opening={state.operation === 'open-browser'} operationPending={operationPending} onRecheck={() => recheck()} onManageManaged={() => dispatch({ type: 'navigate', stage: 'managed-confirm' })} onSetupChanged={(setup) => dispatch({ type: 'operationSettled', setup, stage: 'summary' })} onChooseAnother={() => dispatch({ type: 'navigate', stage: 'choice', choice: null })} onOpen={openBrowser} />}
+        </div><footer className="appFooter"><span>Your VidXP settings stay on this computer.</span><span>Desktop only stops services that it starts.</span></footer></main></div>
       </div>
     </DesktopViewport>
   );

--- a/desktop/src/components/LocalSetup.tsx
+++ b/desktop/src/components/LocalSetup.tsx
@@ -108,7 +108,7 @@ export function LocalSetup({ onBack, onActivated }: LocalSetupProps) {
       )));
     } catch (error) {
       if (candidateGeneration.current.get(path) !== generation) return;
-      const message = errorMessage(error, 'This executable could not be inspected.');
+      const message = errorMessage(error, 'This VidXP installation could not be checked.');
       setCandidates((current) => current.map((candidate) => (
         candidatePath(candidate) === path
           ? { ...candidate, checking: false, inspection: undefined, inspectionError: message }
@@ -134,7 +134,7 @@ export function LocalSetup({ onBack, onActivated }: LocalSetupProps) {
       setSelectedPath(path);
       void checkCandidate(path);
     } catch (error) {
-      setFailure(errorMessage(error, 'The selected executable could not be opened.'));
+      setFailure(errorMessage(error, 'The selected VidXP installation could not be opened.'));
     } finally {
       setBusy(null);
     }
@@ -151,7 +151,7 @@ export function LocalSetup({ onBack, onActivated }: LocalSetupProps) {
       );
       onActivated(setup);
     } catch (error) {
-      setFailure(errorMessage(error, 'The inspected target could not be activated.'));
+      setFailure(errorMessage(error, 'This VidXP installation could not be connected.'));
     } finally {
       setBusy(null);
     }
@@ -163,29 +163,29 @@ export function LocalSetup({ onBack, onActivated }: LocalSetupProps) {
       <div className="sectionHeading compactHeading">
         <Text className="eyebrow">EXISTING INSTALLATION</Text>
         <Title id="local-setup-title" order={1} className="pageTitle">Connect this desktop to VidXP</Title>
-        <Text className="lede">Choose an installation to check whether it supports this Desktop. Checking and connecting it will not modify it.</Text>
+        <Text className="lede">Choose the VidXP installation you already use. Connecting it here will not change or update it.</Text>
       </div>
 
       <div className="setupPanel">
         <Group justify="space-between" align="flex-start" mb="md">
           <div>
             <Title order={2} className="panelTitle">Found on this computer</Title>
-            <Text className="mutedText" size="sm">Select one candidate to check it, or browse to another executable.</Text>
+            <Text className="mutedText" size="sm">Select an installation, or browse if yours is not listed.</Text>
           </div>
           <Button variant="default" leftSection={<IconRefresh aria-hidden="true" size={16} />} loading={busy === 'discover'} disabled={busy !== null} onClick={() => void discover()}>Scan again</Button>
         </Group>
 
         {busy === 'discover' && candidates.length === 0 ? (
-          <div className="emptyState" role="status" aria-live="polite"><Loader size="sm" /> Looking for VidXP executables…</div>
+          <div className="emptyState" role="status" aria-live="polite"><Loader size="sm" /> Looking for VidXP installations…</div>
         ) : candidates.length > 0 ? (
-          <Radio.Group value={selectedPath} onChange={selectCandidate} aria-label="Discovered VidXP executables" readOnly={busy !== null}>
+          <Radio.Group value={selectedPath} onChange={selectCandidate} aria-label="Discovered VidXP installations" readOnly={busy !== null}>
             <Stack gap="xs">
               {candidates.map((candidate) => {
                 const path = candidatePath(candidate);
                 const selected = selectedPath === path;
                 const inspection = candidate.inspection;
                 const validation = inspection?.validation;
-                const title = inspection?.reported_version ? `VidXP ${inspection.reported_version}` : 'VidXP executable';
+                const title = inspection?.reported_version ? `VidXP ${inspection.reported_version}` : 'VidXP installation';
                 const color = inspection?.state === 'ready_to_use' ? 'teal' : inspection?.state === 'update_required' ? 'yellow' : inspection?.state === 'cannot_start' || candidate.inspectionError ? 'red' : 'gray';
                 return (
                   <div className="candidateWrapper" key={path}>
@@ -199,43 +199,44 @@ export function LocalSetup({ onBack, onActivated }: LocalSetupProps) {
                               {candidate.checking ? 'Checking…' : inspection ? stateLabel[inspection.state] : candidate.inspectionError ? 'Cannot start' : 'Found'}
                             </Badge>
                           </Group>
-                          <Code className="pathCode">{candidateDisplayPath(candidate)}</Code>
-                          <Text size="xs" className="mutedText">{candidate.checking ? 'Checking compatibility…' : inspection || candidate.inspectionError ? candidate.source && `Discovered via ${candidate.source}` : 'Not checked'}</Text>
+                          <Text size="xs" className="mutedText">{candidate.checking ? 'Checking installed features…' : inspection || candidate.inspectionError ? candidate.source && `Found on this computer` : 'Select to check'}</Text>
                         </div>
                       </Group>
                     </Radio.Card>
 
                     {selected && candidate.checking && (
-                      <div className="inlineInspection" role="status" aria-live="polite"><Loader size="xs" /> Checking identity, probe, and launch compatibility…</div>
+                      <div className="inlineInspection" role="status" aria-live="polite"><Loader size="xs" /> Checking this VidXP installation…</div>
                     )}
                     {selected && candidate.inspectionError && (
                       <Alert m="sm" color="red" icon={<IconAlertCircle aria-hidden="true" />} title="Cannot start">{candidate.inspectionError}</Alert>
                     )}
                     {selected && inspection && (
                       <div className="inlineInspection">
-                        <Text size="sm">{inspection.message}</Text>
-                        <div className="validationGrid">
-                          <span>Desktop probe</span><strong>{inspection.probe_compatible ? `Compatible · protocol ${validation?.protocol_version ?? 'supported'}` : 'Unavailable or incompatible'}</strong>
-                          <span>Launch contract</span><strong>{inspection.launch_compatible ? `Compatible · protocol ${validation?.launch_protocol_version ?? 'supported'}` : 'Not accepted'}</strong>
-                          {validation?.python_version && <><span>Python</span><strong>{validation.python_version}</strong></>}
-                          {validation?.display_data_root && <><span>Data root</span><Code className="pathCode">{validation.display_data_root}</Code></>}
-                          {validation?.frontend && <><span>Browser interface</span><strong>{validation.frontend.launchable ? 'Available' : 'Unavailable'}</strong></>}
-                        </div>
+                        <Text size="sm">{inspection.adoptable ? 'This VidXP installation is ready to connect.' : inspection.message}</Text>
+                        {validation?.surfaces && <Group gap="xs" mt="sm">{validation.surfaces.map((surface) => <Badge key={surface} variant="light">{surface === 'worker' ? 'Local video processing' : surface === 'browser' ? 'Browser interface' : surface === 'mcp' ? 'AI assistant integration' : surface === 'server' ? 'App integration service' : surface}</Badge>)}</Group>}
+                        <details className="technicalDetails">
+                          <summary>Technical details</summary>
+                          <Code className="pathCode">{candidateDisplayPath(candidate)}</Code>
+                          <div className="validationGrid">
+                            <span>Compatibility check</span><strong>{inspection.probe_compatible ? `Supported · version ${validation?.protocol_version ?? 'current'}` : 'Not supported'}</strong>
+                            <span>App connection</span><strong>{inspection.launch_compatible ? `Supported · version ${validation?.launch_protocol_version ?? 'current'}` : 'Not supported'}</strong>
+                            {validation?.python_version && <><span>Python</span><strong>{validation.python_version}</strong></>}
+                            {validation?.display_data_root && <><span>Data location</span><Code className="pathCode">{validation.display_data_root}</Code></>}
+                          </div>
+                          {inspection.technical_details && <Code block>{inspection.technical_details}</Code>}
+                        </details>
                         {inspection.remediation && <Text size="sm" mt="sm"><strong>What to do:</strong> {inspection.remediation}</Text>}
                         {validation?.can_launch_frontend === false && (
-                          <Alert mt="sm" color="yellow" title="Desktop action required">
-                            <Text size="sm"><strong>Usable:</strong> This installation remains available through its own command-line workflows.</Text>
-                            <Text size="sm" mt="xs"><strong>Missing:</strong> {validation.frontend?.message}</Text>
-                            <Text size="sm" mt="xs"><strong>Enable it:</strong> {validation.frontend?.remediation}</Text>
+                          <Alert mt="sm" color="yellow" title="The browser interface is not enabled">
+                            <Text size="sm">You can still connect this installation and use its other features. After connecting, open Setup options to add the browser interface.</Text>
                           </Alert>
                         )}
-                        {inspection.technical_details && <details className="technicalDetails"><summary>Technical details</summary><Code block>{inspection.technical_details}</Code></details>}
                         {inspection.adoptable && validation && (
                           <Stack gap="sm" mt="md">
-                            <TextInput label="Target name" description="Used only to identify this connection in VidXP Desktop." value={displayName} onChange={(event) => setDisplayName(event.currentTarget.value)} />
+                            <TextInput label="Connection name" description="Used only to identify this installation in VidXP Desktop." value={displayName} onChange={(event) => setDisplayName(event.currentTarget.value)} />
                             <Group justify="flex-end">
                               <Button color={validation.can_launch_frontend === false ? 'yellow' : 'teal'} leftSection={validation.can_launch_frontend === false ? <IconAlertCircle size={16} /> : <IconCheck size={16} />} loading={busy === 'activate'} onClick={() => void activate(inspection)}>
-                                {validation.can_launch_frontend === false ? 'Save external target' : 'Use this installation'}
+                                Use this installation
                               </Button>
                             </Group>
                           </Stack>
@@ -248,13 +249,13 @@ export function LocalSetup({ onBack, onActivated }: LocalSetupProps) {
             </Stack>
           </Radio.Group>
         ) : (
-          <div className="emptyState"><IconFileSearch aria-hidden="true" size={22} /><span>No candidates were found automatically. Your installation may still be usable.</span></div>
+          <div className="emptyState"><IconFileSearch aria-hidden="true" size={22} /><span>No VidXP installations were found automatically. You can still choose one below.</span></div>
         )}
 
-        <Button mt="md" variant="light" leftSection={<IconFolderOpen aria-hidden="true" size={17} />} loading={busy === 'browse'} disabled={busy !== null} onClick={() => void browse()}>Browse for an executable…</Button>
+        <Button mt="md" variant="light" leftSection={<IconFolderOpen aria-hidden="true" size={17} />} loading={busy === 'browse'} disabled={busy !== null} onClick={() => void browse()}>Choose a VidXP installation…</Button>
       </div>
 
-      {busy === 'activate' && <div className="statusRegion" role="status" aria-live="polite"><Loader size="xs" /> Saving and activating this target…</div>}
+      {busy === 'activate' && <div className="statusRegion" role="status" aria-live="polite"><Loader size="xs" /> Connecting this VidXP installation…</div>}
       {failure && <Alert icon={<IconAlertCircle aria-hidden="true" />} color="red" title="Could not continue" role="alert">{failure}</Alert>}
     </section>
   );

--- a/desktop/src/components/ManagedSetup.tsx
+++ b/desktop/src/components/ManagedSetup.tsx
@@ -49,7 +49,7 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
   const [modelDirectory, setModelDirectory] = useState('');
   const [inventory, setInventory] = useState<ModelDirectoryInventory | null>(null);
   const [operation, setOperation] = useState<ManagedOperation | null>('load');
-  const [message, setMessage] = useState('Loading managed runtime options…');
+  const [message, setMessage] = useState('Loading VidXP options…');
   const [failure, setFailure] = useState<string | null>(null);
   const operations = useExclusiveOperation<ManagedOperation>();
   const initialLoad = useRef<Promise<{
@@ -98,7 +98,7 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
       setModelDirectory(nextStatus.model_directory);
       setPrepareDuringInstall(!recoverable);
       setInventory(nextInventory);
-      setMessage(nextStatus.ready ? 'The managed runtime is ready.' : nextStatus.detail);
+      setMessage(nextStatus.ready ? 'VidXP is ready.' : nextStatus.detail);
     } catch (error) {
       if (operations.current(operationId)) {
         setFailure(errorMessage(error, 'Managed setup could not be loaded.'));
@@ -128,6 +128,20 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
     setter(checked ? [...current, value] : current.filter((item) => item !== value));
   }
 
+  function toggleSurface(id: string, checked: boolean) {
+    toggleValue(id, checked, setSurfaces, surfaces);
+    if (id === 'worker' && checked && manifest) {
+      setCapabilities(Object.keys(manifest.capabilities));
+    }
+  }
+
+  function toggleCapability(id: string, checked: boolean) {
+    toggleValue(id, checked, setCapabilities, capabilities);
+    if (!checked && surfaces.includes('worker')) {
+      setSurfaces(surfaces.filter((surface) => surface !== 'worker'));
+    }
+  }
+
   async function chooseFolder() {
     const operationId = beginOperation('folder');
     if (operationId === null) return;
@@ -146,7 +160,7 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
 
   async function install() {
     if (capabilities.length === 0) {
-      setFailure('Select at least one capability.');
+      setFailure('Select at least one search feature.');
       return;
     }
     const operationId = beginOperation('install');
@@ -166,20 +180,20 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
         const repaired = await runtimeStatus();
         if (repaired.ready) {
           setStatus(repaired);
-          setMessage('The managed runtime is ready.');
+          setMessage('VidXP is ready.');
           return;
         }
       }
       setMessage(
         captured.prepare_models
-          ? 'Creating the managed runtime, verifying cached models, and downloading anything missing…'
-          : 'Creating the managed runtime…',
+          ? 'Installing VidXP and preparing the selected search features…'
+          : 'Installing VidXP…',
       );
       const result = await installRuntime(captured);
-      setMessage(result.install.prepared ? 'Runtime and selected models are ready.' : 'Runtime ready. Model downloads were deferred.');
+      setMessage(result.install.prepared ? 'VidXP and the selected search features are ready.' : 'VidXP is installed. Search files can be downloaded later.');
       onCommitted(result.setup);
     } catch (error) {
-      setFailure(errorMessage(error, 'Managed setup failed. The previous target remains authoritative; any completed replacement runtime is retained for recovery.'));
+      setFailure(errorMessage(error, 'Setup did not finish. Your previous VidXP installation is unchanged.'));
     } finally {
       settleOperation(operationId);
     }
@@ -211,7 +225,7 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
         setFailure('Models were prepared, but the cache inventory could not be refreshed.');
       }
     } catch (error) {
-      setFailure(errorMessage(error, 'Model preparation failed. The installed runtime remains active.'));
+      setFailure(errorMessage(error, 'The search files could not be prepared. Your installed VidXP remains available.'));
     } finally {
       settleOperation(operationId);
     }
@@ -248,7 +262,7 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
   }
 
   const isBusy = operation !== null;
-  const attentionTitle = /ffmpeg|ffprobe/i.test(message) ? 'Media tools required' : 'Managed runtime needs attention';
+  const attentionTitle = /ffmpeg|ffprobe/i.test(message) ? 'Video tools need attention' : 'VidXP needs attention';
 
   function formatBytes(bytes: number) {
     if (bytes < 1024) return `${bytes} B`;
@@ -266,9 +280,9 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
     <section aria-labelledby="managed-setup-title">
       <Button variant="subtle" leftSection={<IconArrowLeft aria-hidden="true" size={17} />} onClick={() => void onBack()} disabled={isBusy}>Back</Button>
       <div className="sectionHeading compactHeading">
-        <Text className="eyebrow">DESKTOP-MANAGED RUNTIME</Text>
-        <Title id="managed-setup-title" order={1} className="pageTitle">Set up local processing</Title>
-        <Text className="lede">VidXP Desktop owns this private runtime. Installation starts only when you confirm below.</Text>
+        <Text className="eyebrow">SETUP OPTIONS</Text>
+        <Title id="managed-setup-title" order={1} className="pageTitle">Choose your VidXP features</Title>
+        <Text className="lede">Choose what VidXP can search, where video work runs, and how you want to open or connect to it. You can change these later.</Text>
       </div>
 
       {!manifest ? (
@@ -276,7 +290,7 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
       ) : (
         <Stack gap="md">
           <div className="setupPanel">
-            <Title order={2} className="panelTitle" mb="md">Capabilities</Title>
+            <Title order={2} className="panelTitle" mb="md">Search features</Title>
             <div className="optionGrid">
               {Object.entries(manifest.capabilities).map(([id, capability]) => (
                 <Checkbox.Card
@@ -284,27 +298,36 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
                   key={id}
                   checked={capabilities.includes(id)}
                   disabled={isBusy}
-                  onClick={() => { if (!isBusy) toggleValue(id, !capabilities.includes(id), setCapabilities, capabilities); }}
+                  onClick={() => { if (!isBusy) toggleCapability(id, !capabilities.includes(id)); }}
                 >
-                  <Group wrap="nowrap" align="flex-start"><Checkbox.Indicator aria-hidden="true" /><div><Text fw={650}>{capability.label}</Text><Text size="sm" className="mutedText">{capability.description || `Installs the ${capability.extra} capability.`}</Text></div></Group>
+                  <Group wrap="nowrap" align="flex-start"><Checkbox.Indicator aria-hidden="true" /><div><Text fw={650}>{capability.label}</Text>{capability.description && <Text size="sm" className="mutedText">{capability.description}</Text>}</div></Group>
                 </Checkbox.Card>
               ))}
             </div>
           </div>
 
           <div className="setupPanel">
-            <Title order={2} className="panelTitle" mb="md">Interface</Title>
+            <Title order={2} className="panelTitle" mb="md">Video processing</Title>
             <Stack gap="xs">
-              {Object.entries(manifest.surfaces).map(([id, surface]) => (
-                <Checkbox key={id} checked={surfaces.includes(id)} disabled={isBusy} onChange={(event) => toggleValue(id, event.currentTarget.checked, setSurfaces, surfaces)} label={surface.label} description={surface.description} />
+              {Object.entries(manifest.surfaces).filter(([id]) => id === 'worker').map(([id, surface]) => (
+                <Checkbox key={id} checked={surfaces.includes(id)} disabled={isBusy} onChange={(event) => toggleSurface(id, event.currentTarget.checked)} label={surface.label} description={surface.description} />
+              ))}
+            </Stack>
+          </div>
+
+          <div className="setupPanel">
+            <Title order={2} className="panelTitle" mb="md">Interfaces and integrations</Title>
+            <Stack gap="xs">
+              {Object.entries(manifest.surfaces).filter(([id]) => id !== 'worker').map(([id, surface]) => (
+                <Checkbox key={id} checked={surfaces.includes(id)} disabled={isBusy} onChange={(event) => toggleSurface(id, event.currentTarget.checked)} label={surface.label} description={surface.description} />
               ))}
             </Stack>
           </div>
 
           <div className="setupPanel">
             <Group justify="space-between" align="center" wrap="nowrap">
-              <div className="folderCopy"><Text fw={650}>Model storage</Text><Text size="sm" className="pathText">{modelDirectory ? displayPath(modelDirectory) : 'Using the default location'}</Text></div>
-              <Button variant="default" leftSection={<IconFolderOpen aria-hidden="true" size={16} />} loading={operation === 'folder'} disabled={isBusy} onClick={() => void chooseFolder()}>Choose folder…</Button>
+              <div className="folderCopy"><Text fw={650}>Downloaded model storage</Text><Text size="sm" className="mutedText">VidXP keeps the files needed by your selected search features here.</Text>{modelDirectory && <details className="technicalDetails"><summary>Storage location</summary><Text size="sm" className="pathText">{displayPath(modelDirectory)}</Text></details>}</div>
+              <Button variant="default" leftSection={<IconFolderOpen aria-hidden="true" size={16} />} loading={operation === 'folder'} disabled={isBusy} onClick={() => void chooseFolder()}>Change location…</Button>
             </Group>
             <div className="cacheInventory" aria-live="polite">
               {operation === 'load' || operation === 'folder' || operation === 'reset' ? (
@@ -326,7 +349,7 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
                   {inventory.recognized_models.length > 0 && (
                     <Group gap="xs" mt="xs">{inventory.recognized_models.map((model) => <Badge key={model.id} variant="light">{model.label}</Badge>)}</Group>
                   )}
-                  <Text size="sm" mt="xs">Cached files detected; verification required. VidXP will reuse valid cached files and download only missing material.</Text>
+                  <Text size="sm" mt="xs">VidXP will reuse files that are ready and download only what is missing.</Text>
                 </>
               ) : null}
             </div>
@@ -344,26 +367,26 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
           className="managedAttention"
           icon={<IconAlertCircle aria-hidden="true" />}
           color="yellow"
-          title={corruptPointer ? 'Managed runtime configuration is unreadable' : attentionTitle}
+          title={corruptPointer ? 'VidXP could not read the saved setup' : attentionTitle}
           role="alert"
         >
           {corruptPointer
-            ? `${message} Choose a new managed configuration below. The unreadable pointer remains unchanged until the replacement is fully installed, validated, and activated.`
-            : message}
+            ? 'Review the options above and rebuild VidXP. Your saved setup is not changed until the new one is ready.'
+            : <><Text size="sm">Use the repair action below to check and restore this installation.</Text><details className="technicalDetails"><summary>Technical details</summary>{message}</details></>}
         </Alert>
       )}
 
       {status?.state === 'ready' && (
         <div className="runtimeSummary">
-          <Text fw={700}>Installed managed runtime</Text>
-          <Text size="sm">VidXP {status.package_version} · Capabilities: {status.capabilities.join(', ') || 'none'} · Interfaces: {status.surfaces.join(', ') || 'processing only'}</Text>
-          <Text size="sm" className="pathText">Models: {displayPath(status.model_directory)}</Text>
+          <Text fw={700}>VidXP is installed</Text>
+          <Text size="sm">Search: {status.capabilities.map((id) => manifest?.capabilities[id]?.label || id).join(', ') || 'none selected'}</Text>
+          <Text size="sm">Processing and access: {status.surfaces.map((id) => manifest?.surfaces[id]?.label || id).join(', ') || 'command line only'}</Text>
+          <details className="technicalDetails"><summary>Technical details</summary><Text size="xs">Version {status.package_version}</Text><Text size="xs" className="pathText">Models: {displayPath(status.model_directory)}</Text></details>
         </div>
       )}
 
-      {recoverableConfiguration && (dirty || status?.state === 'broken') && <Alert color="yellow" title={dirty ? 'Update creates a replacement runtime' : 'Repair keeps the current configuration'}>{dirty ? 'The installed runtime remains active while Desktop creates and validates this draft. It is replaced only after activation succeeds.' : 'Desktop will repair media tools first. It replaces the managed runtime only if the installed runtime is still damaged, preserving its capabilities, browser surface, and model folder.'}</Alert>}
-      {corruptPointer && <Alert color="yellow" title="Replacement becomes authoritative only after activation">Desktop cannot recover settings from the unreadable pointer. Review the default capabilities, browser surface, and model folder above before configuring a replacement.</Alert>}
-      {status?.ready && !displayedRuntimeSelected && <Alert color="yellow" title="Select this managed target to use it">Prepare and Open are unavailable because another target is currently selected. Return to Manage targets and select this managed runtime first.</Alert>}
+      {recoverableConfiguration && (dirty || status?.state === 'broken') && <Alert color="yellow" title={dirty ? 'Your current setup stays available during the update' : 'Repair keeps your selected features'}>{dirty ? 'VidXP switches to the updated setup only after it has been installed and checked.' : 'VidXP first repairs the video tools, then restores this installation only if needed.'}</Alert>}
+      {status?.ready && !displayedRuntimeSelected && <Alert color="yellow" title="This is not your active installation">Switch back to this installation before preparing models or opening VidXP.</Alert>}
 
       <div className="managedFooter">
         <div className="statusRegion" role="status" aria-live="polite" aria-atomic="true">{isBusy && <Loader size="xs" />}{(isBusy || status?.ready) && message}</div>
@@ -371,11 +394,11 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
           <Group>
             <Button variant="default" disabled={!dirty || isBusy} onClick={() => void resetDraft()}>Reset changes</Button>
             <Button loading={operation === 'install'} disabled={(!dirty && status?.state !== 'broken') || !manifest || isBusy} onClick={() => void install()}>{status?.state === 'broken' && !dirty ? 'Repair VidXP' : 'Apply update'}</Button>
-            <Button variant="light" loading={operation === 'prepare'} disabled={!status?.ready || dirty || !displayedRuntimeSelected || isBusy} onClick={() => void prepareModels()}>Prepare / verify models</Button>
+            <Button variant="light" loading={operation === 'prepare'} disabled={!status?.ready || dirty || !displayedRuntimeSelected || isBusy} onClick={() => void prepareModels()}>Check downloaded models</Button>
             <Button leftSection={<IconExternalLink aria-hidden="true" size={17} />} loading={operation === 'launch'} disabled={!status?.ready || dirty || !displayedRuntimeSelected || isBusy} onClick={() => void launch()}>Open VidXP</Button>
           </Group>
         ) : (
-          <Button loading={operation === 'install'} disabled={!manifest || isBusy} onClick={() => void install()}>{corruptPointer ? 'Configure replacement' : 'Configure VidXP'}</Button>
+          <Button loading={operation === 'install'} disabled={!manifest || isBusy} onClick={() => void install()}>{corruptPointer ? 'Rebuild VidXP' : 'Install VidXP'}</Button>
         )}
       </div>
       {failure && <Alert mt="md" icon={<IconAlertCircle aria-hidden="true" />} color="red" title="Could not continue" role="alert">{failure}</Alert>}

--- a/desktop/src/components/TargetChoice.tsx
+++ b/desktop/src/components/TargetChoice.tsx
@@ -21,8 +21,8 @@ const targets = [
   {
     value: 'managed' as const,
     title: 'Set up VidXP for me',
-    description: 'Create a private runtime managed by this desktop app.',
-    detail: 'Downloads Python, VidXP, and only the capabilities you choose.',
+    description: 'Install VidXP here and let the desktop app keep it ready.',
+    detail: 'Downloads only what your selected features need.',
     icon: IconDownload,
   },
 ];
@@ -32,10 +32,10 @@ export function TargetChoice({ value, disabled, onChange, onContinue }: TargetCh
     <section aria-labelledby="target-choice-title">
       <div className="sectionHeading">
         <Title id="target-choice-title" order={1} className="displayTitle">
-          Where should VidXP run?
+          How would you like to set up VidXP?
         </Title>
         <Text className="lede">
-          Choose before anything is installed. You can change the selected target later.
+          Choose before anything is installed. You can switch installations later.
         </Text>
       </div>
 

--- a/desktop/src/components/TargetSummary.tsx
+++ b/desktop/src/components/TargetSummary.tsx
@@ -41,6 +41,13 @@ interface TargetSummaryProps {
   onOpen: () => Promise<void>;
 }
 
+const CAPABILITY_LABELS: Record<string, string> = {
+  actor: 'Actor recognition',
+  dialogue: 'Dialogue search',
+  media: 'Video tools',
+  scene: 'Visual scene search',
+};
+
 export function TargetSummary({ profile, validationError, checking, operationPending, opening, onRecheck, onManageManaged, onSetupChanged, onChooseAnother, onOpen }: TargetSummaryProps) {
   const executable = profile.display_executable;
   const [doctor, setDoctor] = useState<DoctorReport | null>(null);
@@ -58,12 +65,18 @@ export function TargetSummary({ profile, validationError, checking, operationPen
   const [externalSurfaces, setExternalSurfaces] = useState<string[]>([]);
   const [externalFailure, setExternalFailure] = useState<string | null>(null);
   const [externalTechnical, setExternalTechnical] = useState<string | null>(null);
-  const desktopSurfaceUnavailable = !profile.frontend.launchable;
-  const browserAvailable = profile.surfaces.includes('browser');
-  const workerAvailable = profile.surfaces.includes('worker');
-  const mcpAvailable = profile.surfaces.includes('mcp') || profile.surfaces.includes('server');
-  const serverAvailable = profile.surfaces.includes('server');
+  const [readinessOpened, setReadinessOpened] = useState(false);
+  const [readinessElapsed, setReadinessElapsed] = useState(0);
+  const needsRuntimeUpdate = validationError?.code === 'runtime_update_required';
+  const runtimeCompatible = !validationError;
+  const desktopSurfaceUnavailable = !runtimeCompatible || !profile.frontend.launchable;
+  const browserAvailable = runtimeCompatible && profile.surfaces.includes('browser');
+  const workerAvailable = runtimeCompatible && profile.surfaces.includes('worker');
+  const mcpAvailable = runtimeCompatible && (profile.surfaces.includes('mcp') || profile.surfaces.includes('server'));
+  const serverAvailable = runtimeCompatible && profile.surfaces.includes('server');
   const failedChecks = doctor?.checks.filter((check) => !check.ok) ?? [];
+
+  const capabilityLabel = (capability: string) => CAPABILITY_LABELS[capability] ?? capability;
 
   useEffect(() => {
     setDoctor(null);
@@ -130,9 +143,19 @@ export function TargetSummary({ profile, validationError, checking, operationPen
     return () => { active = false; clearInterval(timer); };
   }, [profile.id, workerAvailable]);
 
+  useEffect(() => {
+    if (busy !== 'doctor') return;
+    setReadinessElapsed(0);
+    const started = Date.now();
+    const timer = setInterval(() => setReadinessElapsed(Math.floor((Date.now() - started) / 1000)), 1000);
+    return () => clearInterval(timer);
+  }, [busy]);
+
   async function runDoctor() {
     setBusy('doctor');
     setRuntimeFailure(null);
+    setDoctor(null);
+    setReadinessOpened(true);
     try {
       setDoctor(await targetDoctor());
     } catch (error) {
@@ -163,8 +186,14 @@ export function TargetSummary({ profile, validationError, checking, operationPen
     try {
       const manifest = await runtimeManifest();
       setExternalManifest(manifest);
-      setExternalCapabilities(profile.capabilities.filter((capability) => capability in manifest.capabilities));
-      setExternalSurfaces([...profile.surfaces]);
+      if (needsRuntimeUpdate) {
+        const defaultSurfaces = Object.entries(manifest.surfaces).filter(([, surface]) => surface.default).map(([id]) => id);
+        setExternalSurfaces(defaultSurfaces);
+        setExternalCapabilities(defaultSurfaces.includes('worker') ? Object.keys(manifest.capabilities) : []);
+      } else {
+        setExternalCapabilities(profile.capabilities.filter((capability) => capability in manifest.capabilities));
+        setExternalSurfaces([...profile.surfaces]);
+      }
       setExternalSetupOpened(true);
     } catch (error) {
       setRuntimeFailure(errorMessage(error, 'VidXP could not load the available setup options.'));
@@ -260,12 +289,18 @@ export function TargetSummary({ profile, validationError, checking, operationPen
         </Group>
       </div>
 
-      {desktopSurfaceUnavailable && (
+      {needsRuntimeUpdate && (
+        <Alert color="yellow" mb="md" title="Update this VidXP installation to continue">
+          <Text size="sm">This Desktop version cannot safely read or manage the features in the selected Python installation.</Text>
+          <Button mt="md" variant="light" loading={busy === 'features'} disabled={operationPending || busy !== null} onClick={() => void openExternalSetup()}>Update this installation</Button>
+        </Alert>
+      )}
+      {!needsRuntimeUpdate && desktopSurfaceUnavailable && (
         <Alert color="yellow" mb="md" title="The browser interface is not enabled">
           <Text size="sm">Other installed features are still available. Open Setup options to add the browser interface.</Text>
         </Alert>
       )}
-      {validationError && (
+      {validationError && !needsRuntimeUpdate && (
         <Alert color="red" title="This setup needs attention" role="alert" mb="md">
           {validationError.message}
           <details className="technicalDetails"><summary>Technical details</summary><Code>{validationError.code}</Code></details>
@@ -276,12 +311,13 @@ export function TargetSummary({ profile, validationError, checking, operationPen
       <div className="summaryPanel">
         <div className="summaryGrid">
           <Text>Status</Text><strong>{validationError ? 'Needs attention' : 'Connected'}</strong>
-          <Text>Available</Text><strong>{[
+          <Text>Available</Text><strong>{runtimeCompatible ? [
             workerAvailable && 'local video processing',
             !desktopSurfaceUnavailable && 'browser interface',
             mcpAvailable && 'AI assistant integration',
             serverAvailable && 'app integration service',
-          ].filter(Boolean).join(', ') || 'Command-line tools'}</strong>
+          ].filter(Boolean).join(', ') || 'Command-line tools' : 'Available after the installation is updated'}</strong>
+          <Text>Search features</Text><strong>{runtimeCompatible ? profile.capabilities.map(capabilityLabel).join(', ') || 'None installed' : 'Unknown until the installation is updated'}</strong>
           {profile.last_validated_at && <><Text>Last checked</Text><strong>{new Date(profile.last_validated_at).toLocaleString()}</strong></>}
         </div>
         <details className="technicalDetails">
@@ -310,13 +346,13 @@ export function TargetSummary({ profile, validationError, checking, operationPen
 
         <Stack gap="sm" mt="lg">
           <Group justify="space-between" className="runtimeControlRow">
-            <div><Text fw={650}>Readiness check</Text><Text size="sm" className="mutedText">Make sure video tools, search features, and downloaded models are ready to use.</Text></div>
-            <Button variant="light" leftSection={<IconActivityHeartbeat size={17} />} loading={busy === 'doctor'} disabled={operationPending || busy !== null} onClick={() => void runDoctor()}>Check readiness</Button>
+            <div><Text fw={650}>Readiness check</Text><Text size="sm" className="mutedText">Checks FFmpeg plus the packages and downloaded models required by each installed search feature.</Text></div>
+            <Button variant="light" leftSection={<IconActivityHeartbeat size={17} />} loading={busy === 'doctor'} disabled={!runtimeCompatible || operationPending || busy !== null} onClick={() => void runDoctor()}>Check readiness</Button>
           </Group>
           {doctor && (
-            <Alert color={doctor.ok ? 'teal' : 'yellow'} title={doctor.ok ? 'VidXP is ready' : `${failedChecks.length} item${failedChecks.length === 1 ? '' : 's'} need attention`}>
+            <Alert color={doctor.ok && doctor.modalities.length > 0 ? 'teal' : 'yellow'} title={doctor.ok ? doctor.modalities.length > 0 ? 'VidXP is ready' : 'Video tools are ready' : `${failedChecks.length} item${failedChecks.length === 1 ? '' : 's'} need attention`}>
               {doctor.ok
-                ? 'Your installed search features and media tools are ready.'
+                ? doctor.modalities.length > 0 ? `Ready search features: ${doctor.modalities.map(capabilityLabel).join(', ')}.` : 'No search features were reported, so this result covers only the shared video tools.'
                 : <><Text size="sm">Open setup to repair a managed installation, or use your installer to repair an external one.</Text><details className="technicalDetails"><summary>See check details</summary>{failedChecks.map((check) => <Text size="xs" key={`${check.capability}-${check.name}`}>{check.error || `${check.name} is unavailable.`}</Text>)}</details></>}
             </Alert>
           )}
@@ -372,8 +408,26 @@ export function TargetSummary({ profile, validationError, checking, operationPen
         <Group justify="flex-end" mt="md"><Button leftSection={<IconCopy size={17} />} onClick={() => void copyMcpConfig()}>{copied ? 'Copied' : 'Copy setup'}</Button></Group>
       </Modal>
 
+      <Modal opened={readinessOpened} onClose={() => { if (busy !== 'doctor') setReadinessOpened(false); }} title={busy === 'doctor' ? 'Checking VidXP readiness' : 'VidXP readiness'} size="lg" closeOnClickOutside={busy !== 'doctor'} closeOnEscape={busy !== 'doctor'}>
+        {busy === 'doctor' ? <Stack gap="md">
+          <Group><Loader size="sm" /><Text>Checking the selected installation… {readinessElapsed}s</Text></Group>
+          <Text size="sm" className="mutedText">VidXP is inspecting video tools, installed search packages, and model files. It does not download or change anything, and stops after three minutes if it cannot finish.</Text>
+          <div><Text size="sm" fw={650}>Search features expected from this installation</Text><Text size="sm">{profile.capabilities.map(capabilityLabel).join(', ') || 'The installed runtime will report these as part of the check.'}</Text></div>
+        </Stack> : doctor ? <Stack gap="sm">
+          {doctor.modalities.length > 0
+            ? <Alert color={doctor.ok ? 'teal' : 'yellow'} title={doctor.ok ? 'Ready to use' : 'Some items need attention'}>Search features checked: {doctor.modalities.map(capabilityLabel).join(', ')}.</Alert>
+            : <Alert color="yellow" title="No search features were checked">Only the shared video tools were reported by this installation.</Alert>}
+          {doctor.checks.map((check) => <Group key={`${check.capability}-${check.kind}-${check.name}`} justify="space-between" className="runtimeControlRow" wrap="nowrap">
+            <div><Text fw={650}>{check.name}</Text><Text size="xs" className="mutedText">{capabilityLabel(check.capability)} · {check.kind === 'model' ? 'Downloaded model' : 'Installed package or video tool'}</Text>{check.error && <Text size="xs" c="red">{check.error}</Text>}</div>
+            <Badge color={check.ok ? 'teal' : 'yellow'} variant="light">{check.ok ? 'Ready' : 'Needs attention'}</Badge>
+          </Group>)}
+          <Group justify="flex-end"><Button onClick={() => setReadinessOpened(false)}>Done</Button></Group>
+        </Stack> : null}
+      </Modal>
+
       <Modal opened={externalSetupOpened} onClose={() => { if (busy === null) setExternalSetupOpened(false); }} title="Change features for this installation" size="lg" closeOnClickOutside={busy === null} closeOnEscape={busy === null}>
         <Text size="sm" mb="md">Choose what VidXP can search, where video work runs, and how other apps can connect.</Text>
+        {needsRuntimeUpdate && externalManifest && <Alert color="yellow" title="This update is required" mb="md">VidXP will update this same installation from {profile.observed_vidxp_version} to {externalManifest.package_version}, then apply the selected features. It will not create a Desktop-managed copy.</Alert>}
         {externalFailure && <Alert color="red" title="Features could not be updated" mb="md">{externalFailure}{externalTechnical && <details className="technicalDetails"><summary>Technical details</summary><Code block>{externalTechnical}</Code></details>}</Alert>}
         {!externalManifest ? <Loader size="sm" /> : <Stack gap="sm">
           <Text fw={650}>Search features</Text>
@@ -389,10 +443,10 @@ export function TargetSummary({ profile, validationError, checking, operationPen
             return <Checkbox key={id} checked={externalSurfaces.includes(id)} disabled={busy !== null} onChange={(event) => { const checked = event.currentTarget.checked; setExternalSurfaces((current) => checked ? [...current, id] : current.filter((value) => value !== id)); }} label={surface.label} description={surface.description} />;
           })}
         </Stack>}
-        <Alert color="blue" mt="md" title="Your existing installation stays selected">VidXP reinstalls this isolated app environment at its current version with the selected features. It does not replace it with a Desktop-managed copy.</Alert>
+        {!needsRuntimeUpdate && <Alert color="blue" mt="md" title="Your existing installation stays selected">VidXP reinstalls this isolated app environment at its current compatible version with the selected features. It does not replace it with a Desktop-managed copy.</Alert>}
         <Group justify="flex-end" mt="md">
           <Button variant="default" disabled={busy !== null} onClick={() => setExternalSetupOpened(false)}>Cancel</Button>
-          <Button loading={busy === 'features'} disabled={busy !== null || ([...externalCapabilities].sort().join(',') === [...profile.capabilities].sort().join(',') && [...externalSurfaces].sort().join(',') === [...profile.surfaces].sort().join(','))} onClick={() => void applyExternalFeatures()}>Apply changes</Button>
+          <Button loading={busy === 'features'} disabled={busy !== null || (!needsRuntimeUpdate && [...externalCapabilities].sort().join(',') === [...profile.capabilities].sort().join(',') && [...externalSurfaces].sort().join(',') === [...profile.surfaces].sort().join(','))} onClick={() => void applyExternalFeatures()}>{needsRuntimeUpdate ? 'Update and apply' : 'Apply changes'}</Button>
         </Group>
       </Modal>
     </section>

--- a/desktop/src/components/TargetSummary.tsx
+++ b/desktop/src/components/TargetSummary.tsx
@@ -1,7 +1,32 @@
-import { Alert, Badge, Button, Code, Group, Text, Title } from '@mantine/core';
-import { IconExternalLink, IconRefresh, IconSettings } from '@tabler/icons-react';
+import { Alert, Badge, Button, Checkbox, Code, Group, Loader, Modal, Stack, Text, Title } from '@mantine/core';
+import { IconActivityHeartbeat, IconCopy, IconExternalLink, IconPlayerPlay, IconPlayerStop, IconRefresh, IconSettings, IconShare, IconTerminal2 } from '@tabler/icons-react';
+import { useEffect, useState } from 'react';
 
-import { type TargetError, type TargetProfile } from '../tauri';
+import {
+  errorMessage,
+  browserServiceStatus,
+  configureExternalInstallation,
+  localServerStatus,
+  localWorkerStatus,
+  mcpClientConfig,
+  runtimeManifest,
+  startLocalServer,
+  startSharedBrowser,
+  startSharedServer,
+  startLocalWorker,
+  stopLocalServer,
+  stopBrowserService,
+  stopLocalWorker,
+  targetDoctor,
+  type DoctorReport,
+  type BrowserServiceStatus,
+  type LocalServerStatus,
+  type LocalWorkerStatus,
+  type RuntimeManifest,
+  type TargetError,
+  type TargetProfile,
+  type TargetSetupState,
+} from '../tauri';
 
 interface TargetSummaryProps {
   profile: TargetProfile;
@@ -11,65 +36,365 @@ interface TargetSummaryProps {
   opening?: boolean;
   onRecheck: () => Promise<void>;
   onManageManaged: () => void;
+  onSetupChanged: (setup: TargetSetupState) => void;
   onChooseAnother: () => void;
   onOpen: () => Promise<void>;
 }
 
-export function TargetSummary({ profile, validationError, checking, operationPending, opening, onRecheck, onManageManaged, onChooseAnother, onOpen }: TargetSummaryProps) {
+export function TargetSummary({ profile, validationError, checking, operationPending, opening, onRecheck, onManageManaged, onSetupChanged, onChooseAnother, onOpen }: TargetSummaryProps) {
   const executable = profile.display_executable;
+  const [doctor, setDoctor] = useState<DoctorReport | null>(null);
+  const [server, setServer] = useState<LocalServerStatus | null>(null);
+  const [browser, setBrowser] = useState<BrowserServiceStatus | null>(null);
+  const [worker, setWorker] = useState<LocalWorkerStatus | null>(null);
+  const [mcpConfig, setMcpConfig] = useState<string | null>(null);
+  const [busy, setBusy] = useState<'doctor' | 'config' | 'features' | 'worker-start' | 'worker-stop' | 'browser-share' | 'browser-stop' | 'server-start' | 'server-share' | 'server-stop' | null>(null);
+  const [runtimeFailure, setRuntimeFailure] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [shareCopied, setShareCopied] = useState(false);
+  const [externalSetupOpened, setExternalSetupOpened] = useState(false);
+  const [externalManifest, setExternalManifest] = useState<RuntimeManifest | null>(null);
+  const [externalCapabilities, setExternalCapabilities] = useState<string[]>([]);
+  const [externalSurfaces, setExternalSurfaces] = useState<string[]>([]);
+  const [externalFailure, setExternalFailure] = useState<string | null>(null);
+  const [externalTechnical, setExternalTechnical] = useState<string | null>(null);
   const desktopSurfaceUnavailable = !profile.frontend.launchable;
-  const desktopAction = desktopSurfaceUnavailable
-    ? profile.lifecycle_ownership === 'external'
-      ? 'Unavailable · enable the browser surface in the externally managed installation'
-      : 'Unavailable · return to managed setup to enable the browser surface'
-    : 'Browser interface available';
+  const browserAvailable = profile.surfaces.includes('browser');
+  const workerAvailable = profile.surfaces.includes('worker');
+  const mcpAvailable = profile.surfaces.includes('mcp') || profile.surfaces.includes('server');
+  const serverAvailable = profile.surfaces.includes('server');
+  const failedChecks = doctor?.checks.filter((check) => !check.ok) ?? [];
+
+  useEffect(() => {
+    setDoctor(null);
+    setMcpConfig(null);
+    setRuntimeFailure(null);
+    if (!serverAvailable) {
+      setServer(null);
+      return;
+    }
+    let active = true;
+    let timer: ReturnType<typeof setInterval> | null = null;
+    const poll = async () => {
+      try {
+        const status = await localServerStatus();
+        if (!active) return;
+        setServer(status);
+      } catch (error) {
+        if (active) setRuntimeFailure(errorMessage(error, 'The local service status could not be checked.'));
+      }
+    };
+    void poll();
+    timer = setInterval(() => void poll(), 5000);
+    return () => {
+      active = false;
+      if (timer) clearInterval(timer);
+    };
+  }, [profile.id, serverAvailable]);
+
+  useEffect(() => {
+    if (!browserAvailable) {
+      setBrowser(null);
+      return;
+    }
+    let active = true;
+    const poll = async () => {
+      try {
+        const status = await browserServiceStatus();
+        if (active) setBrowser(status);
+      } catch (error) {
+        if (active) setRuntimeFailure(errorMessage(error, 'The browser sharing status could not be checked.'));
+      }
+    };
+    void poll();
+    const timer = setInterval(() => void poll(), 5000);
+    return () => { active = false; clearInterval(timer); };
+  }, [profile.id, browserAvailable]);
+
+  useEffect(() => {
+    if (!workerAvailable) {
+      setWorker(null);
+      return;
+    }
+    let active = true;
+    const poll = async () => {
+      try {
+        const status = await localWorkerStatus();
+        if (active) setWorker(status);
+      } catch (error) {
+        if (active) setRuntimeFailure(errorMessage(error, 'Local video processing status could not be checked.'));
+      }
+    };
+    void poll();
+    const timer = setInterval(() => void poll(), 5000);
+    return () => { active = false; clearInterval(timer); };
+  }, [profile.id, workerAvailable]);
+
+  async function runDoctor() {
+    setBusy('doctor');
+    setRuntimeFailure(null);
+    try {
+      setDoctor(await targetDoctor());
+    } catch (error) {
+      setRuntimeFailure(errorMessage(error, 'VidXP could not check whether this setup is ready.'));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function loadMcpConfig() {
+    setBusy('config');
+    setRuntimeFailure(null);
+    setCopied(false);
+    try {
+      setMcpConfig(await mcpClientConfig());
+    } catch (error) {
+      setRuntimeFailure(errorMessage(error, 'VidXP could not create the AI client setup.'));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function openExternalSetup() {
+    setBusy('features');
+    setRuntimeFailure(null);
+    setExternalFailure(null);
+    setExternalTechnical(null);
+    try {
+      const manifest = await runtimeManifest();
+      setExternalManifest(manifest);
+      setExternalCapabilities(profile.capabilities.filter((capability) => capability in manifest.capabilities));
+      setExternalSurfaces([...profile.surfaces]);
+      setExternalSetupOpened(true);
+    } catch (error) {
+      setRuntimeFailure(errorMessage(error, 'VidXP could not load the available setup options.'));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function applyExternalFeatures() {
+    setBusy('features');
+    setExternalFailure(null);
+    setExternalTechnical(null);
+    try {
+      const setup = await configureExternalInstallation(externalCapabilities, externalSurfaces);
+      onSetupChanged(setup);
+      setExternalSetupOpened(false);
+    } catch (error) {
+      const detail = errorMessage(error, 'VidXP could not update the selected features for this installation.');
+      setExternalFailure(detail.includes('not an isolated uv tool installation')
+        ? 'This installation uses a different package manager. Change its features there, then check the connection again.'
+        : 'VidXP could not reinstall this app with the selected features. Your current installation may need attention.');
+      setExternalTechnical(detail);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function setServerMode(mode: 'local' | 'shared' | 'stopped') {
+    setBusy(mode === 'local' ? 'server-start' : mode === 'shared' ? 'server-share' : 'server-stop');
+    setRuntimeFailure(null);
+    setShareCopied(false);
+    try {
+      setServer(await (mode === 'local' ? startLocalServer() : mode === 'shared' ? startSharedServer() : stopLocalServer()));
+    } catch (error) {
+      setRuntimeFailure(errorMessage(error, 'VidXP could not change the sharing service.'));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function setBrowserShared(running: boolean) {
+    setBusy(running ? 'browser-share' : 'browser-stop');
+    setRuntimeFailure(null);
+    try {
+      setBrowser(await (running ? startSharedBrowser() : stopBrowserService()));
+    } catch (error) {
+      setRuntimeFailure(errorMessage(error, 'VidXP could not change browser sharing.'));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function copyShareToken() {
+    if (!server?.bearer_token) return;
+    await navigator.clipboard.writeText(server.bearer_token);
+    setShareCopied(true);
+  }
+
+  async function setWorkerRunning(running: boolean) {
+    setBusy(running ? 'worker-start' : 'worker-stop');
+    setRuntimeFailure(null);
+    try {
+      setWorker(await (running ? startLocalWorker() : stopLocalWorker()));
+    } catch (error) {
+      setRuntimeFailure(errorMessage(error, 'VidXP could not change local video processing.'));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function copyMcpConfig() {
+    if (!mcpConfig) return;
+    try {
+      await navigator.clipboard.writeText(mcpConfig);
+      setCopied(true);
+    } catch {
+      setRuntimeFailure('VidXP could not copy this automatically. Select the setup text and copy it manually.');
+    }
+  }
 
   return (
     <section aria-labelledby="target-summary-title">
       <div className="sectionHeading compactHeading">
-        <Text className="eyebrow">ACTIVE TARGET</Text>
+        <Text className="eyebrow">YOUR VIDXP</Text>
         <Group justify="space-between" align="flex-end">
           <div>
             <Title id="target-summary-title" order={1} className="pageTitle">{profile.display_name}</Title>
-            <Text className="lede">This target is restored and checked again whenever VidXP Desktop opens.</Text>
+            <Text className="lede">Choose how you want to use VidXP. Your setup is remembered the next time you open the app.</Text>
           </div>
           <Badge size="lg" variant="light" color={profile.kind === 'managed' ? 'violet' : 'teal'}>
-            {profile.kind === 'managed' ? 'Desktop managed' : 'Externally managed'}
+            {profile.kind === 'managed' ? 'Managed by VidXP' : 'Your installation'}
           </Badge>
         </Group>
       </div>
 
       {desktopSurfaceUnavailable && (
-        <Alert color="yellow" mb="md" title="Action required · no usable desktop surface">
-          <Text size="sm"><strong>Usable:</strong> {profile.lifecycle_ownership === 'external' ? 'This externally managed installation remains available through its own command-line and package-managed workflows.' : 'The managed runtime remains configured for its installed non-browser capabilities.'}</Text>
-          <Text size="sm" mt="xs"><strong>Missing:</strong> {profile.frontend?.message || 'The supported browser interface cannot currently be launched.'}</Text>
-          <Text size="sm" mt="xs"><strong>How to enable it:</strong> {profile.frontend?.remediation || (profile.lifecycle_ownership === 'external' ? "Use this installation's own package-management workflow to enable the VidXP browser interface, then return here and revalidate." : 'Return to managed setup and select the browser surface.')}</Text>
+        <Alert color="yellow" mb="md" title="The browser interface is not enabled">
+          <Text size="sm">Other installed features are still available. Open Setup options to add the browser interface.</Text>
         </Alert>
       )}
       {validationError && (
-        <Alert color="red" title={validationError.code} role="alert" mb="md">
+        <Alert color="red" title="This setup needs attention" role="alert" mb="md">
           {validationError.message}
+          <details className="technicalDetails"><summary>Technical details</summary><Code>{validationError.code}</Code></details>
         </Alert>
       )}
+      {runtimeFailure && <Alert color="red" title="That did not work" role="alert" mb="md">{runtimeFailure}</Alert>}
 
       <div className="summaryPanel">
         <div className="summaryGrid">
-          <Text>Ownership</Text><strong>{profile.lifecycle_ownership === 'external' ? 'You manage this installation' : 'VidXP Desktop manages this runtime'}</strong>
-          {executable && <><Text>Executable</Text><Code className="pathCode">{executable}</Code></>}
-          {profile.observed_vidxp_version && <><Text>VidXP version</Text><strong>{profile.observed_vidxp_version}</strong></>}
-          <Text>Data root</Text><Code className="pathCode">{profile.display_data_root}</Code>
+          <Text>Status</Text><strong>{validationError ? 'Needs attention' : 'Connected'}</strong>
+          <Text>Available</Text><strong>{[
+            workerAvailable && 'local video processing',
+            !desktopSurfaceUnavailable && 'browser interface',
+            mcpAvailable && 'AI assistant integration',
+            serverAvailable && 'app integration service',
+          ].filter(Boolean).join(', ') || 'Command-line tools'}</strong>
           {profile.last_validated_at && <><Text>Last checked</Text><strong>{new Date(profile.last_validated_at).toLocaleString()}</strong></>}
-          <Text>Desktop action</Text><strong>{desktopAction}</strong>
         </div>
+        <details className="technicalDetails">
+          <summary>Technical details</summary>
+          <div className="summaryGrid technicalSummary">
+            {profile.observed_vidxp_version && <><Text>Version</Text><strong>{profile.observed_vidxp_version}</strong></>}
+            {executable && <><Text>Program</Text><Code className="pathCode">{executable}</Code></>}
+            <Text>Data location</Text><Code className="pathCode">{profile.display_data_root}</Code>
+          </div>
+        </details>
         <Group justify="space-between" mt="xl">
           <Group>
-            <Button variant="default" leftSection={<IconRefresh aria-hidden="true" size={17} />} disabled={operationPending} onClick={onChooseAnother}>Manage targets</Button>
-            <Button variant="subtle" leftSection={<IconRefresh aria-hidden="true" size={17} />} loading={checking} disabled={operationPending && !checking} onClick={() => void onRecheck()}>Recheck target</Button>
-            {profile.kind === 'managed' && <Button variant="subtle" leftSection={<IconSettings aria-hidden="true" size={17} />} disabled={operationPending} onClick={onManageManaged}>Manage setup</Button>}
+            <Button variant="default" leftSection={<IconRefresh aria-hidden="true" size={17} />} disabled={operationPending} onClick={onChooseAnother}>Switch installation</Button>
+            <Button variant="subtle" leftSection={<IconRefresh aria-hidden="true" size={17} />} loading={checking} disabled={operationPending && !checking} onClick={() => void onRecheck()}>Check connection</Button>
+            {profile.kind === 'managed'
+              ? <Button variant="subtle" leftSection={<IconSettings aria-hidden="true" size={17} />} disabled={operationPending} onClick={onManageManaged}>Setup options</Button>
+              : <Button variant="subtle" leftSection={<IconSettings aria-hidden="true" size={17} />} loading={busy === 'features'} disabled={operationPending || busy !== null} onClick={() => void openExternalSetup()}>Setup options</Button>}
           </Group>
           <Button leftSection={<IconExternalLink aria-hidden="true" size={17} />} loading={opening} disabled={Boolean(validationError) || desktopSurfaceUnavailable || operationPending} onClick={() => void onOpen()}>Open VidXP</Button>
         </Group>
       </div>
+
+      <div className="setupPanel runtimeControlPanel">
+        <Title order={2} className="panelTitle">Health and background services</Title>
+        <Text size="sm" className="mutedText">Check whether VidXP is usable and control only the services you enabled.</Text>
+
+        <Stack gap="sm" mt="lg">
+          <Group justify="space-between" className="runtimeControlRow">
+            <div><Text fw={650}>Readiness check</Text><Text size="sm" className="mutedText">Make sure video tools, search features, and downloaded models are ready to use.</Text></div>
+            <Button variant="light" leftSection={<IconActivityHeartbeat size={17} />} loading={busy === 'doctor'} disabled={operationPending || busy !== null} onClick={() => void runDoctor()}>Check readiness</Button>
+          </Group>
+          {doctor && (
+            <Alert color={doctor.ok ? 'teal' : 'yellow'} title={doctor.ok ? 'VidXP is ready' : `${failedChecks.length} item${failedChecks.length === 1 ? '' : 's'} need attention`}>
+              {doctor.ok
+                ? 'Your installed search features and media tools are ready.'
+                : <><Text size="sm">Open setup to repair a managed installation, or use your installer to repair an external one.</Text><details className="technicalDetails"><summary>See check details</summary>{failedChecks.map((check) => <Text size="xs" key={`${check.capability}-${check.name}`}>{check.error || `${check.name} is unavailable.`}</Text>)}</details></>}
+            </Alert>
+          )}
+
+          {workerAvailable && <Group justify="space-between" className="runtimeControlRow">
+            <div>
+              <Text fw={650}>Local video processing</Text>
+              <Text size="sm" className="mutedText">{worker?.running ? 'Ready to process indexing, search, and model jobs on this computer.' : 'Starts automatically when VidXP needs to process a video. You can also start it now.'}</Text>
+            </div>
+            {worker?.running
+              ? <Button color="red" variant="light" leftSection={<IconPlayerStop size={17} />} loading={busy === 'worker-stop'} disabled={operationPending || busy !== null} onClick={() => void setWorkerRunning(false)}>Stop processing</Button>
+              : <Button variant="light" leftSection={<IconPlayerPlay size={17} />} loading={busy === 'worker-start'} disabled={operationPending || busy !== null} onClick={() => void setWorkerRunning(true)}>Start processing</Button>}
+          </Group>}
+
+          {browserAvailable && <Group justify="space-between" className="runtimeControlRow" align="flex-start">
+            <div>
+              <Text fw={650}>Browser interface</Text>
+              <Text size="sm" className="mutedText">{browser?.shared ? 'Shared without authentication on your current local network.' : 'Private to this computer unless you explicitly share it.'}</Text>
+              {browser?.shared && browser.network_url && <div className="connectionDetails"><Text size="xs">Network address</Text><Code className="pathCode">{browser.network_url}</Code></div>}
+            </div>
+            {browser?.shared
+              ? <Button color="red" variant="light" leftSection={<IconPlayerStop size={17} />} loading={busy === 'browser-stop'} disabled={operationPending || busy !== null} onClick={() => void setBrowserShared(false)}>Stop sharing</Button>
+              : <Button color="yellow" variant="light" leftSection={<IconShare size={17} />} loading={busy === 'browser-share'} disabled={operationPending || busy !== null} onClick={() => void setBrowserShared(true)}>Share browser</Button>}
+          </Group>}
+
+          {mcpAvailable && <Group justify="space-between" className="runtimeControlRow">
+            <div><Text fw={650}>AI assistant integration</Text><Text size="sm" className="mutedText">Create the MCP setup needed to use VidXP from a compatible AI assistant.</Text></div>
+            <Button variant="light" leftSection={<IconTerminal2 size={17} />} loading={busy === 'config'} disabled={operationPending || busy !== null} onClick={() => void loadMcpConfig()}>Set up connection</Button>
+          </Group>}
+
+          {serverAvailable && <Group justify="space-between" className="runtimeControlRow">
+            <div>
+              <Text fw={650}>App integration service</Text>
+              <Text size="sm" className="mutedText">{server?.shared ? 'Authenticated API and MCP access is available on your current local network.' : server?.running ? 'The API and MCP connection are private to this computer.' : 'Start this only when another app needs to connect to VidXP.'}</Text>
+              {server?.running && <div className="connectionDetails">
+                {server.origin && <><Text size="xs">API address</Text><Code className="pathCode">{server.origin}</Code></>}
+                {server.mcp_url && <><Text size="xs" mt="xs">MCP address</Text><Code className="pathCode">{server.mcp_url}</Code></>}
+                {server.shared && server.bearer_token && <details className="technicalDetails"><summary>Bearer token</summary><Code className="pathCode">{server.bearer_token}</Code><Button mt="xs" size="compact-sm" variant="subtle" leftSection={<IconCopy size={15} />} onClick={() => void copyShareToken()}>{shareCopied ? 'Copied' : 'Copy token'}</Button></details>}
+              </div>}
+            </div>
+            <Group gap="xs" justify="flex-end">
+              {!server?.running && <Button variant="light" leftSection={<IconPlayerPlay size={17} />} loading={busy === 'server-start'} disabled={operationPending || busy !== null} onClick={() => void setServerMode('local')}>Start locally</Button>}
+              {!server?.shared && <Button color="yellow" variant="light" leftSection={<IconShare size={17} />} loading={busy === 'server-share'} disabled={operationPending || busy !== null} onClick={() => void setServerMode('shared')}>Share service</Button>}
+              {server?.running && <Button color="red" variant="light" leftSection={<IconPlayerStop size={17} />} loading={busy === 'server-stop'} disabled={operationPending || busy !== null} onClick={() => void setServerMode('stopped')}>Stop service</Button>}
+            </Group>
+          </Group>}
+        </Stack>
+      </div>
+
+      <Modal opened={mcpConfig !== null} onClose={() => setMcpConfig(null)} title="Connect an AI assistant" size="lg">
+        <Text size="sm" mb="sm">Copy this MCP setup into a compatible AI assistant. It already points to this VidXP installation and video library.</Text>
+        <Code block className="mcpConfigCode">{mcpConfig}</Code>
+        <Group justify="flex-end" mt="md"><Button leftSection={<IconCopy size={17} />} onClick={() => void copyMcpConfig()}>{copied ? 'Copied' : 'Copy setup'}</Button></Group>
+      </Modal>
+
+      <Modal opened={externalSetupOpened} onClose={() => { if (busy === null) setExternalSetupOpened(false); }} title="Change features for this installation" size="lg" closeOnClickOutside={busy === null} closeOnEscape={busy === null}>
+        <Text size="sm" mb="md">Choose what VidXP can search, where video work runs, and how other apps can connect.</Text>
+        {externalFailure && <Alert color="red" title="Features could not be updated" mb="md">{externalFailure}{externalTechnical && <details className="technicalDetails"><summary>Technical details</summary><Code block>{externalTechnical}</Code></details>}</Alert>}
+        {!externalManifest ? <Loader size="sm" /> : <Stack gap="sm">
+          <Text fw={650}>Search features</Text>
+          {Object.entries(externalManifest.capabilities).map(([id, capability]) => (
+            <Checkbox key={id} checked={externalCapabilities.includes(id)} disabled={busy !== null} onChange={(event) => { const checked = event.currentTarget.checked; setExternalCapabilities((current) => checked ? [...current, id] : current.filter((value) => value !== id)); if (!checked) setExternalSurfaces((current) => current.filter((surface) => surface !== 'worker')); }} label={capability.label} />
+          ))}
+          <Text fw={650} mt="sm">Video processing</Text>
+          {Object.entries(externalManifest.surfaces).filter(([id]) => id === 'worker').map(([id, surface]) => {
+            return <Checkbox key={id} checked={externalSurfaces.includes(id)} disabled={busy !== null} onChange={(event) => { const checked = event.currentTarget.checked; setExternalSurfaces((current) => checked ? [...current, id] : current.filter((value) => value !== id)); if (checked && externalManifest) setExternalCapabilities(Object.keys(externalManifest.capabilities)); }} label={surface.label} description={surface.description} />;
+          })}
+          <Text fw={650} mt="sm">Interfaces and integrations</Text>
+          {Object.entries(externalManifest.surfaces).filter(([id]) => id !== 'worker').map(([id, surface]) => {
+            return <Checkbox key={id} checked={externalSurfaces.includes(id)} disabled={busy !== null} onChange={(event) => { const checked = event.currentTarget.checked; setExternalSurfaces((current) => checked ? [...current, id] : current.filter((value) => value !== id)); }} label={surface.label} description={surface.description} />;
+          })}
+        </Stack>}
+        <Alert color="blue" mt="md" title="Your existing installation stays selected">VidXP reinstalls this isolated app environment at its current version with the selected features. It does not replace it with a Desktop-managed copy.</Alert>
+        <Group justify="flex-end" mt="md">
+          <Button variant="default" disabled={busy !== null} onClick={() => setExternalSetupOpened(false)}>Cancel</Button>
+          <Button loading={busy === 'features'} disabled={busy !== null || ([...externalCapabilities].sort().join(',') === [...profile.capabilities].sort().join(',') && [...externalSurfaces].sort().join(',') === [...profile.surfaces].sort().join(','))} onClick={() => void applyExternalFeatures()}>Apply changes</Button>
+        </Group>
+      </Modal>
     </section>
   );
 }

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -116,6 +116,11 @@ button, [role='radio'], [role='checkbox'], input { -webkit-tap-highlight-color: 
 .managedAttention { margin-top: 1rem; border-color: rgba(255, 212, 59, .3); background: rgba(255, 212, 59, .09); }
 .neutralSetupNote, .runtimeSummary { margin-top: 1rem; padding: .9rem 1rem; border: 1px solid rgba(139,124,255,.22); border-radius: .75rem; background: rgba(35,31,65,.3); color: var(--mantine-color-dimmed); }
 .runtimeSummary { color: inherit; }
+.runtimeControlPanel { margin-top: 1rem; }
+.runtimeControlRow { gap: 1rem; padding: .9rem 0; border-top: 1px solid rgba(255,255,255,.08); }
+.runtimeControlRow > div:first-child { min-width: 0; flex: 1; }
+.connectionDetails { display: grid; gap: .25rem; margin-top: .65rem; }
+.mcpConfigCode { max-height: 22rem; overflow: auto; white-space: pre-wrap; overflow-wrap: anywhere; }
 .confirmationPanel { max-width: 42rem; margin: .75rem auto 0; padding: clamp(1.25rem, 3dvh, 2.25rem); border-radius: 1.25rem; text-align: center; }
 .ownershipNote { display: grid; grid-template-columns: auto 1fr; gap: .35rem 1rem; margin-top: 1.5rem; padding: 1rem; border-radius: .75rem; background: rgba(121,80,242,.12); text-align: left; }
 .ownershipNote span { color: #aeb5c4; }

--- a/desktop/src/tauri.test.ts
+++ b/desktop/src/tauri.test.ts
@@ -8,7 +8,20 @@ import {
   beginManagedSetup,
   displayPath,
   installRuntime,
+  configureExternalInstallation,
+  browserServiceStatus,
+  localServerStatus,
+  localWorkerStatus,
+  mcpClientConfig,
   recheckTargetState,
+  startLocalServer,
+  startSharedBrowser,
+  startSharedServer,
+  startLocalWorker,
+  stopLocalServer,
+  stopBrowserService,
+  stopLocalWorker,
+  targetDoctor,
   targetSetupState,
 } from './tauri';
 
@@ -69,5 +82,43 @@ describe('desktop IPC adapter', () => {
 
     expect(invoke).toHaveBeenNthCalledWith(1, 'begin_managed_setup');
     expect(invoke).toHaveBeenNthCalledWith(2, 'install_runtime', { request });
+  });
+
+  it('maps runtime health, MCP configuration, and service lifecycle commands', async () => {
+    invoke.mockResolvedValue({});
+
+    await targetDoctor();
+    await mcpClientConfig();
+    await localWorkerStatus();
+    await startLocalWorker();
+    await stopLocalWorker();
+    await browserServiceStatus();
+    await startSharedBrowser();
+    await stopBrowserService();
+    await localServerStatus();
+    await startLocalServer();
+    await startSharedServer();
+    await stopLocalServer();
+
+    expect(invoke).toHaveBeenNthCalledWith(1, 'target_doctor');
+    expect(invoke).toHaveBeenNthCalledWith(2, 'mcp_client_config');
+    expect(invoke).toHaveBeenNthCalledWith(3, 'local_worker_status');
+    expect(invoke).toHaveBeenNthCalledWith(4, 'start_local_worker');
+    expect(invoke).toHaveBeenNthCalledWith(5, 'stop_local_worker');
+    expect(invoke).toHaveBeenNthCalledWith(6, 'browser_service_status');
+    expect(invoke).toHaveBeenNthCalledWith(7, 'start_shared_browser');
+    expect(invoke).toHaveBeenNthCalledWith(8, 'stop_browser_service');
+    expect(invoke).toHaveBeenNthCalledWith(9, 'local_server_status');
+    expect(invoke).toHaveBeenNthCalledWith(10, 'start_local_server');
+    expect(invoke).toHaveBeenNthCalledWith(11, 'start_shared_server');
+    expect(invoke).toHaveBeenNthCalledWith(12, 'stop_local_server');
+  });
+
+  it('adds optional surfaces to the selected existing installation', async () => {
+    invoke.mockResolvedValue({ profiles: [], selected_profile_id: null, issues: [] });
+
+    await configureExternalInstallation(['scene'], ['mcp', 'server']);
+
+    expect(invoke).toHaveBeenCalledWith('configure_external_installation', { capabilities: ['scene'], surfaces: ['mcp', 'server'] });
   });
 });

--- a/desktop/src/tauri.ts
+++ b/desktop/src/tauri.ts
@@ -98,6 +98,7 @@ interface WireValidatedTarget {
   data_root: string;
   repository_root: string;
   frontend: FrontendCapability;
+  surfaces: string[];
   validated_at: number;
 }
 
@@ -122,6 +123,7 @@ export interface LocalTargetValidation {
   display_data_root: string;
   can_launch_frontend: boolean;
   frontend: FrontendCapability;
+  surfaces: string[];
 }
 
 export interface LocalTargetInspection extends Omit<WireTargetInspection, 'validated'> {
@@ -197,6 +199,49 @@ export interface InstallTransitionResult {
   setup: TargetSetupState;
 }
 
+export interface DoctorCheck {
+  capability: string;
+  kind: 'distribution' | 'model' | string;
+  name: string;
+  installed_version?: string | null;
+  download_size_bytes?: number | null;
+  ok: boolean;
+  error?: string | null;
+}
+
+export interface DoctorReport {
+  ok: boolean;
+  modalities: string[];
+  checks: DoctorCheck[];
+}
+
+export interface LocalServerStatus {
+  state: 'stopped' | 'starting' | 'ready';
+  running: boolean;
+  shared: boolean;
+  port: number | null;
+  origin: string | null;
+  health_url: string | null;
+  mcp_url: string | null;
+  bearer_token: string | null;
+  detail: string;
+}
+
+export interface BrowserServiceStatus {
+  state: 'stopped' | 'ready';
+  running: boolean;
+  shared: boolean;
+  port: number | null;
+  local_url: string | null;
+  network_url: string | null;
+  detail: string;
+}
+
+export interface LocalWorkerStatus {
+  running: boolean;
+  detail: string;
+}
+
 interface WireInstallTransitionResult {
   install: InstallRuntimeResult;
   setup: WireTargetState;
@@ -255,6 +300,7 @@ export function inspectLocalTarget(executable: string): Promise<LocalTargetInspe
           display_data_root: displayPath(result.validated.data_root),
           can_launch_frontend: result.validated.frontend.launchable,
           frontend: result.validated.frontend,
+          surfaces: result.validated.surfaces,
         }
       : null,
   }));
@@ -306,6 +352,21 @@ export function prepareManagedModels(draftId: string): Promise<TargetSetupState>
   return invoke<WireTargetState>('prepare_managed_models', { draftId }).then(normalizeState);
 }
 export function launchUi(): Promise<void> { return invoke('launch_ui'); }
+export function targetDoctor(): Promise<DoctorReport> { return invoke('target_doctor'); }
+export function configureExternalInstallation(capabilities: string[], surfaces: string[]): Promise<TargetSetupState> {
+  return invoke<WireTargetState>('configure_external_installation', { capabilities, surfaces }).then(normalizeState);
+}
+export function mcpClientConfig(): Promise<string> { return invoke('mcp_client_config'); }
+export function localWorkerStatus(): Promise<LocalWorkerStatus> { return invoke('local_worker_status'); }
+export function startLocalWorker(): Promise<LocalWorkerStatus> { return invoke('start_local_worker'); }
+export function stopLocalWorker(): Promise<LocalWorkerStatus> { return invoke('stop_local_worker'); }
+export function browserServiceStatus(): Promise<BrowserServiceStatus> { return invoke('browser_service_status'); }
+export function startSharedBrowser(): Promise<BrowserServiceStatus> { return invoke('start_shared_browser'); }
+export function stopBrowserService(): Promise<BrowserServiceStatus> { return invoke('stop_browser_service'); }
+export function localServerStatus(): Promise<LocalServerStatus> { return invoke('local_server_status'); }
+export function startLocalServer(): Promise<LocalServerStatus> { return invoke('start_local_server'); }
+export function startSharedServer(): Promise<LocalServerStatus> { return invoke('start_shared_server'); }
+export function stopLocalServer(): Promise<LocalServerStatus> { return invoke('stop_local_server'); }
 
 export function selectedProfile(state: TargetSetupState): TargetProfile | null {
   return state.profiles.find((profile) => profile.id === state.selected_profile_id) ?? null;

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -115,7 +115,11 @@ The target-first screen offers two paths:
   browser, AI-assistant, or app-integration features. For an isolated uv-tool
   installation, the bundled `uv` uses
   `uv tool install --force` to recreate the tool environment from the complete
-  selected extra set while pinning its reported VidXP and Python versions. The
+  selected extra set while retaining its compatible VidXP and Python versions.
+  If its probe contract predates the Desktop management contract, Desktop stops
+  presenting the missing fields as disabled features and instead offers an
+  explicit in-place update to the package version in the bundled runtime
+  manifest. A newer, unsupported probe requires a Desktop update. The
   target is stopped only if Desktop launched its UI/API child, then re-probed
   after the package operation. Other external environment types remain under
   their original package manager.
@@ -140,6 +144,11 @@ disabled, then resolves that package's selected extras. Beta and stable desktop
 releases use production PyPI for both steps, so a pinned prerelease and its
 normal dependencies come from one authoritative index. TestPyPI is used only
 for package-only nightly validation and is never a desktop runtime source.
+The release contract classifies prerelease versions as beta and ordinary
+versions as stable, and the bundled manifest pins the matching Python runtime.
+This release does not include an automatic Desktop updater, so there is not yet
+a user-facing update-channel enrollment preference; adding one belongs with the
+signed updater rather than the Python runtime selector.
 Windows and Linux resolve CPU-only PyTorch wheels using uv's
 `--torch-backend cpu`; macOS uses native PyPI wheels. The custom PyTorch index
 is therefore a resolver input and is not embedded as a package URL, avoiding

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -8,16 +8,20 @@ implementation:
 - an existing compatible `vidxp` executable can be adopted without downloading
   Python, VidXP, FFmpeg, models, or another environment;
 - executable discovery never selects a candidate without user confirmation;
-- adopted installations remain externally owned and cannot be installed,
-  repaired, removed, or broadly stopped by the desktop;
-- the selected capability extras are installed from the exact configured
-  package release only after the managed target is explicitly chosen;
-- the Streamlit browser interface is an optional installation surface;
+- adopted isolated uv-tool installations remain externally owned, but an
+  explicit setup action can reinstall their exact reported package version
+  with a changed search, local-processing, or integration feature set; the desktop does not
+  broadly stop them or silently rebuild them;
+- both Desktop-managed and adopted isolated uv-tool installations can add or
+  remove features by reinstalling the complete selected feature set;
+- local video processing installs the existing `local-worker` extra and is
+  separate from the browser interface, AI-assistant integration, and app
+  integration service;
 - managed repositories and models use the same platform VidXP data directory
   as the CLI; adopted targets retain their reported roots, while managed Python
   and package environments use private desktop application-data directories;
 - the existing DBOS worker remains the durable execution boundary; and
-- closing the desktop process stops the exact interface process it launched,
+- closing the desktop process stops the exact browser and API processes it launched,
   while broad worker shutdown remains limited to desktop-owned runtimes.
 
 The desktop separates shared product data from its private implementation
@@ -102,10 +106,19 @@ The target-first screen offers two paths:
   its canonical path and runs `vidxp desktop-probe --json` before activation.
   The probe is side-effect free and reports its raw launcher identity, package
   version, probe and launch contract metadata, Python identity, local data
-  roots, and browser-interface availability. Desktop compares that report with
+  roots, media initialization, and installed search, processing, and integration
+  availability. Desktop compares that report with
   the exact executable the user selected and decides compatibility. Reopening
   Desktop restores the selected profile immediately and rechecks it once in the
   background.
+  After activation, **Setup options** can change search, local-processing,
+  browser, AI-assistant, or app-integration features. For an isolated uv-tool
+  installation, the bundled `uv` uses
+  `uv tool install --force` to recreate the tool environment from the complete
+  selected extra set while pinning its reported VidXP and Python versions. The
+  target is stopped only if Desktop launched its UI/API child, then re-probed
+  after the package operation. Other external environment types remain under
+  their original package manager.
 - **Desktop-managed runtime** reveals the existing capability, model, and media
   setup only after explicit confirmation. The staged installation and activation
   boundary is unchanged.
@@ -114,9 +127,13 @@ Target profiles use a versioned desktop-private schema. Profile content and the
 selected profile identity are stored separately. No credentials or remote tokens
 are stored; remote targets are intentionally outside this release.
 
-Users select dialogue, scene, and actor capabilities independently. Interfaces
-are selected separately: the browser interface adds the `frontend` extra only
-when selected. Model preparation can be deferred, and a native folder picker
+Users select dialogue, scene, and actor search features independently. Product
+choices map to package extras as follows: **Local video processing** adds
+`local-worker` and includes all built-in search features, **Browser interface**
+adds `frontend`, **AI assistant integration** adds the stdio `mcp` transport,
+and **App integration service** adds the loopback API plus Streamable HTTP MCP
+through `server`. These package names stay out of the normal product flow. Model preparation
+can be deferred, and a native folder picker
 can select a model-cache directory before any model is downloaded.
 The managed runtime acquires the exact VidXP package with dependency resolution
 disabled, then resolves that package's selected extras. Beta and stable desktop
@@ -128,8 +145,8 @@ Windows and Linux resolve CPU-only PyTorch wheels using uv's
 is therefore a resolver input and is not embedded as a package URL, avoiding
 the prior package-publication failure mode. Every selected profile is also
 constrained by a requirements snapshot exported from `uv.lock` and embedded
-during the desktop build for the complete local-worker and frontend dependency
-set. Capability selection controls which packages are installed; the constraints
+during the desktop build for the complete local-worker, frontend, MCP, and
+server dependency set. Capability selection controls which packages are installed; the constraints
 prevent those packages from drifting independently after the desktop binary is
 published.
 
@@ -144,8 +161,8 @@ responsible for their own media-runtime setup.
 
 Optional model preparation invokes the shared `vidxp prepare` command for only
 the selected modalities. A ready managed runtime also exposes a separate
-**Prepare / verify models** action, so verification does not require a fake
-configuration change. Setup, probe, worker-stop, and browser-service children
+**Check downloaded models** action, so verification does not require a fake
+configuration change. Setup, probe, worker lifecycle, and browser-service children
 share one process ownership policy: null stdin, bounded captured output where
 applicable, cancellation and timeouts, and whole-tree termination/reaping.
 Closing the app cancels an active managed operation and stops the exact browser
@@ -157,7 +174,16 @@ VidXP** explicitly starts or reuses the supervised loopback service and opens
 one browser tab. Closing a configured control panel hides it to the tray.
 **Manage VidXP** shows the panel, **Open VidXP** performs the separate browser
 action, and **Quit VidXP** runs supervised shutdown for the interface and any
-Desktop-owned repository worker.
+Desktop-owned repository worker. The active-target panel also reports and
+controls local video processing through the existing `JobService` worker
+lifecycle, reports the app integration service, creates AI-assistant MCP config,
+and presents the existing doctor result as product health rather than raw output.
+The browser and app integration service remain loopback-only by default.
+Explicit sharing controls compose their existing `--share` modes: browser
+sharing reports its LAN URL and warns that it is unauthenticated, while API/MCP
+sharing reports its LAN origin, health URL, MCP URL, selected port, and
+app-managed bearer token. Switching sharing modes replaces only the exact
+Desktop-supervised child process.
 
 ## Implementation dependencies
 
@@ -172,7 +198,11 @@ post-spawn failure path. The loopback UI uses the same ownership abstraction as
 a long-lived service.
 
 React's reducer plus the local async-action helper is sufficient for the finite
-setup lifecycle, so no state framework was added. Generated IPC was evaluated:
+setup lifecycle, so no state framework was added. The active-target screen
+reuses `vidxp doctor --json`, exact-target `vidxp-mcp --print-config`, and the
+`vidxp-api` `/health` endpoint. Desktop supervises only processes it starts;
+external environments retain broad-process ownership; package changes require
+the dedicated, user-confirmed feature update. Generated IPC was evaluated:
 `tauri-specta` would require replacing command macros and build integration
 while the transition service is still changing, and `ts-rs` generates DTOs but
 not the command calls. The current adapter is therefore limited to exact,

--- a/src/vidxp/api_cli.py
+++ b/src/vidxp/api_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -46,6 +47,11 @@ def _arguments(values: Sequence[str] | None = None) -> argparse.Namespace:
             "app-managed bearer token."
         ),
     )
+    parser.add_argument(
+        "--print-share-details",
+        action="store_true",
+        help="Print the resolved LAN connection details as JSON and exit.",
+    )
     return parser.parse_args(values)
 
 
@@ -79,11 +85,23 @@ def _shared_settings(settings, *, host: str, token: str):
     return VidXPSettings.model_validate(payload), active_token
 
 
-def _print_share_details(settings, token: str) -> None:
+def _share_details(settings, token: str) -> dict[str, str | int]:
     origin = f"http://{settings.http_bind_host}:{settings.http_port}"
+    return {
+        "origin": origin,
+        "host": settings.http_bind_host,
+        "port": settings.http_port,
+        "health_url": f"{origin}/health",
+        "mcp_url": f"{origin}/mcp",
+        "bearer_token": token,
+    }
+
+
+def _print_share_details(settings, token: str) -> None:
+    details = _share_details(settings, token)
     print("VidXP network sharing is enabled.", flush=True)
-    print(f"Health: {origin}/health", flush=True)
-    print(f"MCP: {origin}/mcp", flush=True)
+    print(f"Health: {details['health_url']}", flush=True)
+    print(f"MCP: {details['mcp_url']}", flush=True)
     print(f"Bearer token: {token}", flush=True)
     print(
         "Keep this token private. LAN traffic uses HTTP and is not encrypted.",
@@ -99,6 +117,9 @@ def _print_share_details(settings, token: str) -> None:
 
 def main(arguments: Sequence[str] | None = None) -> None:
     options = _arguments(arguments)
+
+    if options.print_share_details and not options.share:
+        raise ValueError("--print-share-details requires --share.")
 
     import uvicorn
 
@@ -132,6 +153,10 @@ def main(arguments: Sequence[str] | None = None) -> None:
             token=configured_token or load_or_create_api_share_token(),
         )
     settings.validate_http_server()
+    if options.print_share_details:
+        assert share_token is not None
+        print(json.dumps(_share_details(settings, share_token), sort_keys=True))
+        return
     if share_token is not None:
         _print_share_details(settings, share_token)
     uvicorn.run(

--- a/src/vidxp/cli_commands/jobs.py
+++ b/src/vidxp/cli_commands/jobs.py
@@ -6,7 +6,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from vidxp.application_models import ListJobsCommand
+from vidxp.application_models import ApplicationError, ListJobsCommand
 from vidxp.cli_support import (
     OutputFormat,
     effective_output_format,
@@ -102,4 +102,49 @@ def stop_worker(ctx: typer.Context) -> None:
 
     state = state_from_context(ctx)
     stopped = state.jobs.stop_worker()
-    emit_json({"stopped": stopped})
+    emit_json(
+        {
+            "running": False,
+            "stopped": stopped,
+            "detail": "Local video processing is stopped.",
+        }
+    )
+
+
+@app.command("start-worker")
+def start_worker(ctx: typer.Context) -> None:
+    """Start or reconnect to the repository's local background worker."""
+
+    state = state_from_context(ctx)
+    state.jobs.start()
+    state.jobs.readiness()
+    emit_json(
+        {
+            "running": True,
+            "detail": "Local video processing is ready.",
+        }
+    )
+
+
+@app.command("worker-status")
+def worker_status(ctx: typer.Context) -> None:
+    """Report whether the repository's local background worker is ready."""
+
+    state = state_from_context(ctx)
+    try:
+        state.jobs.readiness()
+    except ApplicationError as exc:
+        emit_json(
+            {
+                "running": False,
+                "detail": "Local video processing is stopped.",
+                "technical_detail": str(exc),
+            }
+        )
+        return
+    emit_json(
+        {
+            "running": True,
+            "detail": "Local video processing is ready.",
+        }
+    )

--- a/src/vidxp/cli_commands/runtime.py
+++ b/src/vidxp/cli_commands/runtime.py
@@ -565,6 +565,10 @@ def ui(
             fg=typer.colors.YELLOW,
             err=True,
         )
+    if share:
+        from vidxp.network_share import primary_lan_address
+
+        typer.echo(f"Browser UI: http://{primary_lan_address()}:{port or 8501}")
     if show_progress:
         emit_progress("Starting the browser interface...")
     try:

--- a/src/vidxp/frontend.py
+++ b/src/vidxp/frontend.py
@@ -47,17 +47,19 @@ def _publish_desktop_readiness() -> None:
     path = Path(destination).expanduser().resolve(strict=False)
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    payload = {
+        "product": "dev.grayhat.vidxp",
+        "protocol_version": 1,
+        "nonce": nonce,
+        "port": int(port),
+        "pid": os.getpid(),
+    }
+    if os.environ.get("VIDXP_DESKTOP_UI_SHARED") == "1":
+        from vidxp.network_share import primary_lan_address
+
+        payload["network_url"] = f"http://{primary_lan_address()}:{port}"
     temporary.write_text(
-        json.dumps(
-            {
-                "product": "dev.grayhat.vidxp",
-                "protocol_version": 1,
-                "nonce": nonce,
-                "port": int(port),
-                "pid": os.getpid(),
-            },
-            sort_keys=True,
-        ),
+        json.dumps(payload, sort_keys=True),
         encoding="utf-8",
     )
     os.replace(temporary, path)

--- a/src/vidxp/local_probe.py
+++ b/src/vidxp/local_probe.py
@@ -60,21 +60,21 @@ def _module_available(name: str) -> bool:
         return False
 
 
-def _frontend_capability() -> dict[str, Any]:
-    installed = _module_available("vidxp.frontend") and _module_available("streamlit")
-    media_ready = media_runtime_is_initialized()
+def _surface_capability(
+    *,
+    installed: bool,
+    media_ready: bool,
+    unavailable_code: str,
+    available_code: str,
+    unavailable_message: str,
+    unavailable_remediation: str,
+    available_message: str,
+) -> dict[str, Any]:
     launchable = installed and media_ready
     if not installed:
-        code = "frontend_unavailable"
-        message = (
-            "The VidXP command-line installation is usable, but its optional "
-            "browser interface is not installed."
-        )
-        remediation = (
-            "Use the environment or package manager that owns this executable "
-            "to install VidXP with the 'frontend' extra, initialize its media "
-            "runtime if needed, then return to VidXP Desktop and revalidate."
-        )
+        code = unavailable_code
+        message = unavailable_message
+        remediation = unavailable_remediation
     elif not media_ready:
         code = "media_runtime_uninitialized"
         message = (
@@ -87,8 +87,8 @@ def _frontend_capability() -> dict[str, Any]:
             "up its media runtime, then return to VidXP Desktop and revalidate."
         )
     else:
-        code = "frontend_available"
-        message = "The browser interface can be launched."
+        code = available_code
+        message = available_message
         remediation = ""
     return {
         "available": installed,
@@ -98,6 +98,103 @@ def _frontend_capability() -> dict[str, Any]:
         "message": message,
         "remediation": remediation,
     }
+
+
+def _surface_capabilities(
+    search_capabilities: list[str],
+) -> dict[str, dict[str, Any]]:
+    media_ready = media_runtime_is_initialized()
+    owner_instruction = (
+        "Use the environment or package manager that owns this executable"
+    )
+    return {
+        "worker": _surface_capability(
+            installed=(
+                {"dialogue", "scene", "actor"}.issubset(search_capabilities)
+                and _module_available("pydantic_ai")
+            ),
+            media_ready=media_ready,
+            unavailable_code="local_worker_unavailable",
+            available_code="local_worker_available",
+            unavailable_message=(
+                "Local background video processing is not installed in this "
+                "VidXP environment."
+            ),
+            unavailable_remediation=(
+                f"{owner_instruction} to install VidXP with the "
+                "'local-worker' extra, then return to VidXP Desktop and "
+                "revalidate."
+            ),
+            available_message="Local background video processing is available.",
+        ),
+        "browser": _surface_capability(
+            installed=(
+                _module_available("vidxp.frontend")
+                and _module_available("streamlit")
+            ),
+            media_ready=media_ready,
+            unavailable_code="frontend_unavailable",
+            available_code="frontend_available",
+            unavailable_message=(
+                "The VidXP command-line installation is usable, but its "
+                "optional browser interface is not installed."
+            ),
+            unavailable_remediation=(
+                f"{owner_instruction} to install VidXP with the 'frontend' "
+                "extra, initialize its media runtime if needed, then return "
+                "to VidXP Desktop and revalidate."
+            ),
+            available_message="The browser interface can be launched.",
+        ),
+        "mcp": _surface_capability(
+            installed=(
+                _module_available("vidxp.mcp") and _module_available("mcp")
+            ),
+            media_ready=media_ready,
+            unavailable_code="mcp_unavailable",
+            available_code="mcp_available",
+            unavailable_message=(
+                "The local stdio MCP server is not installed in this VidXP "
+                "environment."
+            ),
+            unavailable_remediation=(
+                f"{owner_instruction} to install VidXP with the 'mcp' extra, "
+                "then return to VidXP Desktop and revalidate."
+            ),
+            available_message="The local stdio MCP server is available.",
+        ),
+        "server": _surface_capability(
+            installed=all(
+                _module_available(name)
+                for name in ("vidxp.api", "mcp", "fastapi", "uvicorn")
+            ),
+            media_ready=media_ready,
+            unavailable_code="server_unavailable",
+            available_code="server_available",
+            unavailable_message=(
+                "The local HTTP API and remote MCP server are not installed "
+                "in this VidXP environment."
+            ),
+            unavailable_remediation=(
+                f"{owner_instruction} to install VidXP with the 'server' "
+                "extra, then return to VidXP Desktop and revalidate."
+            ),
+            available_message="The local API and remote MCP server are available.",
+        ),
+    }
+
+
+def _installed_search_capabilities() -> list[str]:
+    from vidxp.capabilities.registry import create_capability_registry
+    from vidxp.dependencies import inspect_requirement
+
+    registry = create_capability_registry()
+    installed = []
+    for name in registry.definitions:
+        requirements = registry.requirements_for((name,))
+        if requirements and all(inspect_requirement(item)["ok"] for item in requirements):
+            installed.append(name)
+    return sorted(installed)
 
 
 def build_desktop_probe(
@@ -136,6 +233,8 @@ def build_desktop_probe(
     )
     resolved_launcher = launcher if launcher is not None else sys.argv[0]
 
+    search_capabilities = _installed_search_capabilities()
+    surfaces = _surface_capabilities(search_capabilities)
     return {
         "product": PRODUCT_ID,
         "product_version": __version__,
@@ -167,5 +266,8 @@ def build_desktop_probe(
             ),
             "desktop_version": desktop_version,
         },
-        "capabilities": {"frontend": _frontend_capability()},
+        # ``capabilities.frontend`` is retained for Desktop protocol v1 clients.
+        "capabilities": {"frontend": surfaces["browser"]},
+        "search_capabilities": search_capabilities,
+        "surfaces": surfaces,
     }

--- a/src/vidxp/mcp_cli.py
+++ b/src/vidxp/mcp_cli.py
@@ -13,13 +13,16 @@ from typing import Any, Sequence
 def mcp_executable() -> str:
     """Return the most reliable executable path for desktop MCP clients."""
 
-    discovered = shutil.which("vidxp-mcp")
-    if discovered is not None:
-        return str(Path(discovered).resolve())
     executable_name = "vidxp-mcp.exe" if os.name == "nt" else "vidxp-mcp"
     sibling = Path(sys.executable).with_name(executable_name)
     if sibling.is_file():
         return str(sibling.resolve())
+    invoked = Path(sys.argv[0])
+    if invoked.name.casefold() in {"vidxp-mcp", "vidxp-mcp.exe"} and invoked.is_file():
+        return str(invoked.resolve())
+    discovered = shutil.which("vidxp-mcp")
+    if discovered is not None:
+        return str(Path(discovered).resolve())
     return "vidxp-mcp"
 
 

--- a/tests/test_api_cli.py
+++ b/tests/test_api_cli.py
@@ -1,5 +1,6 @@
 import unittest
 import asyncio
+import json
 from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
@@ -133,6 +134,37 @@ class ApiCliTests(unittest.TestCase):
             create_app.return_value,
             host="127.0.0.1",
             port=32192,
+        )
+
+    def test_share_details_can_be_resolved_without_starting_the_server(self):
+        import uvicorn
+
+        output = StringIO()
+        with (
+            patch.object(uvicorn, "run") as run,
+            patch(
+                "vidxp.api_cli.primary_lan_address",
+                return_value="192.168.100.131",
+            ),
+            patch(
+                "vidxp.api_cli.load_or_create_api_share_token",
+                return_value="x" * 43,
+            ),
+            redirect_stdout(output),
+        ):
+            main(["--share", "--port", "32192", "--print-share-details"])
+
+        run.assert_not_called()
+        self.assertEqual(
+            json.loads(output.getvalue()),
+            {
+                "origin": "http://192.168.100.131:32192",
+                "host": "192.168.100.131",
+                "port": 32192,
+                "health_url": "http://192.168.100.131:32192/health",
+                "mcp_url": "http://192.168.100.131:32192/mcp",
+                "bearer_token": "x" * 43,
+            },
         )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,7 @@ from vidxp.media_runtime import (
 )
 from vidxp.settings import ApplicationMode
 from vidxp.application_models import (
+    ApplicationError,
     Artifact,
     ArtifactJobResult,
     CapabilityDependencyCheck,
@@ -353,11 +354,54 @@ class CliTests(unittest.TestCase):
         )
         self.jobs.stop_worker.assert_called_once_with()
 
+    def test_worker_lifecycle_commands_use_the_existing_job_service(self):
+        started = self.invoke(["jobs", "start-worker"])
+
+        self.assertEqual(started.exit_code, 0, started.output)
+        self.assertTrue(json.loads(started.output)["running"])
+        self.jobs.start.assert_called_once_with()
+        self.jobs.readiness.assert_called_once_with()
+
+        self.jobs.reset_mock()
+        status = self.invoke(["jobs", "worker-status"])
+        self.assertEqual(status.exit_code, 0, status.output)
+        self.assertTrue(json.loads(status.output)["running"])
+        self.jobs.readiness.assert_called_once_with()
+
+        self.jobs.reset_mock()
+        self.jobs.readiness.side_effect = ApplicationError(
+            "job_backend_unavailable",
+            ErrorCategory.unavailable,
+            "The worker is not running.",
+        )
+        stopped = self.invoke(["jobs", "worker-status"])
+        self.assertEqual(stopped.exit_code, 0, stopped.output)
+        self.assertFalse(json.loads(stopped.output)["running"])
+
+        self.jobs.reset_mock()
+        self.jobs.stop_worker.return_value = True
+        stopped = self.invoke(["jobs", "stop-worker"])
+        self.assertEqual(stopped.exit_code, 0, stopped.output)
+        self.assertEqual(
+            json.loads(stopped.output),
+            {
+                "running": False,
+                "stopped": True,
+                "detail": "Local video processing is stopped.",
+            },
+        )
+
     def test_ui_share_uses_streamlit_wildcard_bind_and_warns(self):
-        with patch(
-            "vidxp.frontend.main",
-            side_effect=SystemExit(0),
-        ) as frontend:
+        with (
+            patch(
+                "vidxp.frontend.main",
+                side_effect=SystemExit(0),
+            ) as frontend,
+            patch(
+                "vidxp.network_share.primary_lan_address",
+                return_value="192.168.100.131",
+            ),
+        ):
             result = self.invoke(["ui", "--share"])
 
         self.assertEqual(result.exit_code, 0, result.output)
@@ -366,7 +410,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("--server.showEmailPrompt=false", arguments)
         self.assertIn("--browser.gatherUsageStats=false", arguments)
         self.assertIn("has no authentication", result.output)
-        self.assertNotIn("Browser UI:", result.output)
+        self.assertIn("Browser UI: http://192.168.100.131:8501", result.output)
 
     def test_snippet_rejects_an_inverted_time_range_before_submission(self):
         result = self.invoke(

--- a/tests/test_local_probe.py
+++ b/tests/test_local_probe.py
@@ -36,6 +36,10 @@ class LocalProbeTests(unittest.TestCase):
             patch("vidxp.local_probe.__version__", "0.4.0b0"),
             patch("vidxp.local_probe._module_available", return_value=True),
             patch(
+                "vidxp.local_probe._installed_search_capabilities",
+                return_value=["actor", "dialogue", "scene"],
+            ),
+            patch(
                 "vidxp.local_probe.media_runtime_is_initialized",
                 return_value=True,
             ),
@@ -75,6 +79,15 @@ class LocalProbeTests(unittest.TestCase):
             },
         )
         self.assertTrue(payload["capabilities"]["frontend"]["launchable"])
+        self.assertEqual(
+            set(payload["surfaces"]),
+            {"worker", "browser", "mcp", "server"},
+        )
+        self.assertEqual(
+            payload["search_capabilities"],
+            ["actor", "dialogue", "scene"],
+        )
+        self.assertTrue(all(surface["launchable"] for surface in payload["surfaces"].values()))
 
     def test_differing_package_versions_remain_contract_compatible(self):
         payload = self.build(desktop_version="0.5.0")
@@ -91,6 +104,10 @@ class LocalProbeTests(unittest.TestCase):
         with (
             patch("vidxp.local_probe.__version__", "0.4.0b0"),
             patch("vidxp.local_probe._module_available", return_value=False),
+            patch(
+                "vidxp.local_probe._installed_search_capabilities",
+                return_value=[],
+            ),
             patch(
                 "vidxp.local_probe.media_runtime_is_initialized",
                 return_value=False,
@@ -110,6 +127,9 @@ class LocalProbeTests(unittest.TestCase):
         self.assertIn("command-line installation is usable", frontend["message"])
         self.assertIn("package manager", frontend["remediation"])
         self.assertIn("'frontend' extra", frontend["remediation"])
+        self.assertFalse(payload["surfaces"]["mcp"]["launchable"])
+        self.assertFalse(payload["surfaces"]["server"]["launchable"])
+        self.assertFalse(payload["surfaces"]["worker"]["launchable"])
 
     def test_command_bypasses_composition_and_does_not_create_roots(self):
         with TemporaryDirectory() as directory:
@@ -121,6 +141,10 @@ class LocalProbeTests(unittest.TestCase):
                 patch(
                     "vidxp.local_probe._module_available",
                     return_value=False,
+                ),
+                patch(
+                    "vidxp.local_probe._installed_search_capabilities",
+                    return_value=[],
                 ),
                 patch(
                     "vidxp.local_probe.media_runtime_is_initialized",

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -570,8 +570,14 @@ class PackagingTests(unittest.TestCase):
         dynamic_extras = project["tool"]["setuptools"]["dynamic"][
             "optional-dependencies"
         ]
-        self.assertEqual(set(manifest["surfaces"]), {"browser"})
+        self.assertEqual(
+            set(manifest["surfaces"]),
+            {"worker", "browser", "mcp", "server"},
+        )
+        self.assertTrue(manifest["surfaces"]["worker"]["default"])
         self.assertTrue(manifest["surfaces"]["browser"]["default"])
+        self.assertFalse(manifest["surfaces"]["mcp"]["default"])
+        self.assertFalse(manifest["surfaces"]["server"]["default"])
         for surface in manifest["surfaces"].values():
             self.assertIn(surface["extra"], dynamic_extras)
         for capability in manifest["capabilities"].values():


### PR DESCRIPTION
## Summary

- let Desktop adopt or manage a VidXP installation and configure the complete selected feature set, including search capabilities, local processing, browser, MCP, and API service extras
- require the feature/service inventory contract before showing setup state; older selected uv installations get a product-facing in-place update path using the release manifest instead of misleading unchecked options
- expose product-facing readiness, MCP configuration, worker lifecycle, API lifecycle, and browser/API LAN-sharing controls with ports and connection URLs
- show readiness in a dedicated progress dialog with elapsed time, the search features actually checked, and named package/runtime/model results
- keep all launched commands inside the centralized supervised process runner, including Windows no-console and whole-process-tree ownership
- project the selected installation and supervised browser, processing, and app-service state into a concise tray menu with contextual start, share, stop, URLs, and update-required status

## Why

The Desktop app primarily acted as a browser shim and exposed package/runtime concepts using developer-oriented names. Existing installations also could not change the same optional features as Desktop-managed installations, and the existing worker, doctor, MCP, API, and `--share` primitives were not represented in the product flow.

During upgrade testing, an older probe omitted the inventory fields introduced by this change. Desktop deserialized those missing fields as empty collections, making a working legacy browser look disabled in Setup options and making unknown search state look like no installed features. The compatibility gate now distinguishes a missing management contract from a genuinely empty inventory and offers an explicit update of the same external uv-tool environment. Package versions continue to come only from the release manifest; Release Please remains the version owner.

## User impact

Users can choose an existing isolated uv-tool installation or a Desktop-managed runtime, add or remove supported features, check whether the installation is usable, configure an AI assistant, and start or stop local processing and integration services. Older saved uv installations are no longer represented using fabricated empty state: the app explains that an update is required and opens the feature selection with normal defaults before updating that same installation. Browser and API sharing remain explicit: browser sharing warns that it is unauthenticated, while API/MCP sharing presents the bearer token and resolved LAN addresses.

The system tray now shows the active installation state and concise service submenus. It preserves Open VidXP as the primary action, exposes only valid start/share/stop controls, includes the running browser or app-service URL, and keeps setup, readiness, tokens, and MCP configuration in Manage VidXP. Tray actions reuse the same supervised commands as the main window and never open a terminal.

Readiness now explains that it checks FFmpeg, installed packages, runtime imports, and downloaded models. While the existing JSON CLI contract runs, the app shows elapsed time and its expected scope; after completion it names the returned modalities and every check rather than showing an unexplained spinner or a generic green result.

## Release channels

The existing release contract continues to classify beta and stable builds and pins the matching Python runtime in the bundled manifest. This PR does not introduce an automatic Desktop updater or a fake channel preference; update-channel enrollment belongs with the signed updater work.

## Validation

- isolated `uv tool install` from the working tree with `local-worker`, `frontend`, `mcp`, and `server` extras — installed all six executables without touching the user's installation
- real Windows Desktop probe against that isolated tool — accepted; reported actor, dialogue, scene, browser, worker, MCP, and server
- isolated `doctor --modalities actor,dialogue,scene --json` against the configured local data — passed all 32 package, runtime, model, storage, and media checks
- `uv run ruff check src tests` — passed
- `uv run pytest tests/test_local_probe.py -q` — 10 passed, 1 skipped
- prior targeted Python suite for the full PR — 94 passed, 1 skipped
- `cargo fmt --check` — passed
- `cargo check` and `cargo clippy --all-targets -- -D warnings` — passed
- `cargo test --locked --lib` on Windows — 77 passed
- `npm run check` — typecheck, lint, 36 tests, and production build passed
- `uv run python utils/release_contract.py --channel beta` — passed with all version sources unchanged
- `git diff --check` — passed

BEGIN_COMMIT_OVERRIDE
feat(desktop): set up an existing installation or create a Desktop-managed one, choose its features, verify readiness, and control local services from the app
END_COMMIT_OVERRIDE
