### PR TITLE
feat(mcp): bundle VidXP plugin and install it from Desktop

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,10 @@ include LICENSE
 include docs/images/logo.png
 recursive-include src/vidxp/assets/upload_page *
 recursive-include src/vidxp/assets/artifact_download *
+recursive-include src/vidxp/assets/mcp_app *
+include src/vidxp/bundled_plugins/vidxp/.mcp.json
+include src/vidxp/bundled_plugins/vidxp/.codex-plugin/plugin.json
+recursive-include src/vidxp/bundled_plugins/vidxp/skills *
 include web/upload-page/package.json
 include web/upload-page/package-lock.json
 include web/upload-page/scripts/build.mjs

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ shipped inside the Python package. The plugin keeps both skills and the local
 `vidxp-mcp` server definition together. Its MCP App resource also gives
 compatible hosts an interactive upload and evidence-review view; every workflow
 continues to work through ordinary MCP tool results when a host has no UI.
+When the MCP feature is installed, VidXP Desktop can configure another MCP
+client or install the complete local plugin directly into Codex.
 
 - [Python, HTTP, and MCP installation](INSTALLATION_GUIDE.md)
 - [ChatGPT and Codex plugin integration](docs/integrations/openai-plugin.md)

--- a/README.md
+++ b/README.md
@@ -166,11 +166,14 @@ VidXP includes reusable skill source folders for the two common agent workflows:
 - [Ingest and index videos](skills/vidxp-ingest-video/SKILL.md)
 - [Find moments and return inspectable evidence](skills/vidxp-find-video-evidence/SKILL.md)
 
-Download a skill folder and add it through a supported ChatGPT desktop or Codex
-Skills surface. The skills require a connected VidXP MCP server; installable
-plugin packaging for additional ChatGPT surfaces will follow separately.
+Download a skill folder directly, or install the versioned VidXP plugin bundle
+shipped inside the Python package. The plugin keeps both skills and the local
+`vidxp-mcp` server definition together. Its MCP App resource also gives
+compatible hosts an interactive upload and evidence-review view; every workflow
+continues to work through ordinary MCP tool results when a host has no UI.
 
 - [Python, HTTP, and MCP installation](INSTALLATION_GUIDE.md)
