### PR TITLE
docs(release): link container package from release pages

### DIFF
--- a/.github/release-intro.md
+++ b/.github/release-intro.md
@@ -33,6 +33,8 @@ uv tool install --python 3.14 --torch-backend cpu \
 
 ### Containers
 
+Browse published tags in the [VidXP container package]({container_package_url}).
+
 ```bash
 docker pull {container_image}:{version}
 ```

--- a/tests/test_release_notes.py
+++ b/tests/test_release_notes.py
@@ -47,6 +47,10 @@ class ReleaseNotesTests(unittest.TestCase):
         self.assertIn("vidxp[local-worker,mcp,frontend]==0.4.0-b", result)
         self.assertNotIn("python -m pip install", result)
         self.assertIn("ghcr.io/grayhatdevelopers/vidxp:0.4.0-b", result)
+        self.assertIn(
+            "https://github.com/grayhatdevelopers/vidxp/pkgs/container/vidxp",
+            result,
+        )
         self.assertNotIn("Beta release", result)
 
     def test_beta_warning_and_rendering_are_idempotent(self):
@@ -56,6 +60,10 @@ class ReleaseNotesTests(unittest.TestCase):
         self.assertEqual(first, second)
         self.assertEqual(first.count("Beta release"), 1)
         self.assertEqual(first.count("Fixed upload recovery"), 1)
+        self.assertIn(
+            "https://github.com/grayhatdevelopers/vidxp/pkgs/container/vidxp",
+            first,
+        )
 
     def test_rejects_an_ambiguous_platform_asset(self):
         (self.assets / "another.exe").touch()

--- a/utils/render_release_notes.py
+++ b/utils/render_release_notes.py
@@ -72,6 +72,10 @@ def render(
             repository, tag, asset_paths["checksums"]
         ),
         container_image=f"ghcr.io/{repository.lower()}",
+        container_package_url=(
+            f"https://github.com/{repository.lower()}/pkgs/container/"
+            f"{repository.rsplit('/', maxsplit=1)[-1].lower()}"
+        ),
         deployment_url=f"{source_root}/docs/deployment/coolify.md",
         installation_url=f"{source_root}/INSTALLATION_GUIDE.md",
         issues_url=f"https://github.com/{repository}/issues",


### PR DESCRIPTION
## Summary

- Add a direct link to the VidXP GHCR package page in rendered release and prerelease introductions.
- Derive the package-page URL from the repository passed to the release-note renderer.
- Verify that both stable and beta release notes contain the package link.

This changes release documentation only. It does not change container publication or runtime behavior.

## Validation

- `PYTHONPATH=. uv run --no-sync pytest -q -p no:cacheprovider tests/test_release_notes.py` — 3 passed
- `uv run --no-sync ruff check utils/render_release_notes.py tests/test_release_notes.py`
- `npx --yes markdownlint-cli2@0.23.2`
- `lychee "**/*.md" ".github/**/*.md" ".agents/**/*.md"` — 707 links found, 0 errors
- `git diff --check`

BEGIN_COMMIT_OVERRIDE
chore(docs): link the container package from release pages
END_COMMIT_OVERRIDE
