### PR TITLE
fix(desktop): stabilize managed runtime status and errors

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -4210,44 +4210,87 @@ fn current_unix_seconds() -> u64 {
 
 fn tray_installation_label(profile: Option<&target_profiles::TargetProfile>, now: u64) -> String {
     let Some(profile) = profile else {
-        return "No VidXP installation selected".into();
+        return "No installation selected".into();
     };
-    let state = match profile.validation_error.as_ref().map(|error| &error.code) {
-        Some(target_profiles::TargetErrorCode::RuntimeUpdateRequired) => "Update required",
-        Some(_) => "Needs attention",
-        None if !profile.is_ready(now) => "Check required",
-        None => "Ready",
-    };
-    format!("{} · {state}", profile.display_name)
+    match profile.validation_error.as_ref().map(|error| &error.code) {
+        Some(target_profiles::TargetErrorCode::RuntimeUpdateRequired) => {
+            format!("{} · Update required", profile.display_name)
+        }
+        Some(_) => format!("{} · Needs attention", profile.display_name),
+        None if !profile.is_ready(now) => format!("{} · Check setup", profile.display_name),
+        None => profile.display_name.clone(),
+    }
 }
 
-fn tray_browser_label(status: &BrowserServiceStatus) -> String {
+fn tray_capability_state(selected: bool, installed: bool, ready: bool) -> Option<&'static str> {
+    if !selected || !ready {
+        Some("Unavailable")
+    } else if !installed {
+        Some("Not installed")
+    } else {
+        None
+    }
+}
+
+fn tray_browser_label(
+    status: &BrowserServiceStatus,
+    selected: bool,
+    installed: bool,
+    ready: bool,
+    status_known: bool,
+) -> String {
+    if let Some(state) = tray_capability_state(selected, installed, ready) {
+        return format!("Browser · {state}");
+    }
+    if !status_known {
+        return "Browser · Status unknown".into();
+    }
     if !status.running {
-        return "Browser interface · Stopped".into();
+        return "Browser · Off".into();
     }
     if status.shared {
-        return format!(
-            "Browser interface · Shared · {}",
-            status
-                .network_url
-                .as_deref()
-                .unwrap_or("address unavailable")
-        );
+        return "Browser · Shared".into();
     }
-    format!(
-        "Browser interface · Private · {}",
-        status.local_url.as_deref().unwrap_or("address unavailable")
-    )
+    "Browser · Private".into()
 }
 
-fn tray_server_label(status: &LocalServerStatus) -> String {
+fn tray_worker_label(
+    status: Option<&Result<LocalWorkerStatus, String>>,
+    selected: bool,
+    installed: bool,
+    ready: bool,
+) -> String {
+    if let Some(state) = tray_capability_state(selected, installed, ready) {
+        return format!("Processing · {state}");
+    }
+    match status {
+        Some(Ok(status)) if status.running => "Processing · On",
+        Some(Ok(_)) => "Processing · Off",
+        Some(Err(_)) => "Processing · Status unknown",
+        None => "Processing · Checking…",
+    }
+    .into()
+}
+
+fn tray_server_label(
+    status: &LocalServerStatus,
+    selected: bool,
+    installed: bool,
+    ready: bool,
+    status_known: bool,
+) -> String {
+    if let Some(state) = tray_capability_state(selected, installed, ready) {
+        return format!("App integration · {state}");
+    }
+    if !status_known {
+        return "App integration · Status unknown".into();
+    }
     if !status.running {
-        return "App integration service · Stopped".into();
+        return "App integration · Off".into();
     }
     format!(
-        "App integration service · {} · {}",
-        if status.shared { "Shared" } else { "Private" },
-        status.origin.as_deref().unwrap_or("address unavailable")
+        "App integration · {}",
+        if status.shared { "Shared" } else { "Private" }
     )
 }
 
@@ -4261,17 +4304,23 @@ fn refresh_tray_menu(app: &AppHandle) {
     let profile = target_state
         .as_ref()
         .and_then(target_profiles::TargetState::selected_profile);
+    let selected = profile.is_some();
     let ready = profile.is_some_and(|profile| profile.is_ready(current_unix_seconds()));
-    let browser_available = ready && profile.is_some_and(|profile| profile.frontend.launchable);
-    let worker_available = ready
-        && profile
-            .is_some_and(|profile| profile.surfaces.iter().any(|surface| surface == "worker"));
-    let server_available = ready
-        && profile
-            .is_some_and(|profile| profile.surfaces.iter().any(|surface| surface == "server"));
-    let browser = inspect_browser_service(&state)
+    let browser_installed = profile.is_some_and(|profile| profile.frontend.launchable);
+    let worker_installed =
+        profile.is_some_and(|profile| profile.surfaces.iter().any(|surface| surface == "worker"));
+    let server_installed =
+        profile.is_some_and(|profile| profile.surfaces.iter().any(|surface| surface == "server"));
+    let browser_available = ready && browser_installed;
+    let worker_available = ready && worker_installed;
+    let server_available = ready && server_installed;
+    let browser_result = inspect_browser_service(&state);
+    let browser_status_known = browser_result.is_ok();
+    let browser = browser_result
         .unwrap_or_else(|error| stopped_browser_status(format!("Status unavailable: {error}")));
-    let server = inspect_local_server(&state)
+    let server_result = inspect_local_server(&state);
+    let server_status_known = server_result.is_ok();
+    let server = server_result
         .unwrap_or_else(|error| stopped_server_status(format!("Status unavailable: {error}")));
     let worker = profile.and_then(|profile| {
         state.worker_status.lock().ok().and_then(|cached| {
@@ -4285,21 +4334,36 @@ fn refresh_tray_menu(app: &AppHandle) {
     let _ = items
         .installation
         .set_text(tray_installation_label(profile, current_unix_seconds()));
-    let _ = items.browser.set_text(tray_browser_label(&browser));
+    let _ = items.browser.set_text(tray_browser_label(
+        &browser,
+        selected,
+        browser_installed,
+        ready,
+        browser_status_known,
+    ));
     let _ = items.browser.set_enabled(browser_available);
+    let _ = items.open_browser.set_text(if browser.running {
+        "Open VidXP"
+    } else {
+        "Start and open VidXP"
+    });
     let _ = items.open_browser.set_enabled(browser_available);
+    let _ = items.share_browser.set_text(if browser.running {
+        "Share on local network"
+    } else {
+        "Start and share"
+    });
     let _ = items
         .share_browser
         .set_enabled(browser_available && !browser.shared);
     let _ = items.stop_browser.set_enabled(browser.running);
 
-    let worker_label = match worker.as_ref() {
-        Some(Ok(status)) if status.running => "Local video processing · Running",
-        Some(Ok(_)) => "Local video processing · Stopped",
-        Some(Err(_)) => "Local video processing · Needs attention",
-        None => "Local video processing · Checking…",
-    };
-    let _ = items.worker.set_text(worker_label);
+    let _ = items.worker.set_text(tray_worker_label(
+        worker.as_ref(),
+        selected,
+        worker_installed,
+        ready,
+    ));
     let _ = items.worker.set_enabled(worker_available);
     let _ = items.start_worker.set_enabled(
         worker_available
@@ -4313,7 +4377,13 @@ fn refresh_tray_menu(app: &AppHandle) {
             .is_some_and(|status| status.as_ref().is_ok_and(|status| status.running)),
     );
 
-    let _ = items.server.set_text(tray_server_label(&server));
+    let _ = items.server.set_text(tray_server_label(
+        &server,
+        selected,
+        server_installed,
+        ready,
+        server_status_known,
+    ));
     let _ = items.server.set_enabled(server_available);
     let _ = items.start_server.set_text(if server.shared {
         "Make private"
@@ -4326,6 +4396,11 @@ fn refresh_tray_menu(app: &AppHandle) {
     let _ = items
         .share_server
         .set_enabled(server_available && !server.shared);
+    let _ = items.share_server.set_text(if server.running {
+        "Share on local network"
+    } else {
+        "Start and share"
+    });
     let _ = items.stop_server.set_enabled(server.running);
 }
 
@@ -4463,16 +4538,10 @@ fn create_tray(app: &tauri::App) -> tauri::Result<()> {
         true,
         None::<&str>,
     )?;
-    let stop_browser = MenuItem::with_id(
-        app,
-        "stop-browser",
-        "Stop browser interface",
-        false,
-        None::<&str>,
-    )?;
+    let stop_browser = MenuItem::with_id(app, "stop-browser", "Stop browser", false, None::<&str>)?;
     let browser = Submenu::with_items(
         app,
-        "Browser interface",
+        "Browser · Checking…",
         true,
         &[&share_browser, &stop_browser],
     )?;
@@ -4482,7 +4551,7 @@ fn create_tray(app: &tauri::App) -> tauri::Result<()> {
         MenuItem::with_id(app, "stop-worker", "Stop processing", false, None::<&str>)?;
     let worker = Submenu::with_items(
         app,
-        "Local video processing",
+        "Processing · Checking…",
         true,
         &[&start_worker, &stop_worker],
     )?;
@@ -4495,10 +4564,11 @@ fn create_tray(app: &tauri::App) -> tauri::Result<()> {
         true,
         None::<&str>,
     )?;
-    let stop_server = MenuItem::with_id(app, "stop-server", "Stop service", false, None::<&str>)?;
+    let stop_server =
+        MenuItem::with_id(app, "stop-server", "Stop integration", false, None::<&str>)?;
     let server = Submenu::with_items(
         app,
-        "App integration service",
+        "App integration · Checking…",
         true,
         &[&start_server, &share_server, &stop_server],
     )?;
@@ -5620,7 +5690,7 @@ mod tests {
     }
 
     #[test]
-    fn tray_service_labels_surface_scope_and_addresses() {
+    fn tray_service_labels_are_compact_and_distinguish_availability() {
         let browser = super::BrowserServiceStatus {
             state: "ready",
             running: true,
@@ -5643,16 +5713,58 @@ mod tests {
         };
 
         assert_eq!(
-            super::tray_browser_label(&browser),
-            "Browser interface · Shared · http://192.168.1.20:43124"
+            super::tray_browser_label(&browser, true, true, true, true),
+            "Browser · Shared"
         );
         assert_eq!(
-            super::tray_server_label(&server),
-            "App integration service · Private · http://127.0.0.1:43125"
+            super::tray_server_label(&server, true, true, true, true),
+            "App integration · Private"
+        );
+        assert_eq!(
+            super::tray_browser_label(&browser, true, false, true, true),
+            "Browser · Not installed"
+        );
+        assert_eq!(
+            super::tray_server_label(&server, true, true, false, true),
+            "App integration · Unavailable"
+        );
+        assert_eq!(
+            super::tray_browser_label(&browser, true, true, true, false),
+            "Browser · Status unknown"
         );
         assert_eq!(
             super::tray_installation_label(None, 0),
-            "No VidXP installation selected"
+            "No installation selected"
+        );
+    }
+
+    #[test]
+    fn tray_worker_labels_report_actual_state() {
+        let running = Ok(super::LocalWorkerStatus {
+            running: true,
+            detail: String::new(),
+        });
+        let stopped = Ok(super::LocalWorkerStatus {
+            running: false,
+            detail: String::new(),
+        });
+        let unavailable = Err("timed out".into());
+
+        assert_eq!(
+            super::tray_worker_label(Some(&running), true, true, true),
+            "Processing · On"
+        );
+        assert_eq!(
+            super::tray_worker_label(Some(&stopped), true, true, true),
+            "Processing · Off"
+        );
+        assert_eq!(
+            super::tray_worker_label(Some(&unavailable), true, true, true),
+            "Processing · Status unknown"
+        );
+        assert_eq!(
+            super::tray_worker_label(None, true, false, true),
+            "Processing · Not installed"
         );
     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1722,6 +1722,30 @@ fn managed_probe_error(message: impl Into<String>) -> target_profiles::TargetErr
     }
 }
 
+fn validate_managed_runtime_identity(
+    runtime: &Path,
+    launcher: &Path,
+    identity: &target_profiles::RuntimeIdentity,
+) -> Result<(), target_profiles::TargetError> {
+    if !path_is_confined(launcher, runtime) {
+        return Err(managed_probe_error(format!(
+            "The managed launcher resolved outside the Desktop-owned runtime at {}.",
+            runtime.display()
+        )));
+    }
+    if !same_path(&identity.prefix, runtime) {
+        return Err(managed_probe_error(format!(
+            "The managed probe reported Python environment {}, but VidXP Desktop owns {}.",
+            identity.prefix.display(),
+            runtime.display()
+        )));
+    }
+    // POSIX virtual environments commonly symlink their Python executable to a shared base
+    // interpreter. The environment prefix, not that resolved interpreter target, establishes
+    // which environment the managed launcher is running from.
+    Ok(())
+}
+
 fn validate_managed_projection(
     paths: &DesktopPaths,
     projection: &target_profiles::ManagedRuntimeProjection,
@@ -1752,14 +1776,7 @@ fn validate_managed_projection(
             )));
         }
     }
-    if !path_is_confined(&validated.executable, &runtime)
-        || !path_is_confined(&validated.runtime.python_executable, &runtime)
-        || !same_path(&validated.runtime.prefix, &runtime)
-    {
-        return Err(managed_probe_error(
-            "The managed probe reported a launcher or Python runtime outside the active Desktop-owned environment.",
-        ));
-    }
+    validate_managed_runtime_identity(&runtime, &validated.executable, &validated.runtime)?;
     Ok(validated)
 }
 
@@ -4712,8 +4729,8 @@ mod tests {
         manifest, manifest_digest, normalize_line_endings, normalized_runtime_constraints,
         package_acquisition_arguments, package_specification, read_active_runtime_snapshot,
         reconcile_managed_runtime_storage, required_encoder_missing, restore_active_runtime,
-        selected_capabilities, selected_surfaces, ui_process_action, write_activation_journal,
-        write_active_runtime,
+        selected_capabilities, selected_surfaces, ui_process_action,
+        validate_managed_runtime_identity, write_activation_journal, write_active_runtime,
     };
     use std::{
         ffi::OsStr,
@@ -4753,6 +4770,39 @@ mod tests {
             paths.activation_journal,
             PathBuf::from("private").join("activation-journal.json")
         );
+    }
+
+    #[test]
+    fn managed_runtime_accepts_a_shared_posix_base_interpreter() {
+        let root = std::env::temp_dir().join(format!(
+            "vidxp-managed-runtime-identity-{}",
+            std::process::id()
+        ));
+        let runtime = root.join("runtimes").join("profile");
+        let launcher = runtime.join("bin").join("vidxp");
+        fs::create_dir_all(launcher.parent().expect("launcher parent")).expect("runtime");
+        fs::write(&launcher, b"launcher").expect("launcher");
+        let identity = crate::target_profiles::RuntimeIdentity {
+            python_executable: root
+                .join("python")
+                .join("cpython")
+                .join("bin")
+                .join("python3"),
+            python_version: "3.13.5".into(),
+            implementation: "CPython".into(),
+            prefix: runtime.clone(),
+            base_prefix: root.join("python").join("cpython"),
+        };
+
+        assert!(validate_managed_runtime_identity(&runtime, &launcher, &identity).is_ok());
+        assert!(
+            validate_managed_runtime_identity(&runtime, &root.join("other-vidxp"), &identity)
+                .is_err()
+        );
+        let mut wrong_prefix = identity;
+        wrong_prefix.prefix = root.join("other-environment");
+        assert!(validate_managed_runtime_identity(&runtime, &launcher, &wrong_prefix).is_err());
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -459,6 +459,19 @@ describe('desktop target lifecycle', () => {
     expect(mocks.launchUi).not.toHaveBeenCalled();
   });
 
+  it('keeps a managed installation failure visible in the setup dialog until it is acknowledged', async () => {
+    mocks.installRuntime.mockRejectedValueOnce('The installed runtime failed its compatibility check.');
+    const user = userEvent.setup(); renderApp(); await enterManaged(user);
+
+    await user.click(screen.getByRole('button', { name: 'Install VidXP' }));
+
+    expect(await screen.findByRole('dialog', { name: 'Setup could not finish' })).toBeVisible();
+    expect(screen.getByRole('alert', { name: 'VidXP was not installed' })).toHaveTextContent('The installed runtime failed its compatibility check.');
+    expect(screen.getByText(/model files already downloaded remain cached/i)).toBeVisible();
+    await user.click(screen.getByRole('button', { name: 'Review setup' }));
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Setup could not finish' })).not.toBeInTheDocument());
+  });
+
   it('blocks setup interaction and reports managed installation stages', async () => {
     const media = deferred<{ ready: boolean }>();
     mocks.installMediaRuntime.mockReturnValue(media.promise);

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -206,6 +206,30 @@ describe('desktop target lifecycle', () => {
     expect(mocks.stopLocalServer).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps worker timeouts with the worker control and clears them after recovery', async () => {
+    const operational = {
+      ...managedProfile,
+      frontend,
+      surfaces: ['worker', 'browser'],
+      validation_error: null,
+    };
+    const state = { profiles: [operational], selected_profile_id: operational.id, issues: [] };
+    mocks.targetSetupState.mockResolvedValue(state);
+    mocks.recheckTargetState.mockResolvedValue(state);
+    mocks.localWorkerStatus.mockRejectedValue('VidXP local processing failed: the operation exceeded 120 seconds');
+    const user = userEvent.setup();
+    renderApp();
+
+    const workerFailure = await screen.findByRole('alert', { name: 'Local processing status could not be checked' });
+    expect(workerFailure).toHaveTextContent('the operation exceeded 120 seconds');
+    expect(screen.queryByRole('alert', { name: 'That did not work' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Start processing' }));
+
+    expect(await screen.findByRole('button', { name: 'Stop processing' })).toBeVisible();
+    expect(screen.queryByRole('alert', { name: 'Local processing status could not be checked' })).not.toBeInTheDocument();
+  });
+
   it('adds optional features to the selected existing installation', async () => {
     const updated = { ...localProfile, surfaces: ['worker', 'browser', 'mcp'] };
     const updatedState = { profiles: [updated], selected_profile_id: updated.id, issues: [] };

--- a/desktop/src/components/LocalSetup.tsx
+++ b/desktop/src/components/LocalSetup.tsx
@@ -64,6 +64,7 @@ export function LocalSetup({ onBack, onActivated }: LocalSetupProps) {
   const [busy, setBusy] = useState<'discover' | 'browse' | 'activate' | null>('discover');
   const [failure, setFailure] = useState<string | null>(null);
   const candidateGeneration = useRef(new Map<string, number>());
+  const failureAlert = useRef<HTMLDivElement | null>(null);
 
   async function discover() {
     setBusy('discover');
@@ -89,6 +90,12 @@ export function LocalSetup({ onBack, onActivated }: LocalSetupProps) {
   useEffect(() => {
     void discover();
   }, []);
+
+  useEffect(() => {
+    if (!failure) return;
+    failureAlert.current?.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' });
+    failureAlert.current?.focus({ preventScroll: true });
+  }, [failure]);
 
   async function checkCandidate(path: string) {
     const generation = (candidateGeneration.current.get(path) ?? 0) + 1;
@@ -165,6 +172,8 @@ export function LocalSetup({ onBack, onActivated }: LocalSetupProps) {
         <Title id="local-setup-title" order={1} className="pageTitle">Connect this desktop to VidXP</Title>
         <Text className="lede">Choose the VidXP installation you already use. Connecting it here will not change or update it.</Text>
       </div>
+
+      {failure && <div ref={failureAlert} tabIndex={-1}><Alert mb="md" icon={<IconAlertCircle aria-hidden="true" />} color="red" title="Could not continue" role="alert">{failure}</Alert></div>}
 
       <div className="setupPanel">
         <Group justify="space-between" align="flex-start" mb="md">
@@ -256,7 +265,6 @@ export function LocalSetup({ onBack, onActivated }: LocalSetupProps) {
       </div>
 
       {busy === 'activate' && <div className="statusRegion" role="status" aria-live="polite"><Loader size="xs" /> Connecting this VidXP installation…</div>}
-      {failure && <Alert icon={<IconAlertCircle aria-hidden="true" />} color="red" title="Could not continue" role="alert">{failure}</Alert>}
     </section>
   );
 }

--- a/desktop/src/components/ManagedSetup.tsx
+++ b/desktop/src/components/ManagedSetup.tsx
@@ -55,9 +55,11 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
   const [operation, setOperation] = useState<ManagedOperation | null>('load');
   const [message, setMessage] = useState('Loading VidXP options…');
   const [failure, setFailure] = useState<string | null>(null);
+  const [installFailure, setInstallFailure] = useState<string | null>(null);
   const [setupProgress, setSetupProgress] = useState<ManagedSetupProgress | null>(null);
   const [setupElapsed, setSetupElapsed] = useState(0);
   const operations = useExclusiveOperation<ManagedOperation>();
+  const failureAlert = useRef<HTMLDivElement | null>(null);
   const initialLoad = useRef<Promise<{
     manifest: RuntimeManifest;
     status: RuntimeStatus;
@@ -155,6 +157,12 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
     return () => window.clearInterval(timer);
   }, [operation]);
 
+  useEffect(() => {
+    if (!failure || installFailure) return;
+    failureAlert.current?.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' });
+    failureAlert.current?.focus({ preventScroll: true });
+  }, [failure, installFailure]);
+
   function toggleValue(value: string, checked: boolean, setter: (next: string[]) => void, current: string[]) {
     setter(checked ? [...current, value] : current.filter((item) => item !== value));
   }
@@ -204,6 +212,7 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
       draft_id: draftId,
     };
     setFailure(null);
+    setInstallFailure(null);
     setSetupProgress({
       draft_id: draftId,
       current: 1,
@@ -231,7 +240,9 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
       setMessage(result.install.prepared ? 'VidXP and the selected search features are ready.' : 'VidXP is installed. Search files can be downloaded later.');
       onCommitted(result.setup);
     } catch (error) {
-      setFailure(errorMessage(error, 'Setup did not finish. Your previous VidXP installation is unchanged.'));
+      const detail = errorMessage(error, 'Setup did not finish. Your previous VidXP installation is unchanged.');
+      setFailure(detail);
+      setInstallFailure(detail);
     } finally {
       settleOperation(operationId);
       setSetupProgress(null);
@@ -305,6 +316,11 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
   const progressCurrent = setupProgress?.current ?? 1;
   const progressTotal = setupProgress?.total ?? (prepareDuringInstall ? 8 : 7);
 
+  function dismissInstallFailure() {
+    setInstallFailure(null);
+    setFailure(null);
+  }
+
   function formatBytes(bytes: number) {
     if (bytes < 1024) return `${bytes} B`;
     const units = ['KiB', 'MiB', 'GiB', 'TiB'];
@@ -325,6 +341,8 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
         <Title id="managed-setup-title" order={1} className="pageTitle">Choose your VidXP features</Title>
         <Text className="lede">Choose what VidXP can search, where video work runs, and how you want to open or connect to it. You can change these later.</Text>
       </div>
+
+      {failure && !installFailure && <div ref={failureAlert} tabIndex={-1}><Alert mb="md" icon={<IconAlertCircle aria-hidden="true" />} color="red" title="Could not continue" role="alert">{failure}</Alert></div>}
 
       {!manifest ? (
         <div className="emptyState" role="status" aria-live="polite"><Loader size="sm" /> Loading setup options…</div>
@@ -446,48 +464,55 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, onBack, o
         )}
       </div>
       <Modal
-        opened={operation === 'install'}
-        onClose={() => undefined}
-        title="Setting up VidXP"
+        opened={operation === 'install' || installFailure !== null}
+        onClose={() => { if (operation !== 'install') dismissInstallFailure(); }}
+        title={installFailure ? 'Setup could not finish' : 'Setting up VidXP'}
         size="md"
-        closeOnClickOutside={false}
-        closeOnEscape={false}
-        withCloseButton={false}
+        closeOnClickOutside={operation !== 'install'}
+        closeOnEscape={operation !== 'install'}
+        withCloseButton={operation !== 'install'}
       >
-        <Stack gap="md" role="status" aria-live="polite" aria-atomic="true">
-          <Group justify="space-between" align="baseline">
-            <Text fw={700}>Step {progressCurrent} of {progressTotal}</Text>
-            <Text size="sm" className="mutedText">{setupElapsed}s elapsed</Text>
-          </Group>
-          <Progress value={(progressCurrent / progressTotal) * 100} size="lg" animated />
-          {setupProgress?.stage === 'models'
-            && setupProgress.model_message && (
-              <Stack gap={6}>
-                <Group justify="space-between" align="baseline" wrap="nowrap">
-                  <Text size="sm" fw={650}>{setupProgress.model_message}</Text>
-                  {setupProgress.model_current != null && setupProgress.model_total != null
-                    ? <Text size="xs" className="mutedText" style={{ whiteSpace: 'nowrap' }}>
-                        {formatBytes(setupProgress.model_current)} of {formatBytes(setupProgress.model_total)}
-                      </Text>
-                    : <Loader size="xs" />}
-                </Group>
-                {setupProgress.model_current != null && setupProgress.model_total != null && (
-                  <Progress
-                    aria-label="Current model download progress"
-                    value={(setupProgress.model_current / setupProgress.model_total) * 100}
-                    size="md"
-                    animated
-                  />
-                )}
-              </Stack>
-            )}
-          <div>
-            <Text fw={650}>{setupProgress?.message ?? 'Starting managed setup'}</Text>
-            <Text size="sm" className="mutedText" mt="xs">The existing installation remains active until every step has completed and the replacement passes validation.</Text>
-          </div>
-        </Stack>
+        {installFailure ? (
+          <Stack gap="md">
+            <Alert icon={<IconAlertCircle aria-hidden="true" />} color="red" title="VidXP was not installed" role="alert">{installFailure}</Alert>
+            <Text size="sm">Any model files already downloaded remain cached and will be reused when you retry.</Text>
+            <Group justify="flex-end"><Button onClick={dismissInstallFailure}>Review setup</Button></Group>
+          </Stack>
+        ) : (
+          <Stack gap="md" role="status" aria-live="polite" aria-atomic="true">
+            <Group justify="space-between" align="baseline">
+              <Text fw={700}>Step {progressCurrent} of {progressTotal}</Text>
+              <Text size="sm" className="mutedText">{setupElapsed}s elapsed</Text>
+            </Group>
+            <Progress value={(progressCurrent / progressTotal) * 100} size="lg" animated />
+            {setupProgress?.stage === 'models'
+              && setupProgress.model_message && (
+                <Stack gap={6}>
+                  <Group justify="space-between" align="baseline" wrap="nowrap">
+                    <Text size="sm" fw={650}>{setupProgress.model_message}</Text>
+                    {setupProgress.model_current != null && setupProgress.model_total != null
+                      ? <Text size="xs" className="mutedText" style={{ whiteSpace: 'nowrap' }}>
+                          {formatBytes(setupProgress.model_current)} of {formatBytes(setupProgress.model_total)}
+                        </Text>
+                      : <Loader size="xs" />}
+                  </Group>
+                  {setupProgress.model_current != null && setupProgress.model_total != null && (
+                    <Progress
+                      aria-label="Current model download progress"
+                      value={(setupProgress.model_current / setupProgress.model_total) * 100}
+                      size="md"
+                      animated
+                    />
+                  )}
+                </Stack>
+              )}
+            <div>
+              <Text fw={650}>{setupProgress?.message ?? 'Starting managed setup'}</Text>
+              <Text size="sm" className="mutedText" mt="xs">The existing installation remains active until every step has completed and the replacement passes validation.</Text>
+            </div>
+          </Stack>
+        )}
       </Modal>
-      {failure && <Alert mt="md" icon={<IconAlertCircle aria-hidden="true" />} color="red" title="Could not continue" role="alert">{failure}</Alert>}
     </section>
   );
 }

--- a/desktop/src/components/TargetSummary.tsx
+++ b/desktop/src/components/TargetSummary.tsx
@@ -1,6 +1,6 @@
 import { Alert, Badge, Button, Checkbox, Code, Group, Loader, Modal, Stack, Text, Title } from '@mantine/core';
 import { IconActivityHeartbeat, IconCopy, IconExternalLink, IconPlugConnected, IconPlayerPlay, IconPlayerStop, IconRefresh, IconSettings, IconShare, IconTerminal2 } from '@tabler/icons-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import {
   errorMessage,
@@ -50,6 +50,11 @@ const CAPABILITY_LABELS: Record<string, string> = {
   scene: 'Visual scene search',
 };
 
+interface WorkerFailure {
+  title: string;
+  detail: string;
+}
+
 export function TargetSummary({ profile, validationError, checking, operationPending, opening, onRecheck, onManageManaged, onSetupChanged, onChooseAnother, onOpen }: TargetSummaryProps) {
   const executable = profile.display_executable;
   const [doctor, setDoctor] = useState<DoctorReport | null>(null);
@@ -60,6 +65,9 @@ export function TargetSummary({ profile, validationError, checking, operationPen
   const [codexSetup, setCodexSetup] = useState<CodexPluginInstallResult | null>(null);
   const [busy, setBusy] = useState<'doctor' | 'config' | 'codex' | 'features' | 'worker-start' | 'worker-stop' | 'browser-share' | 'browser-stop' | 'server-start' | 'server-share' | 'server-stop' | null>(null);
   const [runtimeFailure, setRuntimeFailure] = useState<string | null>(null);
+  const [workerFailure, setWorkerFailure] = useState<WorkerFailure | null>(null);
+  const workerStatusRequest = useRef(0);
+  const workerActionActive = useRef(false);
   const [copied, setCopied] = useState(false);
   const [shareCopied, setShareCopied] = useState(false);
   const [externalSetupOpened, setExternalSetupOpened] = useState(false);
@@ -131,20 +139,40 @@ export function TargetSummary({ profile, validationError, checking, operationPen
   useEffect(() => {
     if (!workerAvailable) {
       setWorker(null);
+      setWorkerFailure(null);
       return;
     }
     let active = true;
+    let timer: ReturnType<typeof setTimeout> | null = null;
     const poll = async () => {
+      if (workerActionActive.current) {
+        if (active) timer = setTimeout(() => void poll(), 5000);
+        return;
+      }
+      const request = ++workerStatusRequest.current;
       try {
         const status = await localWorkerStatus();
-        if (active) setWorker(status);
+        if (active && request === workerStatusRequest.current) {
+          setWorker(status);
+          setWorkerFailure(null);
+        }
       } catch (error) {
-        if (active) setRuntimeFailure(errorMessage(error, 'Local video processing status could not be checked.'));
+        if (active && request === workerStatusRequest.current) {
+          setWorkerFailure({
+            title: 'Local processing status could not be checked',
+            detail: errorMessage(error, 'VidXP could not check local video processing.'),
+          });
+        }
+      } finally {
+        if (active) timer = setTimeout(() => void poll(), 5000);
       }
     };
     void poll();
-    const timer = setInterval(() => void poll(), 5000);
-    return () => { active = false; clearInterval(timer); };
+    return () => {
+      active = false;
+      workerStatusRequest.current += 1;
+      if (timer) clearTimeout(timer);
+    };
   }, [profile.id, workerAvailable]);
 
   useEffect(() => {
@@ -271,12 +299,18 @@ export function TargetSummary({ profile, validationError, checking, operationPen
 
   async function setWorkerRunning(running: boolean) {
     setBusy(running ? 'worker-start' : 'worker-stop');
-    setRuntimeFailure(null);
+    setWorkerFailure(null);
+    workerActionActive.current = true;
+    workerStatusRequest.current += 1;
     try {
       setWorker(await (running ? startLocalWorker() : stopLocalWorker()));
     } catch (error) {
-      setRuntimeFailure(errorMessage(error, 'VidXP could not change local video processing.'));
+      setWorkerFailure({
+        title: running ? 'Local processing could not be started' : 'Local processing could not be stopped',
+        detail: errorMessage(error, 'VidXP could not change local video processing.'),
+      });
     } finally {
+      workerActionActive.current = false;
       setBusy(null);
     }
   }
@@ -374,15 +408,18 @@ export function TargetSummary({ profile, validationError, checking, operationPen
             </Alert>
           )}
 
-          {workerAvailable && <Group justify="space-between" className="runtimeControlRow">
-            <div>
-              <Text fw={650}>Local video processing</Text>
-              <Text size="sm" className="mutedText">{worker?.running ? 'Ready to process indexing, search, and model jobs on this computer.' : 'Starts automatically when VidXP needs to process a video. You can also start it now.'}</Text>
-            </div>
-            {worker?.running
-              ? <Button color="red" variant="light" leftSection={<IconPlayerStop size={17} />} loading={busy === 'worker-stop'} disabled={operationPending || busy !== null} onClick={() => void setWorkerRunning(false)}>Stop processing</Button>
-              : <Button variant="light" leftSection={<IconPlayerPlay size={17} />} loading={busy === 'worker-start'} disabled={operationPending || busy !== null} onClick={() => void setWorkerRunning(true)}>Start processing</Button>}
-          </Group>}
+          {workerAvailable && <div>
+            <Group justify="space-between" className="runtimeControlRow">
+              <div>
+                <Text fw={650}>Local video processing</Text>
+                <Text size="sm" className="mutedText">{worker?.running ? 'Ready to process indexing, search, and model jobs on this computer.' : 'Starts automatically when VidXP needs to process a video. You can also start it now.'}</Text>
+              </div>
+              {worker?.running
+                ? <Button color="red" variant="light" leftSection={<IconPlayerStop size={17} />} loading={busy === 'worker-stop'} disabled={operationPending || busy !== null} onClick={() => void setWorkerRunning(false)}>Stop processing</Button>
+                : <Button variant="light" leftSection={<IconPlayerPlay size={17} />} loading={busy === 'worker-start'} disabled={operationPending || busy !== null} onClick={() => void setWorkerRunning(true)}>Start processing</Button>}
+            </Group>
+            {workerFailure && <Alert mt="sm" color="red" title={workerFailure.title} role="alert">{workerFailure.detail}</Alert>}
+          </div>}
 
           {browserAvailable && <Group justify="space-between" className="runtimeControlRow" align="flex-start">
             <div>


### PR DESCRIPTION
## Summary

- Accept Desktop-managed POSIX virtual environments when their Python executable resolves to uv's shared base interpreter, while still requiring both the VidXP launcher and reported environment prefix to belong to the Desktop-owned runtime.
- Keep managed-install failures visible in the setup dialog until acknowledged, and place other setup errors consistently where the UI focuses them.
- Serialize local-worker status polling, show worker failures beside the processing control, and clear stale failures after a successful authoritative result.
- Make the tray report compact, truthful states: omit redundant `Ready`, distinguish `Not installed`, `Unavailable`, and `Status unknown` from `Off`, and identify actions that start a stopped service.
- Preserve downloaded model files for reuse after a failed installation attempt.

The macOS setup failure occurred after package and model preparation because the final compatibility check rejected a legitimate virtual-environment interpreter symlink. The contradictory Windows page had a separate cause: worker status was polled on a fixed interval while earlier subprocesses could still be active, and a timeout stored in the shared page banner was not cleared by a later successful status. The tray also conflated installation readiness, capability availability, and service runtime state, producing combinations such as `Ready` with an unavailable service labeled `Stopped`.

There is no storage migration or index rebuild.

## Validation

- `python -m build` — built the Python sdist and wheel consumed by the Desktop build.
- `npm --prefix desktop run sidecar:windows` — fetched and verified the pinned uv sidecar required by the Rust build on this machine.
- `npm --prefix desktop run typecheck` — checked the Desktop TypeScript project.
- `npm --prefix desktop run lint` — linted the Desktop frontend.
- `npm --prefix desktop test -- --run src/App.test.tsx` — ran 28 mocked Desktop UI lifecycle tests, including persistent install-failure and worker-timeout recovery coverage; this is not end-to-end validation.
- `npm --prefix desktop run build` — produced the production Vite frontend bundle.
- `cargo test --locked --manifest-path desktop/src-tauri/Cargo.toml` — ran all 81 Rust unit tests, including managed-runtime ownership and compact tray-state regressions.
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check`
- `git diff --check`

A real macOS Desktop installer was not available from this Windows worktree, so the original installer path still needs a macOS smoke test.

BEGIN_COMMIT_OVERRIDE
chore(desktop): stabilize managed runtime status and errors
END_COMMIT_OVERRIDE