+- [ChatGPT and Codex plugin integration](docs/integrations/openai-plugin.md)
 - [Optional capability packages](INSTALLATION_GUIDE.md#optional-dependency-extras)
 - [Coolify server setup](docs/deployment/coolify.md)
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -486,6 +486,17 @@ struct LocalWorkerStatus {
     detail: String,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct CodexPluginInstallResult {
+    plugin_name: String,
+    plugin_id: Option<String>,
+    plugin_version: String,
+    marketplace_name: String,
+    marketplace_path: String,
+    installed_path: Option<String>,
+    detail: String,
+}
+
 #[derive(Clone)]
 struct TrayMenuItems {
     installation: MenuItem<tauri::Wry>,
@@ -3641,6 +3652,49 @@ async fn mcp_client_config(
     .map_err(|error| format!("MCP configuration stopped unexpectedly: {error}"))?
 }
 
+#[tauri::command]
+async fn install_codex_plugin(
+    app: AppHandle,
+    state: tauri::State<'_, DesktopState>,
+) -> Result<CodexPluginInstallResult, String> {
+    let _active = state.active_operations.register()?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let (profile, paths) = selected_target_context(&app)?;
+        if !profile
+            .surfaces
+            .iter()
+            .any(|surface| surface == "mcp" || surface == "server")
+        {
+            return Err(
+                "The selected VidXP installation does not expose an installed MCP surface.".into(),
+            );
+        }
+        let installer_path = target_companion_executable(&profile, "vidxp-codex-plugin");
+        if !installer_path.is_file() {
+            return Err(format!(
+                "The selected installation did not provide {}. Update VidXP and try again.",
+                installer_path.display()
+            ));
+        }
+        let marketplace_root = paths.private_data.join("codex-marketplace");
+        let mut command = target_command(&profile, &paths, &installer_path);
+        command
+            .arg("--marketplace-root")
+            .arg(&marketplace_root)
+            .arg("--repository")
+            .arg("default")
+            .arg("--index-directory")
+            .arg(&profile.repository_root)
+            .arg("--data-dir")
+            .arg(&profile.data_root);
+        let output = checked_output(command, "VidXP Codex plugin setup")?;
+        serde_json::from_slice(&output.stdout)
+            .map_err(|error| format!("VidXP returned invalid Codex setup details: {error}"))
+    })
+    .await
+    .map_err(|error| format!("Codex plugin setup stopped unexpectedly: {error}"))?
+}
+
 fn execute_worker_action(app: &AppHandle, action: &str) -> Result<LocalWorkerStatus, String> {
     let (profile, paths) = selected_target_context(app)?;
     if !profile.surfaces.iter().any(|surface| surface == "worker") {
@@ -4601,6 +4655,7 @@ pub fn run() {
             target_doctor,
             configure_external_installation,
             mcp_client_config,
+            install_codex_plugin,
             local_worker_status,
             start_local_worker,
             stop_local_worker,

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -109,7 +109,7 @@ describe('desktop target lifecycle', () => {
     mocks.mcpClientConfig.mockResolvedValue('{"mcpServers":{"vidxp":{"command":"vidxp-mcp"}}}');
     mocks.installCodexPlugin.mockResolvedValue({
       plugin_name: 'vidxp', plugin_id: 'vidxp@vidxp-local', plugin_version: '0.4.0+codex.1234',
-      marketplace_name: 'vidxp-local', marketplace_path: 'C:\\Data\\codex-marketplace\\marketplace.json',
+      marketplace_name: 'vidxp-local', marketplace_path: 'C:\\Data\\codex-marketplace\\.agents\\plugins\\marketplace.json',
       installed_path: 'C:\\Users\\test\\.codex\\plugins\\vidxp',
       detail: 'VidXP is installed in Codex with its MCP server and skills. Start a new Codex chat to use the updated plugin.',
     });

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
   prepareManagedModels: vi.fn(), onManagedSetupProgress: vi.fn(),
   runtimeManifest: vi.fn(), runtimeStatus: vi.fn(), launchUi: vi.fn(),
   chooseModelDirectory: vi.fn(), modelDirectoryInventory: vi.fn(),
-  targetDoctor: vi.fn(), mcpClientConfig: vi.fn(), localServerStatus: vi.fn(), localWorkerStatus: vi.fn(), browserServiceStatus: vi.fn(),
+  targetDoctor: vi.fn(), mcpClientConfig: vi.fn(), installCodexPlugin: vi.fn(), localServerStatus: vi.fn(), localWorkerStatus: vi.fn(), browserServiceStatus: vi.fn(),
   startLocalServer: vi.fn(), startSharedServer: vi.fn(), stopLocalServer: vi.fn(), startSharedBrowser: vi.fn(), stopBrowserService: vi.fn(), startLocalWorker: vi.fn(), stopLocalWorker: vi.fn(), configureExternalInstallation: vi.fn(),
 }));
 
@@ -107,6 +107,12 @@ describe('desktop target lifecycle', () => {
     mocks.launchUi.mockResolvedValue(undefined);
     mocks.targetDoctor.mockResolvedValue({ ok: true, modalities: ['scene'], checks: [{ capability: 'media', kind: 'distribution', name: 'ffmpeg', ok: true }] });
     mocks.mcpClientConfig.mockResolvedValue('{"mcpServers":{"vidxp":{"command":"vidxp-mcp"}}}');
+    mocks.installCodexPlugin.mockResolvedValue({
+      plugin_name: 'vidxp', plugin_id: 'vidxp@vidxp-local', plugin_version: '0.4.0+codex.1234',
+      marketplace_name: 'vidxp-local', marketplace_path: 'C:\\Data\\codex-marketplace\\marketplace.json',
+      installed_path: 'C:\\Users\\test\\.codex\\plugins\\vidxp',
+      detail: 'VidXP is installed in Codex with its MCP server and skills. Start a new Codex chat to use the updated plugin.',
+    });
     mocks.browserServiceStatus.mockResolvedValue({ state: 'stopped', running: false, shared: false, port: null, local_url: null, network_url: null, detail: 'Stopped.' });
     mocks.startSharedBrowser.mockResolvedValue({ state: 'ready', running: true, shared: true, port: 8501, local_url: 'http://127.0.0.1:8501', network_url: 'http://192.168.1.20:8501', detail: 'Shared.' });
     mocks.stopBrowserService.mockResolvedValue({ state: 'stopped', running: false, shared: false, port: null, local_url: null, network_url: null, detail: 'Stopped.' });
@@ -176,7 +182,11 @@ describe('desktop target lifecycle', () => {
     expect(await screen.findByText('VidXP is ready')).toBeVisible();
     expect(mocks.targetDoctor).toHaveBeenCalledTimes(1);
 
-    await user.click(screen.getByRole('button', { name: 'Set up connection' }));
+    await user.click(screen.getByRole('button', { name: 'Set up in Codex' }));
+    expect(await screen.findByText('VidXP is installed in Codex with its MCP server and skills. Start a new Codex chat to use the updated plugin.')).toBeVisible();
+    expect(mocks.installCodexPlugin).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'Copy MCP setup' }));
     expect(await screen.findByRole('heading', { name: 'Connect an AI assistant' })).toBeVisible();
     expect(mocks.mcpClientConfig).toHaveBeenCalledTimes(1);
 
@@ -211,7 +221,8 @@ describe('desktop target lifecycle', () => {
     await user.click(screen.getByRole('button', { name: 'Apply changes' }));
 
     await waitFor(() => expect(mocks.configureExternalInstallation).toHaveBeenCalledWith([], ['worker', 'browser', 'mcp']));
-    expect(await screen.findByRole('button', { name: 'Set up connection' })).toBeVisible();
+    expect(await screen.findByRole('button', { name: 'Set up in Codex' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Copy MCP setup' })).toBeVisible();
   });
 
   it('offers an in-place manifest update when the selected runtime contract is too old', async () => {

--- a/desktop/src/components/TargetSummary.tsx
+++ b/desktop/src/components/TargetSummary.tsx
@@ -1,11 +1,12 @@
 import { Alert, Badge, Button, Checkbox, Code, Group, Loader, Modal, Stack, Text, Title } from '@mantine/core';
-import { IconActivityHeartbeat, IconCopy, IconExternalLink, IconPlayerPlay, IconPlayerStop, IconRefresh, IconSettings, IconShare, IconTerminal2 } from '@tabler/icons-react';
+import { IconActivityHeartbeat, IconCopy, IconExternalLink, IconPlugConnected, IconPlayerPlay, IconPlayerStop, IconRefresh, IconSettings, IconShare, IconTerminal2 } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 
 import {
   errorMessage,
   browserServiceStatus,
   configureExternalInstallation,
+  installCodexPlugin,
   localServerStatus,
   localWorkerStatus,
   mcpClientConfig,
@@ -20,6 +21,7 @@ import {
   targetDoctor,
   type DoctorReport,
   type BrowserServiceStatus,
+  type CodexPluginInstallResult,
   type LocalServerStatus,
   type LocalWorkerStatus,
   type RuntimeManifest,
@@ -55,7 +57,8 @@ export function TargetSummary({ profile, validationError, checking, operationPen
   const [browser, setBrowser] = useState<BrowserServiceStatus | null>(null);
   const [worker, setWorker] = useState<LocalWorkerStatus | null>(null);
   const [mcpConfig, setMcpConfig] = useState<string | null>(null);
-  const [busy, setBusy] = useState<'doctor' | 'config' | 'features' | 'worker-start' | 'worker-stop' | 'browser-share' | 'browser-stop' | 'server-start' | 'server-share' | 'server-stop' | null>(null);
+  const [codexSetup, setCodexSetup] = useState<CodexPluginInstallResult | null>(null);
+  const [busy, setBusy] = useState<'doctor' | 'config' | 'codex' | 'features' | 'worker-start' | 'worker-stop' | 'browser-share' | 'browser-stop' | 'server-start' | 'server-share' | 'server-stop' | null>(null);
   const [runtimeFailure, setRuntimeFailure] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [shareCopied, setShareCopied] = useState(false);
@@ -81,6 +84,7 @@ export function TargetSummary({ profile, validationError, checking, operationPen
   useEffect(() => {
     setDoctor(null);
     setMcpConfig(null);
+    setCodexSetup(null);
     setRuntimeFailure(null);
     if (!serverAvailable) {
       setServer(null);
@@ -173,6 +177,19 @@ export function TargetSummary({ profile, validationError, checking, operationPen
       setMcpConfig(await mcpClientConfig());
     } catch (error) {
       setRuntimeFailure(errorMessage(error, 'VidXP could not create the AI client setup.'));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function setupCodex() {
+    setBusy('codex');
+    setRuntimeFailure(null);
+    setCodexSetup(null);
+    try {
+      setCodexSetup(await installCodexPlugin());
+    } catch (error) {
+      setRuntimeFailure(errorMessage(error, 'VidXP could not install the Codex plugin.'));
     } finally {
       setBusy(null);
     }
@@ -379,9 +396,17 @@ export function TargetSummary({ profile, validationError, checking, operationPen
           </Group>}
 
           {mcpAvailable && <Group justify="space-between" className="runtimeControlRow">
-            <div><Text fw={650}>AI assistant integration</Text><Text size="sm" className="mutedText">Create the MCP setup needed to use VidXP from a compatible AI assistant.</Text></div>
-            <Button variant="light" leftSection={<IconTerminal2 size={17} />} loading={busy === 'config'} disabled={operationPending || busy !== null} onClick={() => void loadMcpConfig()}>Set up connection</Button>
+            <div><Text fw={650}>AI assistant integration</Text><Text size="sm" className="mutedText">Install VidXP's MCP server and skills in Codex, or copy the MCP setup for another compatible assistant.</Text></div>
+            <Group gap="xs" justify="flex-end">
+              <Button leftSection={<IconPlugConnected size={17} />} loading={busy === 'codex'} disabled={operationPending || busy !== null} onClick={() => void setupCodex()}>Set up in Codex</Button>
+              <Button variant="light" leftSection={<IconTerminal2 size={17} />} loading={busy === 'config'} disabled={operationPending || busy !== null} onClick={() => void loadMcpConfig()}>Copy MCP setup</Button>
+            </Group>
           </Group>}
+
+          {codexSetup && <Alert color="teal" title="VidXP is installed in Codex">
+            <Text size="sm">{codexSetup.detail}</Text>
+            <details className="technicalDetails"><summary>Installation details</summary><Text size="xs">Plugin {codexSetup.plugin_version} from {codexSetup.marketplace_name}</Text>{codexSetup.installed_path && <Code className="pathCode">{codexSetup.installed_path}</Code>}</details>
+          </Alert>}
 
           {serverAvailable && <Group justify="space-between" className="runtimeControlRow">
             <div>

--- a/desktop/src/tauri.test.ts
+++ b/desktop/src/tauri.test.ts
@@ -9,6 +9,7 @@ import {
   beginManagedSetup,
   displayPath,
   installRuntime,
+  installCodexPlugin,
   configureExternalInstallation,
   browserServiceStatus,
   localServerStatus,
@@ -108,6 +109,7 @@ describe('desktop IPC adapter', () => {
 
     await targetDoctor();
     await mcpClientConfig();
+    await installCodexPlugin();
     await localWorkerStatus();
     await startLocalWorker();
     await stopLocalWorker();
@@ -121,16 +123,17 @@ describe('desktop IPC adapter', () => {
 
     expect(invoke).toHaveBeenNthCalledWith(1, 'target_doctor');
     expect(invoke).toHaveBeenNthCalledWith(2, 'mcp_client_config');
-    expect(invoke).toHaveBeenNthCalledWith(3, 'local_worker_status');
-    expect(invoke).toHaveBeenNthCalledWith(4, 'start_local_worker');
-    expect(invoke).toHaveBeenNthCalledWith(5, 'stop_local_worker');
-    expect(invoke).toHaveBeenNthCalledWith(6, 'browser_service_status');
-    expect(invoke).toHaveBeenNthCalledWith(7, 'start_shared_browser');
-    expect(invoke).toHaveBeenNthCalledWith(8, 'stop_browser_service');
-    expect(invoke).toHaveBeenNthCalledWith(9, 'local_server_status');
-    expect(invoke).toHaveBeenNthCalledWith(10, 'start_local_server');
-    expect(invoke).toHaveBeenNthCalledWith(11, 'start_shared_server');
-    expect(invoke).toHaveBeenNthCalledWith(12, 'stop_local_server');
+    expect(invoke).toHaveBeenNthCalledWith(3, 'install_codex_plugin');
+    expect(invoke).toHaveBeenNthCalledWith(4, 'local_worker_status');
+    expect(invoke).toHaveBeenNthCalledWith(5, 'start_local_worker');
+    expect(invoke).toHaveBeenNthCalledWith(6, 'stop_local_worker');
+    expect(invoke).toHaveBeenNthCalledWith(7, 'browser_service_status');
+    expect(invoke).toHaveBeenNthCalledWith(8, 'start_shared_browser');
+    expect(invoke).toHaveBeenNthCalledWith(9, 'stop_browser_service');
+    expect(invoke).toHaveBeenNthCalledWith(10, 'local_server_status');
+    expect(invoke).toHaveBeenNthCalledWith(11, 'start_local_server');
+    expect(invoke).toHaveBeenNthCalledWith(12, 'start_shared_server');
+    expect(invoke).toHaveBeenNthCalledWith(13, 'stop_local_server');
   });
 
   it('adds optional surfaces to the selected existing installation', async () => {

--- a/desktop/src/tauri.ts
+++ b/desktop/src/tauri.ts
@@ -254,6 +254,16 @@ export interface LocalWorkerStatus {
   detail: string;
 }
 
+export interface CodexPluginInstallResult {
+  plugin_name: string;
+  plugin_id: string | null;
+  plugin_version: string;
+  marketplace_name: string;
+  marketplace_path: string;
+  installed_path: string | null;
+  detail: string;
+}
+
 interface WireInstallTransitionResult {
   install: InstallRuntimeResult;
   setup: WireTargetState;
@@ -374,6 +384,7 @@ export function configureExternalInstallation(capabilities: string[], surfaces: 
   return invoke<WireTargetState>('configure_external_installation', { capabilities, surfaces }).then(normalizeState);
 }
 export function mcpClientConfig(): Promise<string> { return invoke('mcp_client_config'); }
+export function installCodexPlugin(): Promise<CodexPluginInstallResult> { return invoke('install_codex_plugin'); }
 export function localWorkerStatus(): Promise<LocalWorkerStatus> { return invoke('local_worker_status'); }
 export function startLocalWorker(): Promise<LocalWorkerStatus> { return invoke('start_local_worker'); }
 export function stopLocalWorker(): Promise<LocalWorkerStatus> { return invoke('stop_local_worker'); }

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -187,8 +187,18 @@ one browser tab. Closing a configured control panel hides it to the tray.
 action, and **Quit VidXP** runs supervised shutdown for the interface and any
 Desktop-owned repository worker. The active-target panel also reports and
 controls local video processing through the existing `JobService` worker
-lifecycle, reports the app integration service, creates AI-assistant MCP config,
-and presents the existing doctor result as product health rather than raw output.
+lifecycle, reports the app integration service, creates copyable AI-assistant
+MCP config, installs the bundled MCP-and-skills plugin directly into Codex, and
+presents the existing doctor result as product health rather than raw output.
+Codex setup exports a target-specific copy of the plugin from the selected
+VidXP runtime into a dedicated Desktop-private `vidxp-local` marketplace. The
+copy keeps the versioned skills but replaces its generic MCP command with the
+selected runtime's absolute executable, repository, and data paths. Desktop
+then uses `codex plugin marketplace add --json` and
+`codex plugin add vidxp@vidxp-local --json`; it never edits Codex configuration
+or the user's personal marketplace by hand. Re-running setup refreshes the
+managed bundle using a deterministic plugin-version cache key. A new Codex chat
+is required before the refreshed skills and tools are available.
 The browser and app integration service remain loopback-only by default.
 Explicit sharing controls compose their existing `--share` modes: browser
 sharing reports its LAN URL and warns that it is unauthenticated, while API/MCP

--- a/docs/integrations/openai-plugin.md
+++ b/docs/integrations/openai-plugin.md
@@ -16,6 +16,27 @@ The root skill folders remain the authoring source. Packaging tests require the
 bundled snapshot to match their file inventory and text exactly, and Release
 Please keeps the plugin manifest version aligned with the Python package.
 
+## Install in Codex
+
+With **AI assistant integration** enabled, VidXP Desktop shows two distinct
+actions:
+
+- **Set up in Codex** exports a target-specific copy of this bundle to a
+  Desktop-managed `vidxp-local` marketplace, registers that marketplace through
+  the Codex CLI, and installs the plugin. The generated `.mcp.json` pins the
+  selected installation's absolute `vidxp-mcp` command, repository, and data
+  paths, so Codex does not depend on its process `PATH`.
+- **Copy MCP setup** retains the transport-only JSON flow for other compatible
+  local MCP clients.
+
+The Codex action installs the MCP server and both skills as one unit. It uses
+the documented JSON forms of `codex plugin marketplace add` and
+`codex plugin add`, leaves personal marketplace files and `config.toml`
+untouched, and asks the user to start a new Codex chat after installation. The
+exported marketplace lives in VidXP Desktop's private application-data
+directory; the canonical distributable bundle remains checked into this
+repository and packaged in every VidXP wheel.
+
 ## Interactive MCP App
 
 `create_media_upload` and `get_job_evidence` advertise the same

--- a/docs/integrations/openai-plugin.md
+++ b/docs/integrations/openai-plugin.md
@@ -1,0 +1,66 @@
+# ChatGPT and Codex plugin integration
+
+VidXP ships one versioned plugin bundle with its Python distribution. The
+bundle combines the local MCP server definition with VidXP's canonical ingest
+and evidence-search skills, while the MCP server exposes an optional interactive
+view for hosts that implement MCP Apps.
+
+The packaged bundle lives at
+`src/vidxp/bundled_plugins/vidxp/` and contains:
+
+- `.codex-plugin/plugin.json`, the plugin manifest;
+- `.mcp.json`, which starts the installed `vidxp-mcp` command; and
+- `skills/`, a release snapshot of the canonical root `skills/` folders.
+
+The root skill folders remain the authoring source. Packaging tests require the
+bundled snapshot to match their file inventory and text exactly, and Release
+Please keeps the plugin manifest version aligned with the Python package.
+
+## Interactive MCP App
+
+`create_media_upload` and `get_job_evidence` advertise the same
+`ui://vidxp/evidence-review-v1.html` resource. A compatible host can render it
+inline to:
+
+- open VidXP's short-lived HTTPS upload page and refresh session progress;
+- review answer claims and annotated evidence-board pages;
+- select up to ten ranked evidence IDs; and
+- request exact keyframes or clips with `materialize_job_evidence` without
+  rerunning retrieval.
+
+The component completes the MCP Apps `ui/initialize` handshake, then uses the
+standard `tools/call`, `ui/open-link`, `ui/request-display-mode`,
+`ui/update-model-context`, and resize messages. ChatGPT-specific `window.openai`
+helpers are feature-detected only as compatibility fallbacks and for ephemeral
+widget state. VidXP remains authoritative for upload, job, search, and artifact
+state, and non-UI clients receive the existing text, image, and resource-link
+content.
+
+The resource is self-contained, uses system fonts, has no remote script or
+style dependencies, and publishes an explicit empty resource/connect CSP. Add
+only exact HTTPS origins if future component assets or requests require them.
+
+## Connect ChatGPT
+
+The bundled `.mcp.json` is for local plugin hosts. A ChatGPT connection still
+requires a publicly reachable Streamable HTTP endpoint (VidXP serves `/mcp`),
+an HTTPS deployment or secure development tunnel, and registration in ChatGPT
+Developer Mode.
+
+Do not add a placeholder `.app.json`. That file can reference only the real app
+identifier issued after the remote MCP connection is registered. Once that ID
+exists, add the descriptor to the plugin bundle and validate the deployed app
+through ChatGPT Developer Mode.
+
+Before public submission, also complete the current OpenAI review requirements,
+including organization verification, public endpoint availability, privacy and
+support URLs, accurate tool metadata, and CSP validation.
+
+## Official references
+
+- [Plugin architecture](https://developers.openai.com/plugins/concepts/plugins)
+- [Package a plugin](https://developers.openai.com/plugins/build/plugins)
+- [Add a ChatGPT UI](https://developers.openai.com/plugins/build/chatgpt-ui)
+- [UI guidelines](https://developers.openai.com/plugins/concepts/ui-guidelines)
+- [Connect from ChatGPT](https://developers.openai.com/plugins/deploy/connect-chatgpt)
+- [App review](https://developers.openai.com/plugins/deploy/app-review)

--- a/docs/integrations/openai-plugin.md
+++ b/docs/integrations/openai-plugin.md
@@ -34,8 +34,11 @@ the documented JSON forms of `codex plugin marketplace add` and
 `codex plugin add`, leaves personal marketplace files and `config.toml`
 untouched, and asks the user to start a new Codex chat after installation. The
 exported marketplace lives in VidXP Desktop's private application-data
-directory; the canonical distributable bundle remains checked into this
-repository and packaged in every VidXP wheel.
+directory. Its catalog is written to the Codex marketplace contract at
+`.agents/plugins/marketplace.json`, with the plugin at `plugins/vidxp/`. The
+exporter also removes the obsolete root-level `marketplace.json` from earlier
+VidXP-managed exports. The canonical distributable bundle remains checked into
+this repository and packaged in every VidXP wheel.
 
 ## Interactive MCP App
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,12 +71,17 @@ include = ["vidxp*"]
 [tool.setuptools.package-data]
 vidxp = [
   "assets/artifact_download/*",
+  "assets/mcp_app/*",
   "assets/upload_page/*",
   "benchmarks/requirements.txt",
   "capabilities/*/requirements.txt",
   "requirements/*.txt",
   "migrations/*.py",
   "migrations/versions/*.py",
+  "bundled_plugins/vidxp/.mcp.json",
+  "bundled_plugins/vidxp/.codex-plugin/plugin.json",
+  "bundled_plugins/vidxp/skills/*/SKILL.md",
+  "bundled_plugins/vidxp/skills/*/agents/*.yaml",
 ]
 
 [tool.setuptools.dynamic.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ vidxp-worker = "vidxp.workflow_worker:main"
 vidxp-database = "vidxp.database_cli:main"
 vidxp-hooks = "vidxp.hook_cli:main"
 vidxp-mcp = "vidxp.mcp_cli:main"
+vidxp-codex-plugin = "vidxp.codex_plugin_cli:main"
 
 [project.urls]
 Homepage = "https://github.com/grayhatdevelopers/vidxp"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,6 +17,11 @@
           "type": "generic"
         },
         {
+          "jsonpath": "$.version",
+          "path": "src/vidxp/bundled_plugins/vidxp/.codex-plugin/plugin.json",
+          "type": "json"
+        },
+        {
           "path": "desktop/src-tauri/Cargo.toml",
           "type": "generic"
         },

--- a/release-please-config.stable.json
+++ b/release-please-config.stable.json
@@ -20,6 +20,11 @@
           "type": "generic"
         },
         {
+          "jsonpath": "$.version",
+          "path": "src/vidxp/bundled_plugins/vidxp/.codex-plugin/plugin.json",
+          "type": "json"
+        },
+        {
           "path": "desktop/src-tauri/Cargo.toml",
           "type": "generic"
         },

--- a/skills/vidxp-find-video-evidence/SKILL.md
+++ b/skills/vidxp-find-video-evidence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vidxp-find-video-evidence
-description: Use VidXP to search indexed videos, answer grounded questions about video content, locate when people, actions, dialogue, or scenes occur, and return inspectable evidence boards, keyframes, or clips. Trigger for requests such as "find where X appears," "when does Y happen," "what is said," "what happens," or "show me the matching clip," even when the user does not name VidXP. Do not trigger for ingesting new media or ordinary video editing.
+description: Use VidXP to search indexed videos and surface inspectable evidence boards, keyframes, and clips before analysis. Trigger for requests such as "find where X appears," "when does Y happen," "what is said," "what happens," or "show me the matching clip," even when the user does not name VidXP. Favor one-pass evidence delivery and only add brief accuracy feedback; do not trigger for ingesting new media or ordinary video editing.
 ---
 
 # Find video evidence with VidXP
@@ -9,30 +9,28 @@ description: Use VidXP to search indexed videos, answer grounded questions about
 
 1. Resolve the `vidxp` MCP tools, then call `get_workspace`. If the requested
    video is not indexed, explain that it must be indexed first.
-2. Use `search_moments` to locate moments or `query_video` for a synthesized,
-   grounded answer. Use `command.query` with `search_moments` and
-   `command.question` with `query_video`. Set `command.media_id` when the user
-   means one video.
-3. Omit `command.evidence_delivery` for the normal path. The completed job
-   includes an annotated board covering the ranked results.
+2. Submit one retrieval job. Use `search_moments` to locate moments; use
+   `query_video` only when the user asks for a synthesized answer. Use
+   `command.query` with `search_moments` and `command.question` with
+   `query_video`. Set `command.media_id` when the user means one video.
+3. In that initial job, put exactly this inside `command`:
+   `"evidence_delivery": {"mode": "keyframes_and_clips", "max_items": 3}`.
+   This prepares the ranked board, standalone keyframes, and clips without a
+   second retrieval pass. Never send `command.materialize`.
 4. Call `wait_job` for bounded waits. Pass its `observation_token` as
    `after_observation_token` on the next wait. When terminal, call
    `get_job_evidence` once. It returns the concise evidence index and visual
-   content without the full structured job dump. Use `get_job` only when exact
-   machine fields not present in that index are actually needed. Search and
-   query may take time; update the user
-   when the stage changes or about once per minute, never after every wait and
-   never with an invented ETA.
-5. Inspect and show the returned board before making visual claims. Use its tile
-   evidence IDs for follow-up:
-   - `materialize_job_evidence` accepts up to ten selected IDs and returns
-     model-visible standalone keyframes or clip links without rerunning retrieval.
-   - `create_evidence_board` is only for a custom selection or the
-     `next_start_rank` continuation; wait on its returned job ID the same way.
-6. When standalone artifacts are required in the initial job, put exactly this
-   inside `command`: `"evidence_delivery": {"mode":
-   "keyframes_and_clips", "max_items": 3}`. Never send
-   `command.materialize`.
+   content without the full structured job dump. Search and query may take
+   time; update the user when the stage changes or about once per minute, never
+   after every wait and never with an invented ETA.
+5. Surface the returned board, keyframes, and clips immediately. Do not call
+   `get_job`, repeat the search, materialize more evidence, create another
+   board, or perform a self-directed verification loop before showing the
+   initial evidence.
+6. Stop after the first evidence delivery. Only when the user explicitly asks
+   for another selection or format, use tile evidence IDs with
+   `materialize_job_evidence`, or use `create_evidence_board` for a custom
+   selection or `next_start_rank` continuation.
 
 ## Actor scope
 
@@ -40,15 +38,20 @@ description: Use VidXP to search indexed videos, answer grounded questions about
   anonymous, video-scoped face clusters—not a named or cross-video identity.
 - Treat its image as a representative full frame, not an exact face crop or
   proof of continuous presence. Do not claim exhaustive named appearances.
-- Use scene evidence plus board inspection for named-person requests, and label
-  uncertain matches as candidates.
+- For named-person requests, surface the best scene candidates immediately and
+  label uncertain matches as candidates. Do not delay delivery while trying to
+  prove identity through additional searches.
 
 ## Output
 
-- The final response must visibly embed a returned board or frame, or include a
-  working downloadable resource link—not timestamps alone. Use the returned
-  `local_path` or `download_url`; never write an unlinked label such as “View
-  evidence board.” Use `get_artifact_download` only if neither is returned.
+- Lead with evidence, not a search narrative: first embed the returned board or
+  frame or provide its working resource link, then list the ready clips and
+  keyframes. Use the returned `local_path` or `download_url`; never write an
+  unlinked label such as “View evidence board.” Use `get_artifact_download`
+  only if neither is returned.
+- After the evidence, add at most a brief accuracy note. State uncertainty or
+  visible mismatches without launching another search. Accuracy feedback must
+  not replace or precede the evidence.
 - Preserve the source job and evidence IDs. Describe scores as retrieval scores,
   and distinguish a visible appearance from a dialogue or caption mention.
 - Stop waiting on success, failure, or cancellation. An empty result means no

--- a/skills/vidxp-find-video-evidence/agents/openai.yaml
+++ b/skills/vidxp-find-video-evidence/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Find Video Evidence with VidXP"
-  short_description: "Search indexed videos and return verifiable evidence"
-  default_prompt: "Use $vidxp-find-video-evidence to find and verify moments in my indexed videos."
+  short_description: "Surface video boards, frames, and clips first"
+  default_prompt: "Use $vidxp-find-video-evidence to surface the best board, keyframes, and clips before brief accuracy feedback."
 
 policy:
   allow_implicit_invocation: true

--- a/src/vidxp/assets/mcp_app/index.html
+++ b/src/vidxp/assets/mcp_app/index.html
@@ -1,0 +1,469 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>VidXP evidence review</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        --accent: #6d5ef7;
+        --surface: color-mix(in srgb, Canvas 94%, CanvasText 6%);
+        --surface-strong: color-mix(in srgb, Canvas 88%, CanvasText 12%);
+        --border: color-mix(in srgb, CanvasText 18%, transparent);
+        --muted: color-mix(in srgb, CanvasText 64%, transparent);
+      }
+
+      * { box-sizing: border-box; }
+      body { margin: 0; color: CanvasText; background: Canvas; }
+      button, a { font: inherit; }
+      button:focus-visible, a:focus-visible { outline: 3px solid color-mix(in srgb, var(--accent) 60%, transparent); outline-offset: 2px; }
+      .app { display: grid; gap: 16px; padding: 16px; }
+      .header { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
+      .eyebrow { margin: 0 0 4px; color: var(--muted); font-size: 12px; font-weight: 650; letter-spacing: .08em; text-transform: uppercase; }
+      h1, h2, p { margin-top: 0; }
+      h1 { margin-bottom: 4px; font-size: 20px; line-height: 1.25; }
+      h2 { margin-bottom: 10px; font-size: 16px; }
+      .lede, .status { margin-bottom: 0; color: var(--muted); font-size: 14px; line-height: 1.45; }
+      .toolbar { display: flex; flex-wrap: wrap; gap: 8px; }
+      .button { min-height: 38px; border: 1px solid var(--border); border-radius: 10px; padding: 8px 12px; color: CanvasText; background: var(--surface); cursor: pointer; text-decoration: none; }
+      .button:hover { background: var(--surface-strong); }
+      .button.primary { border-color: var(--accent); color: white; background: var(--accent); }
+      .button:disabled { cursor: not-allowed; opacity: .5; }
+      .panel { border: 1px solid var(--border); border-radius: 14px; padding: 14px; background: var(--surface); }
+      .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); gap: 8px; }
+      .metric { border: 1px solid var(--border); border-radius: 10px; padding: 10px; background: Canvas; }
+      .metric strong { display: block; font-size: 18px; }
+      .metric span { color: var(--muted); font-size: 12px; }
+      .board-grid, .drilldown-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr)); gap: 12px; }
+      .board-image, .drilldown-image { display: block; width: 100%; height: auto; border: 1px solid var(--border); border-radius: 10px; background: Canvas; }
+      .tile-list { display: grid; gap: 8px; margin: 0; padding: 0; list-style: none; }
+      .tile { width: 100%; display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 10px; border: 1px solid var(--border); border-radius: 10px; padding: 10px; color: CanvasText; background: Canvas; text-align: left; cursor: pointer; }
+      .tile[aria-pressed="true"] { border-color: var(--accent); box-shadow: inset 3px 0 0 var(--accent); }
+      .rank { min-width: 28px; color: var(--accent); font-weight: 750; }
+      .tile-copy { min-width: 0; }
+      .tile-title { display: block; overflow: hidden; font-size: 14px; font-weight: 650; text-overflow: ellipsis; white-space: nowrap; }
+      .tile-meta { display: block; margin-top: 3px; color: var(--muted); font-size: 12px; }
+      .check { font-size: 16px; }
+      .file-list { display: grid; gap: 8px; margin: 0; padding: 0; list-style: none; }
+      .file { display: grid; grid-template-columns: 1fr auto; gap: 8px; border-top: 1px solid var(--border); padding-top: 8px; }
+      .file:first-child { border-top: 0; padding-top: 0; }
+      .badge { align-self: start; border-radius: 999px; padding: 3px 8px; color: var(--muted); background: Canvas; font-size: 12px; }
+      .error { border-color: color-mix(in srgb, #c43b3b 45%, var(--border)); }
+      .notice { min-height: 20px; color: var(--muted); font-size: 13px; }
+      .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; }
+      @media (max-width: 560px) { .app { padding: 12px; } .header { align-items: stretch; flex-direction: column; } .header .button { align-self: flex-start; } }
+    </style>
+  </head>
+  <body>
+    <main class="app" aria-live="polite">
+      <header class="header">
+        <div>
+          <p class="eyebrow">VidXP</p>
+          <h1 id="title">Preparing video workspace…</h1>
+          <p id="lede" class="lede">Waiting for the tool result.</p>
+        </div>
+        <button id="expand" class="button" type="button" hidden>Expand</button>
+      </header>
+      <section id="content"></section>
+      <p id="notice" class="notice" role="status"></p>
+    </main>
+    <script>
+      (() => {
+        "use strict";
+
+        const title = document.getElementById("title");
+        const lede = document.getElementById("lede");
+        const content = document.getElementById("content");
+        const notice = document.getElementById("notice");
+        const expand = document.getElementById("expand");
+        const pending = new Map();
+        const selected = new Set();
+        let requestId = 1;
+        let latestResult = null;
+        let uploadPageUrl = null;
+        let connected = false;
+        let hostCapabilities = {};
+        let hostContext = {};
+
+        const element = (tag, className, text) => {
+          const node = document.createElement(tag);
+          if (className) node.className = className;
+          if (text !== undefined && text !== null) node.textContent = String(text);
+          return node;
+        };
+
+        const asObject = (value) => value && typeof value === "object" && !Array.isArray(value) ? value : {};
+        const asArray = (value) => Array.isArray(value) ? value : [];
+        const formatSeconds = (value) => {
+          const seconds = Number(value);
+          if (!Number.isFinite(seconds) || seconds < 0) return "—";
+          const minutes = Math.floor(seconds / 60);
+          const remainder = (seconds % 60).toFixed(seconds < 60 ? 1 : 0).padStart(2, "0");
+          return `${minutes}:${remainder}`;
+        };
+
+        const normalizeResult = (value) => {
+          const result = asObject(value);
+          if (result.mcp_tool_result) return normalizeResult(result.mcp_tool_result);
+          if (result.call_tool_result) return normalizeResult(result.call_tool_result);
+          return {
+            structuredContent: asObject(result.structuredContent ?? result.structured_content),
+            content: asArray(result.content),
+            isError: Boolean(result.isError ?? result.is_error),
+          };
+        };
+
+        const request = (method, params) => {
+          const id = requestId++;
+          window.parent.postMessage({ jsonrpc: "2.0", id, method, params }, "*");
+          return new Promise((resolve, reject) => {
+            const timer = window.setTimeout(() => {
+              pending.delete(id);
+              reject(new Error(`The host did not answer ${method}.`));
+            }, 15000);
+            pending.set(id, { resolve, reject, timer });
+          });
+        };
+
+        const notify = (method, params) => {
+          window.parent.postMessage({ jsonrpc: "2.0", method, params }, "*");
+        };
+
+        const updateHostContext = (next) => {
+          hostContext = { ...hostContext, ...asObject(next) };
+          const variables = asObject(hostContext.styles?.variables);
+          for (const [name, value] of Object.entries(variables)) {
+            if (name.startsWith("--") && typeof value === "string") {
+              document.documentElement.style.setProperty(name, value);
+            }
+          }
+          const supportsFullscreen = asArray(hostContext.availableDisplayModes).includes("fullscreen");
+          expand.hidden = !(supportsFullscreen || window.openai?.requestDisplayMode);
+        };
+
+        const connect = async () => {
+          try {
+            const initialized = asObject(await request("ui/initialize", {
+              protocolVersion: "2026-01-26",
+              appCapabilities: { availableDisplayModes: ["inline", "fullscreen"] },
+              appInfo: { name: "VidXP video workspace", version: "1.0.0" },
+            }));
+            hostCapabilities = asObject(initialized.hostCapabilities);
+            updateHostContext(initialized.hostContext);
+            connected = true;
+            notify("ui/notifications/initialized");
+          } catch (_error) {
+            updateHostContext({});
+          }
+        };
+
+        const callTool = async (name, args) => {
+          if (connected && hostCapabilities.serverTools) {
+            return normalizeResult(await request("tools/call", { name, arguments: args }));
+          }
+          if (window.openai?.callTool) return normalizeResult(await window.openai.callTool(name, args));
+          return normalizeResult(await request("tools/call", { name, arguments: args }));
+        };
+
+        const imageBlocks = (result) => asArray(result?.content).filter((block) => {
+          const mime = String(block?.mimeType ?? block?.mime_type ?? "").toLowerCase();
+          return block?.type === "image" && (mime === "image/jpeg" || mime === "image/png") && typeof block?.data === "string";
+        });
+
+        const persistSelection = () => {
+          const evidenceIds = [...selected];
+          if (connected) {
+            void request("ui/update-model-context", {
+              structuredContent: { selectedEvidenceIds: evidenceIds },
+            }).catch(() => undefined);
+          }
+          if (window.openai?.setWidgetState) {
+            void Promise.resolve(
+              window.openai.setWidgetState({ selectedEvidenceIds: evidenceIds })
+            ).catch(() => undefined);
+          }
+        };
+
+        const panel = (heading) => {
+          const section = element("section", "panel");
+          if (heading) section.append(element("h2", "", heading));
+          return section;
+        };
+
+        const metric = (value, label) => {
+          const box = element("div", "metric");
+          box.append(element("strong", "", value), element("span", "", label));
+          return box;
+        };
+
+        const renderUpload = (data) => {
+          title.textContent = "Upload videos to VidXP";
+          lede.textContent = data.status || "Use the secure upload page, then refresh progress here.";
+          uploadPageUrl = data.upload_session_url || uploadPageUrl;
+          const wrapper = document.createDocumentFragment();
+          const metrics = element("div", "metrics");
+          metrics.append(
+            metric(data.file_count ?? 0, "files"),
+            metric(data.ready_file_count ?? 0, "ready"),
+            metric(data.failed_file_count ?? 0, "failed"),
+            metric(data.aggregate_state || "empty", "state")
+          );
+          const overview = panel("Session progress");
+          overview.append(metrics);
+          const actions = element("div", "toolbar");
+          if (typeof uploadPageUrl === "string" && /^https:\/\//i.test(uploadPageUrl)) {
+            const open = element("a", "button primary", "Choose videos");
+            open.href = uploadPageUrl;
+            open.target = "_blank";
+            open.rel = "noopener noreferrer";
+            open.addEventListener("click", async (event) => {
+              if (connected && hostCapabilities.openLinks) {
+                event.preventDefault();
+                await request("ui/open-link", { url: uploadPageUrl });
+              } else if (window.openai?.openExternal) {
+                event.preventDefault();
+                await window.openai.openExternal({ href: uploadPageUrl, redirectUrl: false });
+              }
+            });
+            actions.append(open);
+          }
+          const refresh = element("button", "button", "Refresh status");
+          refresh.type = "button";
+          refresh.addEventListener("click", async () => {
+            refresh.disabled = true;
+            notice.textContent = "Refreshing upload status…";
+            try {
+              const next = await callTool("get_media_upload", { upload_session_id: data.session_id });
+              if (next.isError) throw new Error("VidXP could not refresh this upload session.");
+              latestResult = { ...next, structuredContent: { ...data, ...next.structuredContent, upload_session_url: uploadPageUrl } };
+              render(latestResult);
+              notice.textContent = "Upload status refreshed.";
+            } catch (error) {
+              notice.textContent = error instanceof Error ? error.message : "Upload status refresh failed.";
+            } finally {
+              refresh.disabled = false;
+            }
+          });
+          actions.append(refresh);
+          overview.append(actions);
+          wrapper.append(overview);
+
+          const items = asArray(data.items);
+          if (items.length) {
+            const files = panel("Files");
+            const list = element("ul", "file-list");
+            for (const item of items) {
+              const row = element("li", "file");
+              const copy = element("div");
+              copy.append(element("strong", "", item.original_filename || "Video"), element("p", "status", item.status || item.next_action || ""));
+              row.append(copy, element("span", "badge", item.phase || item.state || "pending"));
+              list.append(row);
+            }
+            files.append(list);
+            wrapper.append(files);
+          }
+          content.replaceChildren(wrapper);
+        };
+
+        const renderDrilldown = (result) => {
+          let region = document.getElementById("drilldown");
+          if (!region) {
+            region = panel("Selected evidence");
+            region.id = "drilldown";
+            content.append(region);
+          }
+          region.replaceChildren(element("h2", "", "Selected evidence"));
+          const images = imageBlocks(result);
+          if (images.length) {
+            const grid = element("div", "drilldown-grid");
+            images.forEach((block, index) => {
+              const mime = block.mimeType ?? block.mime_type;
+              const image = element("img", "drilldown-image");
+              image.alt = `Selected VidXP evidence frame ${index + 1}`;
+              image.src = `data:${mime};base64,${block.data}`;
+              grid.append(image);
+            });
+            region.append(grid);
+          } else {
+            region.append(element("p", "status", "VidXP returned resource links for the selected evidence in the conversation."));
+          }
+        };
+
+        const renderEvidence = (data, result) => {
+          const board = asObject(data.board);
+          const tiles = asArray(board.tiles);
+          const pages = asArray(board.pages);
+          const images = imageBlocks(result);
+          title.textContent = data.answer?.claims?.length ? "Grounded video answer" : "Review video evidence";
+          lede.textContent = `${board.rendered_count ?? tiles.length} ranked moment${(board.rendered_count ?? tiles.length) === 1 ? "" : "s"} from job ${data.source_job_id || data.job_id || ""}.`;
+          const wrapper = document.createDocumentFragment();
+
+          if (data.answer?.claims?.length) {
+            const answer = panel("Answer");
+            for (const claim of data.answer.claims) {
+              const text = element("p", "", claim.text || "");
+              const citations = asArray(claim.evidence_ids);
+              if (citations.length) text.append(element("span", "status", ` Evidence: ${citations.join(", ")}`));
+              answer.append(text);
+            }
+            wrapper.append(answer);
+          } else if (data.answer?.fallback_reason) {
+            const answer = panel("Answer unavailable");
+            answer.append(element("p", "status", data.answer.fallback_reason));
+            wrapper.append(answer);
+          }
+
+          const overview = panel("Evidence board");
+          const metrics = element("div", "metrics");
+          metrics.append(
+            metric(board.rendered_count ?? tiles.length, "rendered"),
+            metric(pages.length, "pages"),
+            metric(board.failed_count ?? 0, "failed"),
+            metric(board.next_start_rank ?? "—", "next rank")
+          );
+          overview.append(metrics);
+          if (images.length) {
+            const grid = element("div", "board-grid");
+            images.slice(0, pages.length || images.length).forEach((block, index) => {
+              const mime = block.mimeType ?? block.mime_type;
+              const image = element("img", "board-image");
+              image.alt = `VidXP evidence board page ${pages[index]?.page_number ?? index + 1}`;
+              image.src = `data:${mime};base64,${block.data}`;
+              grid.append(image);
+            });
+            overview.append(grid);
+          } else {
+            overview.append(element("p", "status", "Board pages are available as MCP resources in the conversation."));
+          }
+          wrapper.append(overview);
+
+          if (tiles.length) {
+            const choices = panel("Select moments");
+            const help = element("p", "status", "Choose up to ten moments, then request exact frames or clips without rerunning search.");
+            const list = element("ul", "tile-list");
+            for (const tile of tiles) {
+              const item = element("li");
+              const button = element("button", "tile");
+              button.type = "button";
+              button.dataset.evidenceId = tile.evidence_id;
+              button.setAttribute("aria-pressed", selected.has(tile.evidence_id) ? "true" : "false");
+              button.append(
+                element("span", "rank", `#${tile.rank ?? "?"}`),
+                (() => {
+                  const copy = element("span", "tile-copy");
+                  copy.append(
+                    element("span", "tile-title", tile.display_text || asArray(tile.modalities).join(" + ") || "Video moment"),
+                    element("span", "tile-meta", `${formatSeconds(tile.start)}–${formatSeconds(tile.end)} · ${asArray(tile.modalities).join(", ")}`)
+                  );
+                  return copy;
+                })(),
+                element("span", "check", selected.has(tile.evidence_id) ? "✓" : "+")
+              );
+              button.addEventListener("click", () => {
+                const id = tile.evidence_id;
+                if (selected.has(id)) selected.delete(id);
+                else if (selected.size < 10) selected.add(id);
+                else notice.textContent = "Select at most ten evidence moments at once.";
+                persistSelection();
+                render(latestResult);
+              });
+              item.append(button);
+              list.append(item);
+            }
+            const actions = element("div", "toolbar");
+            for (const [label, mode] of [["Show frames", "keyframes"], ["Create clips", "keyframes_and_clips"]]) {
+              const action = element("button", mode === "keyframes" ? "button primary" : "button", label);
+              action.type = "button";
+              action.disabled = selected.size === 0;
+              action.addEventListener("click", async () => {
+                action.disabled = true;
+                notice.textContent = mode === "keyframes" ? "Preparing selected frames…" : "Preparing selected clips…";
+                try {
+                  const next = await callTool("materialize_job_evidence", {
+                    source_job_id: data.source_job_id,
+                    evidence_ids: [...selected],
+                    mode,
+                  });
+                  if (next.isError) throw new Error("VidXP could not prepare the selected evidence.");
+                  renderDrilldown(next);
+                  notice.textContent = mode === "keyframes" ? "Selected frames are ready." : "Selected clip links are ready.";
+                } catch (error) {
+                  notice.textContent = error instanceof Error ? error.message : "Evidence preparation failed.";
+                } finally {
+                  action.disabled = selected.size === 0;
+                }
+              });
+              actions.append(action);
+            }
+            choices.append(help, list, actions);
+            wrapper.append(choices);
+          }
+          content.replaceChildren(wrapper);
+        };
+
+        const render = (result) => {
+          latestResult = normalizeResult(result);
+          const data = latestResult.structuredContent;
+          notice.textContent = latestResult.isError ? "VidXP returned an error." : "";
+          if (data.view === "upload" || data.upload_session_url || data.aggregate_state) renderUpload(data);
+          else if (data.view === "evidence" || data.board) renderEvidence(data, latestResult);
+          else {
+            title.textContent = "VidXP";
+            lede.textContent = "This tool result does not include an interactive view.";
+            content.replaceChildren();
+          }
+        };
+
+        window.addEventListener("message", (event) => {
+          if (event.source !== window.parent) return;
+          const message = event.data;
+          if (!message || message.jsonrpc !== "2.0") return;
+          if (message.id !== undefined && pending.has(message.id)) {
+            const request = pending.get(message.id);
+            pending.delete(message.id);
+            window.clearTimeout(request.timer);
+            if (message.error) request.reject(message.error);
+            else request.resolve(message.result);
+            return;
+          }
+          if (message.method === "ui/notifications/tool-result") render(message.params);
+          if (message.method === "ui/notifications/host-context-changed") updateHostContext(message.params);
+          if (message.method === "ui/notifications/tool-cancelled") notice.textContent = message.params?.reason || "The tool call was cancelled.";
+          if (message.method === "ui/resource-teardown" && message.id !== undefined) {
+            window.parent.postMessage({ jsonrpc: "2.0", id: message.id, result: {} }, "*");
+          }
+        }, { passive: true });
+
+        const saved = asArray(
+          window.openai?.widgetState?.selectedEvidenceIds ??
+          window.openai?.widgetState?.privateContent?.selectedEvidenceIds
+        );
+        saved.slice(0, 10).forEach((id) => typeof id === "string" && selected.add(id));
+        expand.addEventListener("click", async () => {
+          if (connected && asArray(hostContext.availableDisplayModes).includes("fullscreen")) {
+            await request("ui/request-display-mode", { mode: "fullscreen" });
+          } else if (window.openai?.requestDisplayMode) {
+            await window.openai.requestDisplayMode({ mode: "fullscreen" });
+          }
+        });
+        updateHostContext({});
+        const initialMetadata = window.openai?.toolResponseMetadata;
+        if (initialMetadata) render(initialMetadata);
+        else if (window.openai?.toolOutput) render({ structuredContent: window.openai.toolOutput, content: [] });
+        if (typeof ResizeObserver === "function") {
+          new ResizeObserver(() => {
+            if (connected) {
+              notify("ui/notifications/size-changed", {
+                width: Math.ceil(document.documentElement.scrollWidth),
+                height: Math.ceil(document.documentElement.scrollHeight),
+              });
+            }
+          }).observe(document.documentElement);
+        }
+        void connect();
+      })();
+    </script>
+  </body>
+</html>

--- a/src/vidxp/bundled_plugins/vidxp/.codex-plugin/plugin.json
+++ b/src/vidxp/bundled_plugins/vidxp/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "vidxp",
+  "version": "0.4.0-b.3",
+  "description": "Ingest, index, search, and inspect video evidence with VidXP.",
+  "author": {
+    "name": "Grayhat"
+  },
+  "homepage": "https://github.com/grayhatdevelopers/vidxp",
+  "repository": "https://github.com/grayhatdevelopers/vidxp",
+  "license": "MIT",
+  "keywords": ["video", "search", "evidence", "mcp"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "VidXP",
+    "shortDescription": "Search video and inspect grounded evidence.",
+    "longDescription": "Use VidXP to ingest and index videos, search dialogue and scenes, answer grounded questions, and review evidence boards, frames, and clips.",
+    "developerName": "Grayhat",
+    "category": "Productivity",
+    "capabilities": ["Read", "Write", "Interactive"],
+    "websiteURL": "https://github.com/grayhatdevelopers/vidxp",
+    "defaultPrompt": [
+      "Find and verify moments in my indexed videos.",
+      "Ingest and index a video with VidXP."
+    ],
+    "brandColor": "#6D5EF7"
+  },
+  "mcpServers": "./.mcp.json"
+}

--- a/src/vidxp/bundled_plugins/vidxp/.mcp.json
+++ b/src/vidxp/bundled_plugins/vidxp/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "vidxp": {
+      "command": "vidxp-mcp",
+      "args": ["--repository", "default"]
+    }
+  }
+}

--- a/src/vidxp/bundled_plugins/vidxp/skills/vidxp-find-video-evidence/SKILL.md
+++ b/src/vidxp/bundled_plugins/vidxp/skills/vidxp-find-video-evidence/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: vidxp-find-video-evidence
+description: Use VidXP to search indexed videos, answer grounded questions about video content, locate when people, actions, dialogue, or scenes occur, and return inspectable evidence boards, keyframes, or clips. Trigger for requests such as "find where X appears," "when does Y happen," "what is said," "what happens," or "show me the matching clip," even when the user does not name VidXP. Do not trigger for ingesting new media or ordinary video editing.
+---
+
+# Find video evidence with VidXP
+
+## Workflow
+
+1. Resolve the `vidxp` MCP tools, then call `get_workspace`. If the requested
+   video is not indexed, explain that it must be indexed first.
+2. Use `search_moments` to locate moments or `query_video` for a synthesized,
+   grounded answer. Use `command.query` with `search_moments` and
+   `command.question` with `query_video`. Set `command.media_id` when the user
+   means one video.
+3. Omit `command.evidence_delivery` for the normal path. The completed job
+   includes an annotated board covering the ranked results.
+4. Call `wait_job` for bounded waits. Pass its `observation_token` as
+   `after_observation_token` on the next wait. When terminal, call
+   `get_job_evidence` once. It returns the concise evidence index and visual
+   content without the full structured job dump. Use `get_job` only when exact
+   machine fields not present in that index are actually needed. Search and
+   query may take time; update the user
+   when the stage changes or about once per minute, never after every wait and
+   never with an invented ETA.
+5. Inspect and show the returned board before making visual claims. Use its tile
+   evidence IDs for follow-up:
+   - `materialize_job_evidence` accepts up to ten selected IDs and returns
+     model-visible standalone keyframes or clip links without rerunning retrieval.
+   - `create_evidence_board` is only for a custom selection or the
+     `next_start_rank` continuation; wait on its returned job ID the same way.
+6. When standalone artifacts are required in the initial job, put exactly this
+   inside `command`: `"evidence_delivery": {"mode":
+   "keyframes_and_clips", "max_items": 3}`. Never send
+   `command.materialize`.
+
+## Actor scope
+
+- Actor data is available through `query_video`, not name search. It represents
+  anonymous, video-scoped face clusters—not a named or cross-video identity.
+- Treat its image as a representative full frame, not an exact face crop or
+  proof of continuous presence. Do not claim exhaustive named appearances.
+- Use scene evidence plus board inspection for named-person requests, and label
+  uncertain matches as candidates.
+
+## Output
+
+- The final response must visibly embed a returned board or frame, or include a
+  working downloadable resource link—not timestamps alone. Use the returned
+  `local_path` or `download_url`; never write an unlinked label such as “View
+  evidence board.” Use `get_artifact_download` only if neither is returned.
+- Preserve the source job and evidence IDs. Describe scores as retrieval scores,
+  and distinguish a visible appearance from a dialogue or caption mention.
+- Stop waiting on success, failure, or cancellation. An empty result means no
+  matching indexed evidence was found, not that the event is absent from the
+  original video.

--- a/src/vidxp/bundled_plugins/vidxp/skills/vidxp-find-video-evidence/SKILL.md
+++ b/src/vidxp/bundled_plugins/vidxp/skills/vidxp-find-video-evidence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vidxp-find-video-evidence
-description: Use VidXP to search indexed videos, answer grounded questions about video content, locate when people, actions, dialogue, or scenes occur, and return inspectable evidence boards, keyframes, or clips. Trigger for requests such as "find where X appears," "when does Y happen," "what is said," "what happens," or "show me the matching clip," even when the user does not name VidXP. Do not trigger for ingesting new media or ordinary video editing.
+description: Use VidXP to search indexed videos and surface inspectable evidence boards, keyframes, and clips before analysis. Trigger for requests such as "find where X appears," "when does Y happen," "what is said," "what happens," or "show me the matching clip," even when the user does not name VidXP. Favor one-pass evidence delivery and only add brief accuracy feedback; do not trigger for ingesting new media or ordinary video editing.
 ---
 
 # Find video evidence with VidXP
@@ -9,30 +9,28 @@ description: Use VidXP to search indexed videos, answer grounded questions about
 
 1. Resolve the `vidxp` MCP tools, then call `get_workspace`. If the requested
    video is not indexed, explain that it must be indexed first.
-2. Use `search_moments` to locate moments or `query_video` for a synthesized,
-   grounded answer. Use `command.query` with `search_moments` and
-   `command.question` with `query_video`. Set `command.media_id` when the user
-   means one video.
-3. Omit `command.evidence_delivery` for the normal path. The completed job
-   includes an annotated board covering the ranked results.
+2. Submit one retrieval job. Use `search_moments` to locate moments; use
+   `query_video` only when the user asks for a synthesized answer. Use
+   `command.query` with `search_moments` and `command.question` with
+   `query_video`. Set `command.media_id` when the user means one video.
+3. In that initial job, put exactly this inside `command`:
+   `"evidence_delivery": {"mode": "keyframes_and_clips", "max_items": 3}`.
+   This prepares the ranked board, standalone keyframes, and clips without a
+   second retrieval pass. Never send `command.materialize`.
 4. Call `wait_job` for bounded waits. Pass its `observation_token` as
    `after_observation_token` on the next wait. When terminal, call
    `get_job_evidence` once. It returns the concise evidence index and visual
-   content without the full structured job dump. Use `get_job` only when exact
-   machine fields not present in that index are actually needed. Search and
-   query may take time; update the user
-   when the stage changes or about once per minute, never after every wait and
-   never with an invented ETA.
-5. Inspect and show the returned board before making visual claims. Use its tile
-   evidence IDs for follow-up:
-   - `materialize_job_evidence` accepts up to ten selected IDs and returns
-     model-visible standalone keyframes or clip links without rerunning retrieval.
-   - `create_evidence_board` is only for a custom selection or the
-     `next_start_rank` continuation; wait on its returned job ID the same way.
-6. When standalone artifacts are required in the initial job, put exactly this
-   inside `command`: `"evidence_delivery": {"mode":
-   "keyframes_and_clips", "max_items": 3}`. Never send
-   `command.materialize`.
+   content without the full structured job dump. Search and query may take
+   time; update the user when the stage changes or about once per minute, never
+   after every wait and never with an invented ETA.
+5. Surface the returned board, keyframes, and clips immediately. Do not call
+   `get_job`, repeat the search, materialize more evidence, create another
+   board, or perform a self-directed verification loop before showing the
+   initial evidence.
+6. Stop after the first evidence delivery. Only when the user explicitly asks
+   for another selection or format, use tile evidence IDs with
+   `materialize_job_evidence`, or use `create_evidence_board` for a custom
+   selection or `next_start_rank` continuation.
 
 ## Actor scope
 
@@ -40,15 +38,20 @@ description: Use VidXP to search indexed videos, answer grounded questions about
   anonymous, video-scoped face clusters—not a named or cross-video identity.
 - Treat its image as a representative full frame, not an exact face crop or
   proof of continuous presence. Do not claim exhaustive named appearances.
-- Use scene evidence plus board inspection for named-person requests, and label
-  uncertain matches as candidates.
+- For named-person requests, surface the best scene candidates immediately and
+  label uncertain matches as candidates. Do not delay delivery while trying to
+  prove identity through additional searches.
 
 ## Output
 
-- The final response must visibly embed a returned board or frame, or include a
-  working downloadable resource link—not timestamps alone. Use the returned
-  `local_path` or `download_url`; never write an unlinked label such as “View
-  evidence board.” Use `get_artifact_download` only if neither is returned.
+- Lead with evidence, not a search narrative: first embed the returned board or
+  frame or provide its working resource link, then list the ready clips and
+  keyframes. Use the returned `local_path` or `download_url`; never write an
+  unlinked label such as “View evidence board.” Use `get_artifact_download`
+  only if neither is returned.
+- After the evidence, add at most a brief accuracy note. State uncertainty or
+  visible mismatches without launching another search. Accuracy feedback must
+  not replace or precede the evidence.
 - Preserve the source job and evidence IDs. Describe scores as retrieval scores,
   and distinguish a visible appearance from a dialogue or caption mention.
 - Stop waiting on success, failure, or cancellation. An empty result means no

--- a/src/vidxp/bundled_plugins/vidxp/skills/vidxp-find-video-evidence/agents/openai.yaml
+++ b/src/vidxp/bundled_plugins/vidxp/skills/vidxp-find-video-evidence/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Find Video Evidence with VidXP"
-  short_description: "Search indexed videos and return verifiable evidence"
-  default_prompt: "Use $vidxp-find-video-evidence to find and verify moments in my indexed videos."
+  short_description: "Surface video boards, frames, and clips first"
+  default_prompt: "Use $vidxp-find-video-evidence to surface the best board, keyframes, and clips before brief accuracy feedback."
 
 policy:
   allow_implicit_invocation: true

--- a/src/vidxp/bundled_plugins/vidxp/skills/vidxp-find-video-evidence/agents/openai.yaml
+++ b/src/vidxp/bundled_plugins/vidxp/skills/vidxp-find-video-evidence/agents/openai.yaml
@@ -1,0 +1,13 @@
+interface:
+  display_name: "Find Video Evidence with VidXP"
+  short_description: "Search indexed videos and return verifiable evidence"
+  default_prompt: "Use $vidxp-find-video-evidence to find and verify moments in my indexed videos."
+
+policy:
+  allow_implicit_invocation: true
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "vidxp"
+      description: "VidXP video search and evidence tools"

--- a/src/vidxp/bundled_plugins/vidxp/skills/vidxp-ingest-video/SKILL.md
+++ b/src/vidxp/bundled_plugins/vidxp/skills/vidxp-ingest-video/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: vidxp-ingest-video
+description: Use VidXP to upload, import, register, and automatically index video files through its MCP tools. Trigger for requests to add, upload, ingest, import, register, or index one or more videos, including attached videos and accessible local paths, even when the user does not name VidXP. Do not trigger for editing, transcoding, or searching a video that is already indexed.
+---
+
+# Ingest video with VidXP
+
+## Workflow
+
+1. Resolve the `vidxp` MCP tools and call `get_workspace`. Do not import a video
+   that is already registered or indexed.
+2. Choose indexable modalities from the workspace. Use `dialogue` and `scene`
+   for ordinary content retrieval. Add `actor` only when anonymous recurring-face
+   clusters are wanted; it does not identify people by name.
+3. Call `get_runtime_readiness`. If selected models are missing, submit
+   `prepare_models`, use `wait_job` with its observation token for subsequent
+   bounded waits, then fetch `get_job` once when terminal.
+4. Use `ingest_local_media` for one to ten paths accessible to VidXP; otherwise
+   use `create_media_upload` and give the returned link to the user. Keep
+   `index_after_import` enabled unless registration-only behavior was requested.
+5. Poll the returned ingestion or upload ID with `get_media_ingestion` or
+   `get_media_upload`. Honor its poll interval, reuse the same identifiers, and
+   do not resubmit unchanged work.
+6. Stop at a terminal state and report each file's state, media ID, index job,
+   and searchable snapshot or generation. If indexing fails after registration,
+   retry with `start_indexing`; do not upload the file again.
+7. If the request also asks about the video, continue directly into the VidXP
+   evidence workflow once it is searchable.
+
+## Long operations
+
+- Tell the user that model preparation and indexing can take several minutes.
+- Update when the stage changes or about once per minute; do not narrate every
+  status check or invent an ETA.
+- Treat files independently so one failure does not hide successful siblings.

--- a/src/vidxp/bundled_plugins/vidxp/skills/vidxp-ingest-video/agents/openai.yaml
+++ b/src/vidxp/bundled_plugins/vidxp/skills/vidxp-ingest-video/agents/openai.yaml
@@ -1,0 +1,13 @@
+interface:
+  display_name: "Ingest Video with VidXP"
+  short_description: "Upload or ingest videos and index them with VidXP"
+  default_prompt: "Use $vidxp-ingest-video to ingest and index my video with VidXP."
+
+policy:
+  allow_implicit_invocation: true
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "vidxp"
+      description: "VidXP video ingestion and indexing tools"

--- a/src/vidxp/codex_plugin.py
+++ b/src/vidxp/codex_plugin.py
@@ -18,6 +18,7 @@ from vidxp.mcp_cli import stdio_client_config
 PLUGIN_NAME = "vidxp"
 MARKETPLACE_NAME = "vidxp-local"
 MANAGED_MARKER = ".vidxp-managed-marketplace"
+MARKETPLACE_MANIFEST = Path(".agents") / "plugins" / "marketplace.json"
 
 
 class CodexPluginInstallError(RuntimeError):
@@ -169,8 +170,12 @@ def export_codex_plugin(
             }
         ],
     }
-    marketplace_path = root / "marketplace.json"
+    marketplace_path = root / MARKETPLACE_MANIFEST
+    marketplace_path.parent.mkdir(parents=True, exist_ok=True)
     _write_json(marketplace_path, marketplace)
+    legacy_marketplace_path = root / "marketplace.json"
+    if marker.is_file() and legacy_marketplace_path.is_file():
+        legacy_marketplace_path.unlink()
     marker.write_text("Managed by VidXP Desktop.\n", encoding="utf-8")
     return CodexPluginExport(
         marketplace_root=str(root),

--- a/src/vidxp/codex_plugin.py
+++ b/src/vidxp/codex_plugin.py
@@ -6,9 +6,10 @@ import os
 import shutil
 import subprocess
 import tempfile
+import tomllib
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 from vidxp import __version__
 from vidxp.mcp_cli import stdio_client_config
@@ -218,6 +219,78 @@ def _run_codex_json(
     return payload
 
 
+def _configured_codex_command(
+    environment: Mapping[str, str],
+) -> str | None:
+    codex_home = Path(
+        environment.get("CODEX_HOME", str(Path.home() / ".codex"))
+    ).expanduser()
+    try:
+        config = tomllib.loads(
+            (codex_home / "config.toml").read_text(encoding="utf-8")
+        )
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    servers = config.get("mcp_servers")
+    node_repl = servers.get("node_repl") if isinstance(servers, dict) else None
+    node_repl_environment = (
+        node_repl.get("env") if isinstance(node_repl, dict) else None
+    )
+    policy = config.get("shell_environment_policy")
+    policy_environment = policy.get("set") if isinstance(policy, dict) else None
+    for configured in (node_repl_environment, policy_environment):
+        command = (
+            configured.get("CODEX_CLI_PATH")
+            if isinstance(configured, dict)
+            else None
+        )
+        if isinstance(command, str) and command.strip():
+            return command
+    return None
+
+
+def resolve_codex_command(
+    *,
+    environment: Mapping[str, str] | None = None,
+    which: Callable[[str], str | None] = shutil.which,
+) -> str | None:
+    """Locate the current CLI bundled with Codex or available on PATH."""
+    current_environment = os.environ if environment is None else environment
+    candidates: list[str] = []
+    environment_command = current_environment.get("CODEX_CLI_PATH")
+    if environment_command:
+        candidates.append(environment_command)
+    configured_command = _configured_codex_command(current_environment)
+    if configured_command:
+        candidates.append(configured_command)
+
+    local_app_data = current_environment.get("LOCALAPPDATA")
+    if local_app_data:
+        bin_directory = Path(local_app_data) / "OpenAI" / "Codex" / "bin"
+        if bin_directory.is_dir():
+            versioned = sorted(
+                bin_directory.glob("*/codex.exe"),
+                key=lambda path: path.stat().st_mtime,
+                reverse=True,
+            )
+            candidates.extend(str(path) for path in versioned)
+        candidates.append(str(bin_directory / "codex.exe"))
+
+    path_command = which("codex")
+    if path_command:
+        candidates.append(path_command)
+
+    seen: set[str] = set()
+    for candidate in candidates:
+        normalized = os.path.normcase(os.path.abspath(os.path.expanduser(candidate)))
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        if Path(candidate).expanduser().is_file():
+            return str(Path(candidate).expanduser())
+    return None
+
+
 def install_codex_plugin(
     marketplace_root: Path,
     *,
@@ -239,7 +312,7 @@ def install_codex_plugin(
         data_directory=data_directory,
         device=device,
     )
-    command = codex_command or shutil.which("codex")
+    command = codex_command or resolve_codex_command()
     if command is None:
         raise CodexPluginInstallError(
             "The Codex CLI was not found. Install or update the ChatGPT desktop "

--- a/src/vidxp/codex_plugin.py
+++ b/src/vidxp/codex_plugin.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from vidxp import __version__
+from vidxp.mcp_cli import stdio_client_config
+
+
+PLUGIN_NAME = "vidxp"
+MARKETPLACE_NAME = "vidxp-local"
+MANAGED_MARKER = ".vidxp-managed-marketplace"
+
+
+class CodexPluginInstallError(RuntimeError):
+    """Raised when the bundled Codex plugin cannot be installed safely."""
+
+
+@dataclass(frozen=True)
+class CodexPluginExport:
+    marketplace_root: str
+    marketplace_path: str
+    marketplace_name: str
+    plugin_name: str
+    plugin_version: str
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class CodexPluginInstall:
+    plugin_name: str
+    plugin_id: str | None
+    plugin_version: str
+    marketplace_name: str
+    marketplace_path: str
+    installed_path: str | None
+    detail: str
+
+    def to_dict(self) -> dict[str, str | None]:
+        return asdict(self)
+
+
+def bundled_codex_plugin() -> Path:
+    return Path(__file__).resolve().parent / "bundled_plugins" / PLUGIN_NAME
+
+
+def _json_bytes(payload: Any) -> bytes:
+    return (
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    ).encode("utf-8")
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.write_bytes(_json_bytes(payload))
+
+
+def _bundle_digest(source: Path, mcp_config: dict[str, Any]) -> str:
+    digest = hashlib.sha256(_json_bytes(mcp_config))
+    for path in sorted(item for item in source.rglob("*") if item.is_file()):
+        digest.update(path.relative_to(source).as_posix().encode("utf-8"))
+        digest.update(path.read_bytes())
+    return digest.hexdigest()[:12]
+
+
+def _validated_marketplace_root(marketplace_root: Path) -> Path:
+    root = marketplace_root.expanduser().resolve()
+    if root == Path(root.anchor):
+        raise CodexPluginInstallError(
+            "The Codex marketplace cannot be written at a filesystem root."
+        )
+    marker = root / MANAGED_MARKER
+    if root.exists() and any(root.iterdir()) and not marker.is_file():
+        raise CodexPluginInstallError(
+            f"Refusing to replace the unmanaged marketplace directory at {root}."
+        )
+    return root
+
+
+def export_codex_plugin(
+    marketplace_root: Path,
+    *,
+    registry: str | None = None,
+    repository: str = "default",
+    index_directory: str | None = None,
+    data_directory: Path | None = None,
+    device: str | None = None,
+) -> CodexPluginExport:
+    """Export a target-specific copy of VidXP's bundled Codex plugin."""
+
+    source = bundled_codex_plugin()
+    if not (source / ".codex-plugin" / "plugin.json").is_file():
+        raise CodexPluginInstallError(
+            "This VidXP installation does not contain the bundled Codex plugin."
+        )
+    root = _validated_marketplace_root(marketplace_root)
+    plugins_root = root / "plugins"
+    plugins_root.mkdir(parents=True, exist_ok=True)
+    plugin_root = plugins_root / PLUGIN_NAME
+    marker = root / MANAGED_MARKER
+
+    mcp_config = stdio_client_config(
+        registry=registry,
+        repository=repository,
+        index_directory=index_directory,
+        data_directory=data_directory,
+        device=device,
+    )
+    plugin_version = (
+        f"{__version__.split('+', 1)[0]}+codex."
+        f"{_bundle_digest(source, mcp_config)}"
+    )
+
+    staging_parent = Path(tempfile.mkdtemp(prefix=".vidxp-plugin-", dir=plugins_root))
+    staging_plugin = staging_parent / PLUGIN_NAME
+    backup = plugins_root / ".vidxp-plugin-backup"
+    try:
+        shutil.copytree(source, staging_plugin)
+        manifest_path = staging_plugin / ".codex-plugin" / "plugin.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["version"] = plugin_version
+        _write_json(manifest_path, manifest)
+        _write_json(staging_plugin / ".mcp.json", mcp_config)
+
+        if backup.exists():
+            shutil.rmtree(backup)
+        if plugin_root.exists():
+            if not marker.is_file():
+                raise CodexPluginInstallError(
+                    f"Refusing to replace the unmanaged plugin at {plugin_root}."
+                )
+            os.replace(plugin_root, backup)
+        try:
+            os.replace(staging_plugin, plugin_root)
+        except Exception:
+            if backup.exists() and not plugin_root.exists():
+                os.replace(backup, plugin_root)
+            raise
+        if backup.exists():
+            shutil.rmtree(backup)
+    finally:
+        if staging_parent.exists():
+            shutil.rmtree(staging_parent)
+
+    marketplace = {
+        "name": MARKETPLACE_NAME,
+        "interface": {"displayName": "VidXP Local"},
+        "plugins": [
+            {
+                "name": PLUGIN_NAME,
+                "source": {
+                    "source": "local",
+                    "path": f"./plugins/{PLUGIN_NAME}",
+                },
+                "policy": {
+                    "installation": "AVAILABLE",
+                    "authentication": "ON_INSTALL",
+                },
+                "category": "Productivity",
+            }
+        ],
+    }
+    marketplace_path = root / "marketplace.json"
+    _write_json(marketplace_path, marketplace)
+    marker.write_text("Managed by VidXP Desktop.\n", encoding="utf-8")
+    return CodexPluginExport(
+        marketplace_root=str(root),
+        marketplace_path=str(marketplace_path),
+        marketplace_name=MARKETPLACE_NAME,
+        plugin_name=PLUGIN_NAME,
+        plugin_version=plugin_version,
+    )
+
+
+CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _run_codex_json(
+    command: str,
+    arguments: Sequence[str],
+    *,
+    runner: CommandRunner,
+) -> dict[str, Any]:
+    try:
+        completed = runner(
+            [command, *arguments],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=60,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise CodexPluginInstallError(f"Codex could not be started: {exc}") from exc
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise CodexPluginInstallError(
+            detail or f"Codex exited with status {completed.returncode}."
+        )
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise CodexPluginInstallError(
+            "Codex did not return valid plugin installation details."
+        ) from exc
+    if not isinstance(payload, dict):
+        raise CodexPluginInstallError(
+            "Codex returned an unexpected plugin installation response."
+        )
+    return payload
+
+
+def install_codex_plugin(
+    marketplace_root: Path,
+    *,
+    registry: str | None = None,
+    repository: str = "default",
+    index_directory: str | None = None,
+    data_directory: Path | None = None,
+    device: str | None = None,
+    codex_command: str | None = None,
+    runner: CommandRunner = subprocess.run,
+) -> CodexPluginInstall:
+    """Export, register, and install VidXP's local Codex plugin."""
+
+    exported = export_codex_plugin(
+        marketplace_root,
+        registry=registry,
+        repository=repository,
+        index_directory=index_directory,
+        data_directory=data_directory,
+        device=device,
+    )
+    command = codex_command or shutil.which("codex")
+    if command is None:
+        raise CodexPluginInstallError(
+            "The Codex CLI was not found. Install or update the ChatGPT desktop "
+            "app, make the codex command available, and try again."
+        )
+
+    marketplace_result = _run_codex_json(
+        command,
+        [
+            "plugin",
+            "marketplace",
+            "add",
+            exported.marketplace_root,
+            "--json",
+        ],
+        runner=runner,
+    )
+    marketplace_name = str(
+        marketplace_result.get("marketplaceName") or exported.marketplace_name
+    )
+    plugin_result = _run_codex_json(
+        command,
+        [
+            "plugin",
+            "add",
+            f"{exported.plugin_name}@{marketplace_name}",
+            "--json",
+        ],
+        runner=runner,
+    )
+    return CodexPluginInstall(
+        plugin_name=str(plugin_result.get("name") or exported.plugin_name),
+        plugin_id=(
+            None
+            if plugin_result.get("pluginId") is None
+            else str(plugin_result["pluginId"])
+        ),
+        plugin_version=str(
+            plugin_result.get("version") or exported.plugin_version
+        ),
+        marketplace_name=str(
+            plugin_result.get("marketplaceName") or marketplace_name
+        ),
+        marketplace_path=exported.marketplace_path,
+        installed_path=(
+            None
+            if plugin_result.get("installedPath") is None
+            else str(plugin_result["installedPath"])
+        ),
+        detail=(
+            "VidXP is installed in Codex with its MCP server and skills. "
+            "Start a new Codex chat to use the updated plugin."
+        ),
+    )

--- a/src/vidxp/codex_plugin_cli.py
+++ b/src/vidxp/codex_plugin_cli.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from vidxp.codex_plugin import CodexPluginInstallError, install_codex_plugin
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Install VidXP's bundled MCP server and skills in Codex."
+    )
+    parser.add_argument(
+        "--marketplace-root",
+        type=Path,
+        required=True,
+        help="Dedicated local marketplace directory managed by VidXP Desktop.",
+    )
+    parser.add_argument("--registry")
+    parser.add_argument("--repository", default="default")
+    parser.add_argument("--index-directory")
+    parser.add_argument("--data-dir", type=Path)
+    parser.add_argument("--device")
+    return parser
+
+
+def main(arguments: Sequence[str] | None = None) -> None:
+    parser = _parser()
+    options = parser.parse_args(arguments)
+    try:
+        result = install_codex_plugin(
+            options.marketplace_root,
+            registry=options.registry,
+            repository=options.repository,
+            index_directory=options.index_directory,
+            data_directory=options.data_dir,
+            device=options.device,
+        )
+    except (CodexPluginInstallError, OSError, ValueError) as exc:
+        parser.exit(1, f"VidXP could not set up Codex: {exc}\n")
+    print(json.dumps(result.to_dict(), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/vidxp/mcp.py
+++ b/src/vidxp/mcp.py
@@ -103,6 +103,11 @@ from vidxp.idempotency import (
     scoped_job_id,
     scoped_request_key,
 )
+from vidxp.mcp_app import (
+    MCP_APP_MIME_TYPE,
+    MCP_APP_RESOURCE_URI,
+    load_mcp_app_html,
+)
 from vidxp.core.identifiers import ArtifactId
 from vidxp.evidence_delivery import (
     EvidenceDeliveryService,
@@ -147,6 +152,15 @@ _CANCEL = ToolAnnotations(
     idempotent_hint=True,
     open_world_hint=False,
 )
+
+
+def _mcp_app_tool_meta(invoking: str, invoked: str) -> dict[str, object]:
+    return {
+        "ui": {"resourceUri": MCP_APP_RESOURCE_URI},
+        "openai/outputTemplate": MCP_APP_RESOURCE_URI,
+        "openai/toolInvocation/invoking": invoking,
+        "openai/toolInvocation/invoked": invoked,
+    }
 
 
 class PrincipalBridge:
@@ -546,6 +560,27 @@ def create_mcp_server(
         auth=auth,
         lifespan=lifecycle,
     )
+
+    @server.resource(
+        MCP_APP_RESOURCE_URI,
+        name="vidxp_mcp_app",
+        title="VidXP video workspace",
+        description=(
+            "Interactive upload progress and evidence review for MCP Apps hosts."
+        ),
+        mime_type=MCP_APP_MIME_TYPE,
+        meta={
+            "ui": {
+                "prefersBorder": True,
+                "csp": {
+                    "connectDomains": [],
+                    "resourceDomains": [],
+                },
+            }
+        },
+    )
+    async def read_mcp_app() -> str:
+        return load_mcp_app_html()
 
     async def artifact_bytes(
         artifact_id: ArtifactId,
@@ -1061,9 +1096,125 @@ def create_mcp_server(
         )
         return "\n".join(lines)
 
-    async def evidence_content(
+    def evidence_app_payload(
+        *,
         job: Job,
-    ) -> list[ImageContent | ResourceLink | TextContent]:
+        source_job_id: JobId,
+        delivery: EvidenceDeliveryResult,
+        query_result: QueryAnswer | None,
+    ) -> dict[str, object]:
+        board = delivery.board
+        pages: list[dict[str, object]] = []
+        tiles: list[dict[str, object]] = []
+        if board is not None:
+            for page in board.pages:
+                artifact = page.artifact
+                delivery_info = artifact.delivery
+                pages.append(
+                    {
+                        "page_number": page.page_number,
+                        "media_id": page.media_id,
+                        "width": page.width,
+                        "height": page.height,
+                        "tile_ids": list(page.tile_ids),
+                        "resource_uri": artifact.resource_uri,
+                        "download_url": (
+                            delivery_info.download_url
+                            if delivery_info is not None
+                            else None
+                        ),
+                    }
+                )
+            for tile in board.tiles:
+                tiles.append(
+                    {
+                        "evidence_id": tile.evidence_id,
+                        "rank": tile.rank,
+                        "page_number": tile.page_number,
+                        "position": tile.position,
+                        "media_id": tile.media_id,
+                        "modalities": list(tile.modalities),
+                        "start": tile.start,
+                        "end": tile.end,
+                        "display_text": concise_text(tile.display_text),
+                        "state": tile.state.value,
+                    }
+                )
+            requested_count = board.requested_count
+            rendered_count = board.rendered_count
+            failed_count = board.failed_count
+            next_start_rank = board.next_start_rank
+        else:
+            for item in delivery.items:
+                resolved = item.range
+                tiles.append(
+                    {
+                        "evidence_id": item.evidence_id,
+                        "rank": item.rank,
+                        "page_number": None,
+                        "position": item.rank,
+                        "media_id": item.media_id,
+                        "modalities": list(item.modalities),
+                        "start": (
+                            resolved.source_start_seconds
+                            if resolved is not None
+                            else 0.0
+                        ),
+                        "end": (
+                            resolved.source_end_seconds
+                            if resolved is not None
+                            else 0.0
+                        ),
+                        "display_text": None,
+                        "state": item.state.value,
+                    }
+                )
+            requested_count = len(delivery.items)
+            rendered_count = sum(
+                item.state.value == "ready" for item in delivery.items
+            )
+            failed_count = requested_count - rendered_count
+            next_start_rank = None
+
+        answer: dict[str, object] | None = None
+        if query_result is not None:
+            answer = {
+                "mode": query_result.mode.value,
+                "claims": [
+                    {
+                        "text": concise_text(claim.text, limit=512) or "",
+                        "evidence_ids": list(claim.evidence_ids),
+                    }
+                    for claim in query_result.claims
+                ],
+                "fallback_reason": concise_text(
+                    query_result.fallback_reason,
+                    limit=512,
+                ),
+            }
+
+        return {
+            "view": "evidence",
+            "job_id": job.job_id,
+            "source_job_id": source_job_id,
+            "job_kind": job.kind.value,
+            "answer": answer,
+            "board": {
+                "requested_count": requested_count,
+                "rendered_count": rendered_count,
+                "failed_count": failed_count,
+                "next_start_rank": next_start_rank,
+                "pages": pages,
+                "tiles": tiles,
+            },
+        }
+
+    async def evidence_presentation(
+        job: Job,
+    ) -> tuple[
+        dict[str, object],
+        list[ImageContent | ResourceLink | TextContent],
+    ]:
         query_result = None
         if job.kind in {JobKind.search, JobKind.query}:
             result = job.result.result
@@ -1082,18 +1233,27 @@ def create_mcp_server(
                 delivery=projected_delivery,
                 query_result=query_result,
             )
+            source_job_id = job.job_id
         else:
             board = job.result.result
             projected_board, blocks = await project_evidence_board(board)
+            projected_delivery = EvidenceDeliveryResult(
+                policy=EvidenceDeliveryPolicy(mode=EvidenceDeliveryMode.none),
+                items=(),
+                board=projected_board,
+            )
             index = evidence_index(
                 source_job_id=board.source_job_id,
-                delivery=EvidenceDeliveryResult(
-                    policy=EvidenceDeliveryPolicy(mode=EvidenceDeliveryMode.none),
-                    items=(),
-                    board=projected_board,
-                ),
+                delivery=projected_delivery,
             )
-        return [TextContent(type="text", text=index), *blocks]
+            source_job_id = board.source_job_id
+        payload = evidence_app_payload(
+            job=job,
+            source_job_id=source_job_id,
+            delivery=projected_delivery,
+            query_result=query_result,
+        )
+        return payload, [TextContent(type="text", text=index), *blocks]
 
     def completed_evidence_result(
         source_job_id: JobId,
@@ -1227,6 +1387,10 @@ def create_mcp_server(
             "Automatic indexing defaults on. Poll only get_media_upload."
         ),
         annotations=_SUBMIT,
+        meta=_mcp_app_tool_meta(
+            "Creating a VidXP upload session…",
+            "VidXP upload session ready.",
+        ),
         structured_output=True,
     )
     async def create_media_upload(
@@ -1826,10 +1990,14 @@ def create_mcp_server(
         description=(
             "Present a completed search, query, or evidence-board job as a "
             "concise evidence index plus model-visible board images and resource "
-            "links. This intentionally omits structuredContent; use get_job only "
-            "when the full machine record is actually needed."
+            "links. The compact structured result drives the optional VidXP "
+            "evidence-review UI without exposing the full machine record."
         ),
         annotations=_READ_ONLY,
+        meta=_mcp_app_tool_meta(
+            "Opening VidXP evidence…",
+            "VidXP evidence ready.",
+        ),
     )
     async def get_job_evidence(job_id: JobId) -> CallToolResult:
         def completed_evidence_job(_actor: Principal) -> Job:
@@ -1855,10 +2023,13 @@ def create_mcp_server(
             operation=completed_evidence_job,
         )
         try:
-            blocks = await evidence_content(job)
+            structured_content, blocks = await evidence_presentation(job)
         except ApplicationError as exc:
             raise _application_error(exc) from exc
-        return CallToolResult(content=blocks)
+        return CallToolResult(
+            content=blocks,
+            structured_content=structured_content,
+        )
 
     @server.tool(
         title="Get compact job status",

--- a/src/vidxp/mcp_app.py
+++ b/src/vidxp/mcp_app.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from importlib.resources import files
+
+
+MCP_APP_RESOURCE_URI = "ui://vidxp/evidence-review-v1.html"
+MCP_APP_MIME_TYPE = "text/html;profile=mcp-app"
+
+
+@lru_cache(maxsize=1)
+def load_mcp_app_html() -> str:
+    """Load the self-contained MCP App resource shipped with VidXP."""
+
+    return (
+        files("vidxp")
+        .joinpath("assets", "mcp_app", "index.html")
+        .read_text(encoding="utf-8")
+    )

--- a/tests/test_codex_plugin.py
+++ b/tests/test_codex_plugin.py
@@ -35,9 +35,8 @@ def test_export_codex_plugin_materializes_skills_and_target_mcp_config() -> None
             )
         )
         mcp = json.loads((plugin_root / ".mcp.json").read_text(encoding="utf-8"))
-        marketplace = json.loads(
-            (root / "marketplace.json").read_text(encoding="utf-8")
-        )
+        marketplace_path = root / ".agents" / "plugins" / "marketplace.json"
+        marketplace = json.loads(marketplace_path.read_text(encoding="utf-8"))
 
         assert manifest["name"] == "vidxp"
         assert manifest["version"] == exported.plugin_version
@@ -64,6 +63,25 @@ def test_export_codex_plugin_materializes_skills_and_target_mcp_config() -> None
             "installation": "AVAILABLE",
             "authentication": "ON_INSTALL",
         }
+        assert exported.marketplace_path == str(marketplace_path)
+        assert not (root / "marketplace.json").exists()
+
+
+def test_export_migrates_the_legacy_managed_marketplace_layout() -> None:
+    with TemporaryDirectory() as directory:
+        root = Path(directory) / "marketplace"
+        root.mkdir()
+        (root / ".vidxp-managed-marketplace").write_text(
+            "Managed by VidXP Desktop.\n",
+            encoding="utf-8",
+        )
+        legacy_path = root / "marketplace.json"
+        legacy_path.write_text("{}\n", encoding="utf-8")
+
+        exported = export_codex_plugin(root)
+
+        assert Path(exported.marketplace_path).is_file()
+        assert not legacy_path.exists()
 
 
 def test_install_codex_plugin_registers_marketplace_then_installs_bundle() -> None:

--- a/tests/test_codex_plugin.py
+++ b/tests/test_codex_plugin.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from vidxp.codex_plugin import (
+    CodexPluginInstallError,
+    export_codex_plugin,
+    install_codex_plugin,
+)
+
+
+def test_export_codex_plugin_materializes_skills_and_target_mcp_config() -> None:
+    with TemporaryDirectory() as directory:
+        root = Path(directory) / "codex-marketplace"
+        index_directory = Path("C:/VidXP/repositories/default")
+        data_directory = Path("C:/VidXP")
+        exported = export_codex_plugin(
+            root,
+            repository="default",
+            index_directory=str(index_directory),
+            data_directory=data_directory,
+        )
+
+        plugin_root = root / "plugins" / "vidxp"
+        manifest = json.loads(
+            (plugin_root / ".codex-plugin" / "plugin.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        mcp = json.loads((plugin_root / ".mcp.json").read_text(encoding="utf-8"))
+        marketplace = json.loads(
+            (root / "marketplace.json").read_text(encoding="utf-8")
+        )
+
+        assert manifest["name"] == "vidxp"
+        assert manifest["version"] == exported.plugin_version
+        assert "+codex." in exported.plugin_version
+        assert (plugin_root / "skills" / "vidxp-ingest-video" / "SKILL.md").is_file()
+        assert (
+            plugin_root / "skills" / "vidxp-find-video-evidence" / "SKILL.md"
+        ).is_file()
+        assert mcp["mcpServers"]["vidxp"]["args"] == [
+            "--repository",
+            "default",
+            "--index-directory",
+            str(index_directory),
+            "--data-dir",
+            str(data_directory),
+        ]
+        assert Path(mcp["mcpServers"]["vidxp"]["command"]).name.lower() in {
+            "vidxp-mcp",
+            "vidxp-mcp.exe",
+        }
+        assert marketplace["name"] == "vidxp-local"
+        assert marketplace["plugins"][0]["source"]["path"] == "./plugins/vidxp"
+        assert marketplace["plugins"][0]["policy"] == {
+            "installation": "AVAILABLE",
+            "authentication": "ON_INSTALL",
+        }
+
+
+def test_install_codex_plugin_registers_marketplace_then_installs_bundle() -> None:
+    calls: list[list[str]] = []
+
+    def runner(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[1:4] == ["plugin", "marketplace", "add"]:
+            payload = {"marketplaceName": "vidxp-local", "alreadyAdded": False}
+        else:
+            payload = {
+                "pluginId": "vidxp@vidxp-local",
+                "name": "vidxp",
+                "marketplaceName": "vidxp-local",
+                "version": "0.4.0+codex.example",
+                "installedPath": "/codex/cache/vidxp",
+            }
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+
+    with TemporaryDirectory() as directory:
+        result = install_codex_plugin(
+            Path(directory) / "marketplace",
+            codex_command="codex-test",
+            runner=runner,
+        )
+
+    assert calls[0][0:4] == ["codex-test", "plugin", "marketplace", "add"]
+    assert calls[0][-1] == "--json"
+    assert calls[1] == [
+        "codex-test",
+        "plugin",
+        "add",
+        "vidxp@vidxp-local",
+        "--json",
+    ]
+    assert result.plugin_id == "vidxp@vidxp-local"
+    assert result.installed_path == "/codex/cache/vidxp"
+    assert "MCP server and skills" in result.detail
+
+
+def test_export_refuses_to_replace_an_unmanaged_marketplace() -> None:
+    with TemporaryDirectory() as directory:
+        root = Path(directory) / "marketplace"
+        root.mkdir()
+        (root / "keep.txt").write_text("user data", encoding="utf-8")
+
+        with pytest.raises(CodexPluginInstallError, match="unmanaged marketplace"):
+            export_codex_plugin(root)
+
+        assert (root / "keep.txt").read_text(encoding="utf-8") == "user data"

--- a/tests/test_codex_plugin.py
+++ b/tests/test_codex_plugin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -11,6 +12,7 @@ from vidxp.codex_plugin import (
     CodexPluginInstallError,
     export_codex_plugin,
     install_codex_plugin,
+    resolve_codex_command,
 )
 
 
@@ -112,3 +114,87 @@ def test_export_refuses_to_replace_an_unmanaged_marketplace() -> None:
             export_codex_plugin(root)
 
         assert (root / "keep.txt").read_text(encoding="utf-8") == "user data"
+
+
+def test_resolve_codex_command_prefers_desktop_configured_cli() -> None:
+    with TemporaryDirectory() as directory:
+        root = Path(directory)
+        codex_home = root / ".codex"
+        configured = root / "current" / "codex.exe"
+        stale = root / "OpenAI" / "Codex" / "bin" / "codex.exe"
+        configured.parent.mkdir(parents=True)
+        stale.parent.mkdir(parents=True)
+        configured.touch()
+        stale.touch()
+        codex_home.mkdir()
+        escaped_command = str(configured).replace("\\", "\\\\")
+        (codex_home / "config.toml").write_text(
+            "[mcp_servers.node_repl.env]\n"
+            f'CODEX_CLI_PATH = "{escaped_command}"\n',
+            encoding="utf-8",
+        )
+
+        resolved = resolve_codex_command(
+            environment={
+                "CODEX_HOME": str(codex_home),
+                "LOCALAPPDATA": str(root),
+            },
+            which=lambda _: None,
+        )
+
+    assert resolved == str(configured)
+
+
+def test_resolve_codex_command_uses_desktop_environment_path() -> None:
+    with TemporaryDirectory() as directory:
+        command = Path(directory) / "codex.exe"
+        command.touch()
+
+        resolved = resolve_codex_command(
+            environment={"CODEX_CLI_PATH": str(command)},
+            which=lambda _: None,
+        )
+
+    assert resolved == str(command)
+
+
+def test_resolve_codex_command_falls_back_to_local_app_install() -> None:
+    with TemporaryDirectory() as directory:
+        root = Path(directory)
+        command = root / "OpenAI" / "Codex" / "bin" / "codex.exe"
+        command.parent.mkdir(parents=True)
+        command.touch()
+
+        resolved = resolve_codex_command(
+            environment={
+                "CODEX_HOME": str(root / "missing-codex-home"),
+                "LOCALAPPDATA": str(root),
+            },
+            which=lambda _: None,
+        )
+
+    assert resolved == str(command)
+
+
+def test_resolve_codex_command_prefers_newest_versioned_local_cli() -> None:
+    with TemporaryDirectory() as directory:
+        root = Path(directory)
+        bin_directory = root / "OpenAI" / "Codex" / "bin"
+        stable = bin_directory / "codex.exe"
+        older = bin_directory / "old" / "codex.exe"
+        current = bin_directory / "current" / "codex.exe"
+        for command in (stable, older, current):
+            command.parent.mkdir(parents=True, exist_ok=True)
+            command.touch()
+        os.utime(older, (1, 1))
+        os.utime(current, (2, 2))
+
+        resolved = resolve_codex_command(
+            environment={
+                "CODEX_HOME": str(root / "missing-codex-home"),
+                "LOCALAPPDATA": str(root),
+            },
+            which=lambda _: None,
+        )
+
+    assert resolved == str(current)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -72,6 +72,7 @@ from vidxp.application_models import (
     SearchMomentsPlanStep,
     WorkspaceOverview,
 )
+from vidxp.mcp_app import MCP_APP_MIME_TYPE, MCP_APP_RESOURCE_URI
 from vidxp.authentication import (
     AuthenticatedBearer,
     OIDCBearerAuthenticator,
@@ -439,12 +440,38 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
             async with Client(server) as client:
                 discovered = await client.list_tools()
                 result = await client.call_tool("list_capabilities", {})
+                app_resource = await client.read_resource(MCP_APP_RESOURCE_URI)
 
         self.assertEqual(
             [tool.name for tool in discovered.tools],
             MCP_TOOL_NAMES,
         )
         tools = {tool.name: tool for tool in discovered.tools}
+        for name in ("create_media_upload", "get_job_evidence"):
+            self.assertEqual(
+                tools[name].meta["ui"]["resourceUri"],
+                MCP_APP_RESOURCE_URI,
+            )
+            self.assertEqual(
+                tools[name].meta["openai/outputTemplate"],
+                MCP_APP_RESOURCE_URI,
+            )
+        app_contents = app_resource.contents[0]
+        self.assertEqual(app_contents.mime_type, MCP_APP_MIME_TYPE)
+        self.assertEqual(
+            app_contents.meta["ui"]["csp"],
+            {"connectDomains": [], "resourceDomains": []},
+        )
+        self.assertIn("ui/notifications/tool-result", app_contents.text)
+        self.assertIn('request("ui/initialize"', app_contents.text)
+        self.assertIn('notify("ui/notifications/initialized"', app_contents.text)
+        self.assertIn('request("tools/call"', app_contents.text)
+        self.assertIn('request("ui/open-link"', app_contents.text)
+        self.assertIn('request("ui/request-display-mode"', app_contents.text)
+        self.assertIn('request("ui/update-model-context"', app_contents.text)
+        self.assertIn("window.openai?.requestDisplayMode", app_contents.text)
+        self.assertIn("materialize_job_evidence", app_contents.text)
+        self.assertNotIn("<script src=", app_contents.text)
         self.assertIsNone(tools["get_job_evidence"].output_schema)
         self.assertIsNone(tools["materialize_job_evidence"].output_schema)
         self.assertTrue(
@@ -1528,7 +1555,17 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
                         resource = await client.read_resource(uri)
 
                     self.assertFalse(result.is_error)
-                    self.assertIsNone(result.structured_content)
+                    self.assertEqual(result.structured_content["view"], "evidence")
+                    self.assertEqual(
+                        result.structured_content["source_job_id"],
+                        JOB_ID,
+                    )
+                    self.assertEqual(
+                        result.structured_content["board"]["tiles"][0][
+                            "evidence_id"
+                        ],
+                        "e" * 64,
+                    )
                     self.assertIn(evidence_id := "e" * 64, result.content[0].text)
                     self.assertIn("1.000-2.000", result.content[0].text)
                     if transport == "local_stdio":
@@ -1604,7 +1641,10 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
                             "get_job_evidence", {"job_id": JOB_ID}
                         )
                         self.assertFalse(result.is_error)
-                        self.assertIsNone(result.structured_content)
+                        self.assertEqual(
+                            result.structured_content["view"],
+                            "evidence",
+                        )
                         self.assertEqual(
                             any(
                                 isinstance(block, ImageContent)
@@ -1934,7 +1974,22 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
                 result = await client.call_tool("get_job_evidence", {"job_id": JOB_ID})
 
             self.assertFalse(result.is_error, result.content)
-            self.assertIsNone(result.structured_content)
+            self.assertEqual(result.structured_content["view"], "evidence")
+            self.assertEqual(result.structured_content["source_job_id"], JOB_ID)
+            self.assertEqual(
+                result.structured_content["board"]["rendered_count"],
+                1,
+            )
+            self.assertEqual(
+                result.structured_content["board"]["pages"][0]["resource_uri"],
+                f"vidxp://artifacts/{ARTIFACT_ID}/content.jpg",
+            )
+            self.assertEqual(
+                result.structured_content["board"]["tiles"][0]["evidence_id"],
+                "e" * 64,
+            )
+            serialized = json.dumps(result.structured_content)
+            self.assertNotIn("source_fingerprint", serialized)
             self.assertIn("Board: 1/1 candidates", result.content[0].text)
             self.assertIn("1.000-2.000", result.content[0].text)
             self.assertIn("e" * 64, result.content[0].text)
@@ -2105,7 +2160,8 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
                 block for block in presented.content if isinstance(block, ResourceLink)
             ]
             self.assertEqual(len(links), 2)
-            self.assertIsNone(presented.structured_content)
+            self.assertEqual(presented.structured_content["view"], "evidence")
+            self.assertIsNone(presented.structured_content["answer"])
             self.assertTrue(
                 any(isinstance(block, ImageContent) for block in presented.content)
             )
@@ -2131,7 +2187,12 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
             )
             query_result = completed_query.structured_content["result"]["result"]
             cited = query_result["claims"][0]["evidence_ids"][0]
-            self.assertIsNone(presented_query.structured_content)
+            self.assertEqual(
+                presented_query.structured_content["answer"]["claims"][0][
+                    "evidence_ids"
+                ],
+                [cited],
+            )
             self.assertIn("Grounded answer:", presented_query.content[0].text)
             self.assertIn(cited, presented_query.content[0].text)
             self.assertEqual(cited, query_result["evidence"][0]["evidence_id"])

--- a/tests/test_normalize_sdist.py
+++ b/tests/test_normalize_sdist.py
@@ -1,0 +1,68 @@
+import io
+import hashlib
+from pathlib import Path
+import tarfile
+from tempfile import TemporaryDirectory
+import unittest
+
+from utils.normalize_sdist import normalize_sdist
+
+
+class NormalizeSdistTests(unittest.TestCase):
+    def test_rewrites_archive_with_reproducible_metadata(self):
+        with TemporaryDirectory() as directory:
+            archive_path = Path(directory) / "example.tar.gz"
+            with tarfile.open(archive_path, "w:gz") as archive:
+                for name, content in (
+                    ("example/z-last.txt", b"last"),
+                    ("example/a-first.txt", b"first"),
+                ):
+                    member = tarfile.TarInfo(name)
+                    member.size = len(content)
+                    member.uid = 501
+                    member.gid = 20
+                    member.uname = "builder"
+                    member.gname = "staff"
+                    member.mtime = 1
+                    archive.addfile(member, io.BytesIO(content))
+
+            normalize_sdist(archive_path, 1_700_000_000)
+            first_digest = hashlib.sha256(archive_path.read_bytes()).digest()
+            normalize_sdist(archive_path, 1_700_000_000)
+            self.assertEqual(
+                hashlib.sha256(archive_path.read_bytes()).digest(),
+                first_digest,
+            )
+
+            with archive_path.open("rb") as compressed:
+                compressed.seek(4)
+                self.assertEqual(compressed.read(4), b"\0\0\0\0")
+
+            with tarfile.open(archive_path, "r:gz") as archive:
+                members = archive.getmembers()
+                self.assertEqual(
+                    [member.name for member in members],
+                    ["example/a-first.txt", "example/z-last.txt"],
+                )
+                for member in members:
+                    self.assertEqual(member.uid, 0)
+                    self.assertEqual(member.gid, 0)
+                    self.assertEqual(member.uname, "")
+                    self.assertEqual(member.gname, "")
+                    self.assertEqual(member.mtime, 1_700_000_000)
+                self.assertEqual(
+                    archive.extractfile("example/a-first.txt").read(),
+                    b"first",
+                )
+                self.assertEqual(
+                    archive.extractfile("example/z-last.txt").read(),
+                    b"last",
+                )
+
+    def test_rejects_negative_source_date_epoch(self):
+        with self.assertRaisesRegex(ValueError, "must be non-negative"):
+            normalize_sdist(Path("unused.tar.gz"), -1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -39,6 +39,12 @@ class PackagingTests(unittest.TestCase):
             self.assertEqual(len(wheels), 1)
             with zipfile.ZipFile(wheels[0]) as archive:
                 members = set(archive.namelist())
+                entry_points_name = next(
+                    name
+                    for name in members
+                    if name.endswith(".dist-info/entry_points.txt")
+                )
+                entry_points = archive.read(entry_points_name).decode("utf-8")
 
         required = {
             "vidxp/assets/mcp_app/index.html",
@@ -50,6 +56,10 @@ class PackagingTests(unittest.TestCase):
             "vidxp/bundled_plugins/vidxp/skills/vidxp-find-video-evidence/agents/openai.yaml",
         }
         self.assertLessEqual(required, members)
+        self.assertIn(
+            "vidxp-codex-plugin = vidxp.codex_plugin_cli:main",
+            entry_points,
+        )
 
     def test_bundled_plugin_is_valid_and_skills_match_canonical_sources(self):
         project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import tarfile
 import unittest
+import zipfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import tomllib
@@ -19,6 +20,76 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class PackagingTests(unittest.TestCase):
+    def test_wheel_contains_mcp_app_and_versioned_plugin_bundle(self):
+        with TemporaryDirectory() as directory:
+            subprocess.run(
+                [
+                    sys.executable,
+                    "setup.py",
+                    "bdist_wheel",
+                    "--dist-dir",
+                    directory,
+                ],
+                cwd=ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            wheels = tuple(Path(directory).glob("*.whl"))
+            self.assertEqual(len(wheels), 1)
+            with zipfile.ZipFile(wheels[0]) as archive:
+                members = set(archive.namelist())
+
+        required = {
+            "vidxp/assets/mcp_app/index.html",
+            "vidxp/bundled_plugins/vidxp/.mcp.json",
+            "vidxp/bundled_plugins/vidxp/.codex-plugin/plugin.json",
+            "vidxp/bundled_plugins/vidxp/skills/vidxp-ingest-video/SKILL.md",
+            "vidxp/bundled_plugins/vidxp/skills/vidxp-ingest-video/agents/openai.yaml",
+            "vidxp/bundled_plugins/vidxp/skills/vidxp-find-video-evidence/SKILL.md",
+            "vidxp/bundled_plugins/vidxp/skills/vidxp-find-video-evidence/agents/openai.yaml",
+        }
+        self.assertLessEqual(required, members)
+
+    def test_bundled_plugin_is_valid_and_skills_match_canonical_sources(self):
+        project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        plugin_root = ROOT / "src" / "vidxp" / "bundled_plugins" / "vidxp"
+        manifest = json.loads(
+            (plugin_root / ".codex-plugin" / "plugin.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        mcp = json.loads((plugin_root / ".mcp.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(manifest["name"], "vidxp")
+        self.assertEqual(
+            Version(manifest["version"]),
+            Version(project["project"]["version"]),
+        )
+        self.assertEqual(manifest["skills"], "./skills/")
+        self.assertEqual(manifest["mcpServers"], "./.mcp.json")
+        self.assertEqual(mcp["mcpServers"]["vidxp"]["command"], "vidxp-mcp")
+
+        canonical = ROOT / "skills"
+        bundled = plugin_root / "skills"
+        canonical_files = {
+            path.relative_to(canonical)
+            for path in canonical.rglob("*")
+            if path.is_file()
+        }
+        bundled_files = {
+            path.relative_to(bundled)
+            for path in bundled.rglob("*")
+            if path.is_file()
+        }
+        self.assertEqual(bundled_files, canonical_files)
+        for relative in canonical_files:
+            self.assertEqual(
+                (bundled / relative).read_text(encoding="utf-8"),
+                (canonical / relative).read_text(encoding="utf-8"),
+                relative.as_posix(),
+            )
+
     def test_sdist_contains_every_upload_page_build_input(self):
         with TemporaryDirectory() as directory:
             subprocess.run(
@@ -590,6 +661,7 @@ class PackagingTests(unittest.TestCase):
     def test_combined_release_version_contract(self):
         expected_extra_files = {
             "uv.lock",
+            "src/vidxp/bundled_plugins/vidxp/.codex-plugin/plugin.json",
             "desktop/src-tauri/Cargo.toml",
             "desktop/src-tauri/Cargo.lock",
             "desktop/package.json",

--- a/utils/build_package.sh
+++ b/utils/build_package.sh
@@ -33,23 +33,7 @@ echo "📦 Building package..."
 python -m build
 
 for sdist in "$DIST_DIR"/*.tar.gz; do
-  archive_listing="$(tar -tzf "$sdist")"
-  archive_root="${archive_listing%%/*}"
-  normalize_dir="$(mktemp -d)"
-  uncompressed="${sdist%.gz}"
-  tar -xzf "$sdist" -C "$normalize_dir"
-  rm -- "$sdist"
-  tar \
-    --sort=name \
-    --mtime="@${SOURCE_DATE_EPOCH}" \
-    --owner=0 \
-    --group=0 \
-    --numeric-owner \
-    -cf "$uncompressed" \
-    -C "$normalize_dir" \
-    "$archive_root"
-  gzip --no-name --best "$uncompressed"
-  rm -rf -- "$normalize_dir"
+  python utils/normalize_sdist.py "$sdist" "$SOURCE_DATE_EPOCH"
 done
 
 echo "♻️ Restoring original README..."

--- a/utils/normalize_sdist.py
+++ b/utils/normalize_sdist.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Normalize an sdist archive without relying on platform-specific tar flags."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import gzip
+import os
+from pathlib import Path
+import tarfile
+import tempfile
+
+
+def normalize_sdist(path: Path, source_date_epoch: int) -> None:
+    """Rewrite *path* with stable member ordering and ownership metadata."""
+    if source_date_epoch < 0:
+        raise ValueError("SOURCE_DATE_EPOCH must be non-negative")
+
+    path = path.resolve()
+    temporary_path: Path | None = None
+    try:
+        with tarfile.open(path, "r:gz") as source:
+            members = sorted(source.getmembers(), key=lambda member: member.name)
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                dir=path.parent,
+                prefix=f".{path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as temporary:
+                temporary_path = Path(temporary.name)
+                with gzip.GzipFile(
+                    filename="",
+                    mode="wb",
+                    compresslevel=9,
+                    fileobj=temporary,
+                    mtime=0,
+                ) as compressed:
+                    with tarfile.open(
+                        fileobj=compressed,
+                        mode="w",
+                        format=tarfile.GNU_FORMAT,
+                    ) as destination:
+                        for original in members:
+                            normalized = copy.copy(original)
+                            normalized.uid = 0
+                            normalized.gid = 0
+                            normalized.uname = ""
+                            normalized.gname = ""
+                            normalized.mtime = source_date_epoch
+                            normalized.pax_headers = {}
+                            content = (
+                                source.extractfile(original)
+                                if original.isfile()
+                                else None
+                            )
+                            try:
+                                destination.addfile(normalized, content)
+                            finally:
+                                if content is not None:
+                                    content.close()
+
+        os.replace(temporary_path, path)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive", type=Path)
+    parser.add_argument("source_date_epoch", type=int)
+    args = parser.parse_args()
+    normalize_sdist(args.archive, args.source_date_epoch)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Bundle VidXP’s ingest and evidence skills with its local MCP server and optional MCP Apps UI.
- Add a Desktop **Set up in Codex** action that exports a target-specific local marketplace and installs the plugin through Codex, while retaining **Copy MCP setup** for other clients.
- Keep video data, model execution, and STDIO MCP local; no storage/model migration or index rebuild is required.

## Validation

- `uv run --no-sync ruff check .`
- `uv run --no-sync python -m pytest -q` — 674 passed, 5 skipped, 95 subtests.
- `npm --prefix desktop run check` — typecheck, lint, 38 tests, production build.
- `cargo test --locked --manifest-path desktop/src-tauri/Cargo.toml` — 79 passed.
- `npm --prefix desktop run model-catalog:check`
- `npm --prefix desktop run notices:check`
- `npm --prefix desktop run sidecar:windows`
- Isolated wheel build — plugin bundle and `vidxp-codex-plugin` entry point included.
- Bundled Codex plugin manifest/structure validation passed.

BEGIN_COMMIT_OVERRIDE
chore(codex): bundle the VidXP plugin with Desktop
END_COMMIT_OVERRIDE
