### PR TITLE
fix(desktop): expose VideoPrism setup option

### DIFF
--- a/desktop/runtime-manifest.json
+++ b/desktop/runtime-manifest.json
@@ -47,6 +47,11 @@
       "extra": "actor",
       "modality": "actor",
       "label": "Actor recognition"
+    },
+    "videoprism": {
+      "extra": "videoprism",
+      "modality": "videoprism",
+      "label": "Temporal video search"
     }
   },
   "media_runtime": {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -5349,11 +5349,16 @@ mod tests {
         let manifest = manifest().expect("manifest");
         let selected = selected_capabilities(
             &manifest,
-            &["scene".into(), "dialogue".into(), "scene".into()],
+            &[
+                "scene".into(),
+                "videoprism".into(),
+                "dialogue".into(),
+                "scene".into(),
+            ],
         )
         .expect("selection");
 
-        assert_eq!(selected, ["dialogue", "scene"]);
+        assert_eq!(selected, ["dialogue", "scene", "videoprism"]);
         assert!(selected_capabilities(&manifest, &["other".into()]).is_err());
     }
 


### PR DESCRIPTION
## Summary

- Show VideoPrism as its own **Temporal video search** option in Desktop setup.
- Keep it separate from the existing **Visual scene search** capability.
- Cover the embedded runtime manifest with the existing capability-selection test.

Existing installations are unchanged until the user enables the new option or enables local processing with all built-in search features.

## Validation

- `cargo test --locked --manifest-path desktop/src-tauri/Cargo.toml capability_selection_is_sorted_and_rejects_unknown_values` — 1 targeted Desktop manifest test passed.
- `git diff --check` — no whitespace errors.

BEGIN_COMMIT_OVERRIDE
chore(desktop): expose Action search during setup
END_COMMIT_OVERRIDE
