### PR TITLE
fix(desktop): use a managed headless Ollama runtime

### DIFF
--- a/INSTALLATION_GUIDE.md
+++ b/INSTALLATION_GUIDE.md
@@ -318,21 +318,24 @@ and sharing behavior.
 VidXP search does not require a language model. To let CLI, HTTP, or MCP
 queries plan searches and draft grounded answers locally, enable **Local
 grounded answers** in VidXP Desktop setup. Desktop checks for a compatible
-loopback Ollama service, asks before installing Ollama through the supported
-Windows or macOS package manager when needed, and explicitly downloads the
-approved Qwen3.5 4B model. Linux setup links to Ollama's official installation
-instructions instead of running a privileged script.
+loopback Ollama service and then for an existing Ollama executable. When neither
+is available on Windows x86-64 or macOS Apple Silicon, Desktop asks before
+downloading a pinned, checksum-verified headless runtime into VidXP's private
+data. It does not install the Ollama desktop app. Linux setup links to Ollama's
+official installation instructions instead of running a privileged script.
 
 This optional feature follows Ollama's platform floor: Windows 10 22H2 or
 newer, or macOS 14 or newer. VidXP Desktop itself can still run without local
 grounded answers on older supported systems.
 
-The model is an additional approximately 3.4 GB download and has no per-run
-API charge or numbered hosted-model allowance. It uses local storage, memory,
-compute time, and electricity. Desktop configures the private service address
-for its browser, worker, API, Premiere, and generated MCP/Codex setup; there is
-no URL field to fill in. A command-line-only installation remains available
-for developers and custom deployments.
+The model is an additional approximately 3.4 GB download. When Desktop must
+provide the headless runtime, that download is up to approximately 1.36 GiB;
+reusing Ollama avoids it. Local answers have no per-run API charge or numbered
+hosted-model allowance, but they use local storage, memory, compute time, and
+electricity. Desktop configures the private service address for its browser,
+worker, API, Premiere, and generated MCP/Codex setup; there is no URL field to
+fill in. A command-line-only installation remains available for developers and
+custom deployments.
 
 The complete setup and its current evidence limitations are documented under
 [Enable local grounded answers](docs/local-api.md#enable-local-grounded-answers).

--- a/benchmarks/codex-mcp/.npmrc
+++ b/benchmarks/codex-mcp/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+omit=optional

--- a/desktop/THIRD_PARTY_NOTICES.txt
+++ b/desktop/THIRD_PARTY_NOTICES.txt
@@ -686,6 +686,7 @@ Used by:
 - embed_plist 1.2.2 | https://github.com/nvzqz/embed-plist-rs | registry+https://github.com/rust-lang/crates.io-index
 - encoding_rs 0.8.35 | https://github.com/hsivonen/encoding_rs | registry+https://github.com/rust-lang/crates.io-index
 - utf8_iter 1.0.4 | https://github.com/hsivonen/utf8_iter | registry+https://github.com/rust-lang/crates.io-index
+- zeroize 1.9.0 | https://github.com/RustCrypto/utils | registry+https://github.com/rust-lang/crates.io-index
 
 
                                  Apache License
@@ -905,6 +906,7 @@ Used by:
 - windows-link 0.2.1 | https://github.com/microsoft/windows-rs | registry+https://github.com/rust-lang/crates.io-index
 - windows-numerics 0.2.0 | https://github.com/microsoft/windows-rs | registry+https://github.com/rust-lang/crates.io-index
 - windows-numerics 0.3.1 | https://github.com/microsoft/windows-rs | registry+https://github.com/rust-lang/crates.io-index
+- windows-registry 0.6.1 | https://github.com/microsoft/windows-rs | registry+https://github.com/rust-lang/crates.io-index
 - windows-result 0.3.4 | https://github.com/microsoft/windows-rs | registry+https://github.com/rust-lang/crates.io-index
 - windows-result 0.4.1 | https://github.com/microsoft/windows-rs | registry+https://github.com/rust-lang/crates.io-index
 - windows-strings 0.4.2 | https://github.com/microsoft/windows-rs | registry+https://github.com/rust-lang/crates.io-index
@@ -1358,6 +1360,7 @@ Used by:
 -------------------------------------------------------------------------------
 License: Apache License 2.0 (Apache-2.0)
 Used by:
+- rustls-platform-verifier 0.7.0 | https://github.com/rustls/rustls-platform-verifier | registry+https://github.com/rust-lang/crates.io-index
 - serialize-to-javascript-impl 0.1.2 | https://github.com/chippers/serialize-to-javascript | registry+https://github.com/rust-lang/crates.io-index
 - serialize-to-javascript 0.1.2 | https://github.com/chippers/serialize-to-javascript | registry+https://github.com/rust-lang/crates.io-index
 
@@ -3857,6 +3860,213 @@ limitations under the License.
 -------------------------------------------------------------------------------
 License: Apache License 2.0 (Apache-2.0)
 Used by:
+- tokio-rustls 0.26.4 | https://github.com/rustls/tokio-rustls | registry+https://github.com/rust-lang/crates.io-index
+
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2017 quininer kel
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-------------------------------------------------------------------------------
+License: Apache License 2.0 (Apache-2.0)
+Used by:
 - ppv-lite86 0.2.21 | https://github.com/cryptocorrosion/cryptocorrosion | registry+https://github.com/rust-lang/crates.io-index
 
                               Apache License
@@ -4271,6 +4481,213 @@ limitations under the License.
 -------------------------------------------------------------------------------
 License: Apache License 2.0 (Apache-2.0)
 Used by:
+- rustls-pki-types 1.15.1 | https://github.com/rustls/pki-types | registry+https://github.com/rust-lang/crates.io-index
+
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2023 Dirkjan Ochtman
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-------------------------------------------------------------------------------
+License: Apache License 2.0 (Apache-2.0)
+Used by:
 - async-recursion 1.1.1 | https://github.com/dcchut/async-recursion | registry+https://github.com/rust-lang/crates.io-index
 - keyboard-types 0.7.0 | https://github.com/pyfisch/keyboard-types | registry+https://github.com/rust-lang/crates.io-index
 
@@ -4497,6 +4914,7 @@ Used by:
 - concurrent-queue 2.5.0 | https://github.com/smol-rs/concurrent-queue | registry+https://github.com/rust-lang/crates.io-index
 - core-foundation-sys 0.8.7 | https://github.com/servo/core-foundation-rs | registry+https://github.com/rust-lang/crates.io-index
 - core-foundation 0.10.1 | https://github.com/servo/core-foundation-rs | registry+https://github.com/rust-lang/crates.io-index
+- core-foundation 0.9.4 | https://github.com/servo/core-foundation-rs | registry+https://github.com/rust-lang/crates.io-index
 - core-graphics-types 0.2.0 | https://github.com/servo/core-foundation-rs | registry+https://github.com/rust-lang/crates.io-index
 - core-graphics 0.25.0 | https://github.com/servo/core-foundation-rs | registry+https://github.com/rust-lang/crates.io-index
 - crossbeam-channel 0.5.16 | https://github.com/crossbeam-rs/crossbeam | registry+https://github.com/rust-lang/crates.io-index
@@ -4507,7 +4925,8 @@ Used by:
 - event-listener-strategy 0.5.4 | https://github.com/smol-rs/event-listener-strategy | registry+https://github.com/rust-lang/crates.io-index
 - event-listener 5.4.2 | https://github.com/smol-rs/event-listener | registry+https://github.com/rust-lang/crates.io-index
 - fastrand 2.5.0 | https://github.com/smol-rs/fastrand | registry+https://github.com/rust-lang/crates.io-index
-- flate2 1.1.9 | https://github.com/rust-lang/flate2-rs | registry+https://github.com/rust-lang/crates.io-index
+- filetime 0.2.29 | https://github.com/alexcrichton/filetime | registry+https://github.com/rust-lang/crates.io-index
+- flate2 1.1.10 | https://github.com/rust-lang/flate2-rs | registry+https://github.com/rust-lang/crates.io-index
 - fnv 1.0.7 | https://github.com/servo/rust-fnv | registry+https://github.com/rust-lang/crates.io-index
 - form_urlencoded 1.2.2 | https://github.com/servo/rust-url | registry+https://github.com/rust-lang/crates.io-index
 - futures-lite 2.6.1 | https://github.com/smol-rs/futures-lite | registry+https://github.com/rust-lang/crates.io-index
@@ -4518,6 +4937,7 @@ Used by:
 - hermit-abi 0.5.2 | https://github.com/hermit-os/hermit-rs | registry+https://github.com/rust-lang/crates.io-index
 - html5ever 0.38.0 | https://github.com/servo/html5ever | registry+https://github.com/rust-lang/crates.io-index
 - httparse 1.10.1 | https://github.com/seanmonstar/httparse | registry+https://github.com/rust-lang/crates.io-index
+- hyper-rustls 0.27.9 | https://github.com/rustls/hyper-rustls | registry+https://github.com/rust-lang/crates.io-index
 - idna 1.1.0 | https://github.com/servo/rust-url/ | registry+https://github.com/rust-lang/crates.io-index
 - idna_adapter 1.2.1 | https://github.com/hsivonen/idna_adapter | registry+https://github.com/rust-lang/crates.io-index
 - indexmap 2.14.0 | https://github.com/indexmap-rs/indexmap | registry+https://github.com/rust-lang/crates.io-index
@@ -4531,6 +4951,7 @@ Used by:
 - mime 0.3.17 | https://github.com/hyperium/mime | registry+https://github.com/rust-lang/crates.io-index
 - muda 0.19.3 | https://github.com/tauri-apps/muda | registry+https://github.com/rust-lang/crates.io-index
 - once_cell 1.21.4 | https://github.com/matklad/once_cell | registry+https://github.com/rust-lang/crates.io-index
+- openssl-probe 0.2.1 | https://github.com/rustls/openssl-probe | registry+https://github.com/rust-lang/crates.io-index
 - ordered-stream 0.2.0 | https://github.com/danieldg/ordered-stream | registry+https://github.com/rust-lang/crates.io-index
 - parking 2.2.1 | https://github.com/smol-rs/parking | registry+https://github.com/rust-lang/crates.io-index
 - parking_lot 0.12.5 | https://github.com/Amanieu/parking_lot | registry+https://github.com/rust-lang/crates.io-index
@@ -4544,18 +4965,26 @@ Used by:
 - regex-syntax 0.8.11 | https://github.com/rust-lang/regex | registry+https://github.com/rust-lang/crates.io-index
 - regex 1.13.1 | https://github.com/rust-lang/regex | registry+https://github.com/rust-lang/crates.io-index
 - rustix 1.1.4 | https://github.com/bytecodealliance/rustix | registry+https://github.com/rust-lang/crates.io-index
+- rustls-native-certs 0.8.4 | https://github.com/rustls/rustls-native-certs | registry+https://github.com/rust-lang/crates.io-index
+- rustls 0.23.43 | https://github.com/rustls/rustls | registry+https://github.com/rust-lang/crates.io-index
 - scopeguard 1.2.0 | https://github.com/bluss/scopeguard | registry+https://github.com/rust-lang/crates.io-index
+- security-framework-sys 2.17.0 | https://github.com/kornelski/rust-security-framework | registry+https://github.com/rust-lang/crates.io-index
+- security-framework 3.7.0 | https://github.com/kornelski/rust-security-framework | registry+https://github.com/rust-lang/crates.io-index
 - serde_with 3.21.0 | https://github.com/jonasbb/serde_with/ | registry+https://github.com/rust-lang/crates.io-index
 - serde_with_macros 3.21.0 | https://github.com/jonasbb/serde_with/ | registry+https://github.com/rust-lang/crates.io-index
 - servo_arc 0.4.3 | https://github.com/servo/stylo | registry+https://github.com/rust-lang/crates.io-index
 - signal-hook-registry 1.4.8 | https://github.com/vorner/signal-hook | registry+https://github.com/rust-lang/crates.io-index
 - signal-hook 0.3.18 | https://github.com/vorner/signal-hook | registry+https://github.com/rust-lang/crates.io-index
+- simd_cesu8 1.2.0 | https://github.com/seancroach/simd_cesu8 | registry+https://github.com/rust-lang/crates.io-index
 - smallvec 1.15.2 | https://github.com/servo/rust-smallvec | registry+https://github.com/rust-lang/crates.io-index
 - socket2 0.6.5 | https://github.com/rust-lang/socket2 | registry+https://github.com/rust-lang/crates.io-index
 - stable_deref_trait 1.2.1 | https://github.com/storyyeller/stable_deref_trait | registry+https://github.com/rust-lang/crates.io-index
 - string_cache 0.9.0 | https://github.com/servo/string-cache | registry+https://github.com/rust-lang/crates.io-index
 - syn 1.0.109 | https://github.com/dtolnay/syn | registry+https://github.com/rust-lang/crates.io-index
+- system-configuration-sys 0.6.0 | https://github.com/mullvad/system-configuration-rs | registry+https://github.com/rust-lang/crates.io-index
+- system-configuration 0.7.0 | https://github.com/mullvad/system-configuration-rs | registry+https://github.com/rust-lang/crates.io-index
 - tao-macros 0.1.4 | https://github.com/tauri-apps/tao | registry+https://github.com/rust-lang/crates.io-index
+- tar 0.4.46 | https://github.com/composefs/tar-rs | registry+https://github.com/rust-lang/crates.io-index
 - tempfile 3.27.0 | https://github.com/Stebalien/tempfile | registry+https://github.com/rust-lang/crates.io-index
 - tendril 0.5.1 | https://github.com/servo/html5ever | registry+https://github.com/rust-lang/crates.io-index
 - toml_datetime 0.6.3 | https://github.com/toml-rs/toml | registry+https://github.com/rust-lang/crates.io-index
@@ -4574,6 +5003,7 @@ Used by:
 - window-vibrancy 0.6.0 | https://github.com/tauri-apps/tauri-plugin-vibrancy | registry+https://github.com/rust-lang/crates.io-index
 - wit-bindgen 0.46.0 | https://github.com/bytecodealliance/wit-bindgen | registry+https://github.com/rust-lang/crates.io-index
 - wry 0.55.1 | https://github.com/tauri-apps/wry | registry+https://github.com/rust-lang/crates.io-index
+- xattr 1.6.1 | https://github.com/Stebalien/xattr | registry+https://github.com/rust-lang/crates.io-index
 
                               Apache License
                         Version 2.0, January 2004
@@ -7488,6 +7918,7 @@ License: Apache License 2.0 (Apache-2.0)
 Used by:
 - anyhow 1.0.104 | https://github.com/dtolnay/anyhow | registry+https://github.com/rust-lang/crates.io-index
 - async-trait 0.1.91 | https://github.com/dtolnay/async-trait | registry+https://github.com/rust-lang/crates.io-index
+- aws-lc-sys 0.44.0 | https://github.com/aws/aws-lc-rs | registry+https://github.com/rust-lang/crates.io-index
 - cesu8 1.1.0 | https://github.com/emk/cesu8-rs | registry+https://github.com/rust-lang/crates.io-index
 - dirs-sys 0.5.0 | https://github.com/dirs-dev/dirs-sys-rs | registry+https://github.com/rust-lang/crates.io-index
 - dirs 6.0.0 | https://github.com/soc/dirs-rs | registry+https://github.com/rust-lang/crates.io-index
@@ -7500,10 +7931,13 @@ Used by:
 - field-offset 0.3.6 | https://github.com/Diggsey/rust-field-offset | registry+https://github.com/rust-lang/crates.io-index
 - ident_case 1.0.1 | https://github.com/TedDriggs/ident_case | registry+https://github.com/rust-lang/crates.io-index
 - itoa 1.0.18 | https://github.com/dtolnay/itoa | registry+https://github.com/rust-lang/crates.io-index
+- jni-macros 0.22.4 | https://github.com/jni-rs/jni-rs | registry+https://github.com/rust-lang/crates.io-index
 - jni-sys-macros 0.4.1 | https://github.com/jni-rs/jni-sys | registry+https://github.com/rust-lang/crates.io-index
+- jni 0.22.4 | https://github.com/jni-rs/jni-rs | registry+https://github.com/rust-lang/crates.io-index
 - libappindicator-sys 0.9.0 |  | registry+https://github.com/rust-lang/crates.io-index
 - libc 0.2.189 | https://github.com/rust-lang/libc | registry+https://github.com/rust-lang/crates.io-index
 - miniz_oxide 0.8.9 | https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide | registry+https://github.com/rust-lang/crates.io-index
+- miniz_oxide 0.9.1 | https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide | registry+https://github.com/rust-lang/crates.io-index
 - ndk-sys 0.6.0+11769913 | https://github.com/rust-mobile/ndk | registry+https://github.com/rust-lang/crates.io-index
 - ndk 0.9.0 | https://github.com/rust-mobile/ndk | registry+https://github.com/rust-lang/crates.io-index
 - num-conv 0.2.2 | https://github.com/jhpratt/num-conv | registry+https://github.com/rust-lang/crates.io-index
@@ -7532,6 +7966,7 @@ Used by:
 - rand_chacha 0.9.0 | https://github.com/rust-random/rand | registry+https://github.com/rust-lang/crates.io-index
 - raw-window-handle 0.6.2 | https://github.com/rust-windowing/raw-window-handle | registry+https://github.com/rust-lang/crates.io-index
 - rustc-hash 2.1.3 | https://github.com/rust-lang/rustc-hash | registry+https://github.com/rust-lang/crates.io-index
+- rustls-platform-verifier-android 0.1.1 | https://github.com/rustls/rustls-platform-verifier | registry+https://github.com/rust-lang/crates.io-index
 - rustversion 1.0.23 | https://github.com/dtolnay/rustversion | registry+https://github.com/rust-lang/crates.io-index
 - semver 1.0.28 | https://github.com/dtolnay/semver | registry+https://github.com/rust-lang/crates.io-index
 - serde-untagged 0.1.9 | https://github.com/dtolnay/serde-untagged | registry+https://github.com/rust-lang/crates.io-index
@@ -7541,6 +7976,7 @@ Used by:
 - serde_derive_internals 0.29.1 | https://github.com/serde-rs/serde | registry+https://github.com/rust-lang/crates.io-index
 - serde_json 1.0.151 | https://github.com/serde-rs/json | registry+https://github.com/rust-lang/crates.io-index
 - serde_repr 0.1.21 | https://github.com/dtolnay/serde-repr | registry+https://github.com/rust-lang/crates.io-index
+- simdutf8 0.1.5 | https://github.com/rusticstuff/simdutf8 | registry+https://github.com/rust-lang/crates.io-index
 - siphasher 1.0.3 | https://github.com/jedisct1/rust-siphash | registry+https://github.com/rust-lang/crates.io-index
 - syn 2.0.119 | https://github.com/dtolnay/syn | registry+https://github.com/rust-lang/crates.io-index
 - syn 3.0.3 | https://github.com/dtolnay/syn | registry+https://github.com/rust-lang/crates.io-index
@@ -7565,6 +8001,7 @@ Used by:
 - time-core 0.1.8 | https://github.com/time-rs/time | registry+https://github.com/rust-lang/crates.io-index
 - time-macros 0.2.27 | https://github.com/time-rs/time | registry+https://github.com/rust-lang/crates.io-index
 - time 0.3.47 | https://github.com/time-rs/time | registry+https://github.com/rust-lang/crates.io-index
+- typed-path 0.12.3 | https://github.com/chipsenkbeil/typed-path | registry+https://github.com/rust-lang/crates.io-index
 - typeid 1.0.3 | https://github.com/dtolnay/typeid | registry+https://github.com/rust-lang/crates.io-index
 - unic-char-property 0.9.0 | https://github.com/open-i18n/rust-unic/ | registry+https://github.com/rust-lang/crates.io-index
 - unic-char-range 0.9.0 | https://github.com/open-i18n/rust-unic/ | registry+https://github.com/rust-lang/crates.io-index
@@ -7673,7 +8110,43 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 -------------------------------------------------------------------------------
 License: BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License (BSD-3-Clause)
 Used by:
+- subtle 2.6.1 | https://github.com/dalek-cryptography/subtle | registry+https://github.com/rust-lang/crates.io-index
+
+Copyright (c) 2016-2017 Isis Agora Lovecruft, Henry de Valence. All rights reserved.
+Copyright (c) 2016-2024 Isis Agora Lovecruft. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-------------------------------------------------------------------------------
+License: BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License (BSD-3-Clause)
+Used by:
 - alloc-stdlib 0.2.4 | https://github.com/dropbox/rust-alloc-no-stdlib | registry+https://github.com/rust-lang/crates.io-index
+- aws-lc-sys 0.44.0 | https://github.com/aws/aws-lc-rs | registry+https://github.com/rust-lang/crates.io-index
 
 Copyright (c) <year> <owner>.
 
@@ -7750,6 +8223,92 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -------------------------------------------------------------------------------
+License: Community Data License Agreement Permissive 2.0 (CDLA-Permissive-2.0)
+Used by:
+- webpki-root-certs 1.0.9 | https://github.com/rustls/webpki-roots | registry+https://github.com/rust-lang/crates.io-index
+
+# Community Data License Agreement - Permissive - Version 2.0
+
+This is the Community Data License Agreement - Permissive, Version
+2.0 (the "agreement"). Data Provider(s) and Data Recipient(s) agree
+as follows:
+
+## 1. Provision of the Data
+
+1.1. A Data Recipient may use, modify, and share the Data made
+available by Data Provider(s) under this agreement if that Data
+Recipient follows the terms of this agreement.
+
+1.2. This agreement does not impose any restriction on a Data
+Recipient's use, modification, or sharing of any portions of the
+Data that are in the public domain or that may be used, modified,
+or shared under any other legal exception or limitation.
+
+## 2. Conditions for Sharing Data
+
+2.1. A Data Recipient may share Data, with or without modifications, so
+long as the Data Recipient makes available the text of this agreement
+with the shared Data.
+
+## 3. No Restrictions on Results
+
+3.1. This agreement does not impose any restriction or obligations
+with respect to the use, modification, or sharing of Results.
+
+## 4. No Warranty; Limitation of Liability
+
+4.1. All Data Recipients receive the Data subject to the following
+terms:
+
+THE DATA IS PROVIDED ON AN "AS IS" BASIS, WITHOUT REPRESENTATIONS,
+WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED
+INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+NO DATA PROVIDER SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING
+WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE DATA OR RESULTS,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+## 5. Definitions
+
+5.1. "Data" means the material received by a Data Recipient under
+this agreement.
+
+5.2. "Data Provider" means any person who is the source of Data
+provided under this agreement and in reliance on a Data Recipient's
+agreement to its terms.
+
+5.3. "Data Recipient" means any person who receives Data directly
+or indirectly from a Data Provider and agrees to the terms of this
+agreement.
+
+5.4. "Results" means any outcome obtained by computational analysis
+of Data, including for example machine learning models and models'
+insights.
+
+-------------------------------------------------------------------------------
+License: ISC License (ISC)
+Used by:
+- untrusted 0.9.0 | https://github.com/briansmith/untrusted | registry+https://github.com/rust-lang/crates.io-index
+
+// Copyright 2015-2016 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+-------------------------------------------------------------------------------
 License: ISC License (ISC)
 Used by:
 - libloading 0.7.4 | https://github.com/nagisa/rust_libloading/ | registry+https://github.com/rust-lang/crates.io-index
@@ -7766,6 +8325,46 @@ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR 
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
 NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
+
+-------------------------------------------------------------------------------
+License: ISC License (ISC)
+Used by:
+- rustls-webpki 0.103.15 | https://github.com/rustls/webpki | registry+https://github.com/rust-lang/crates.io-index
+
+Except as otherwise noted, this project is licensed under the following
+(ISC-style) terms:
+
+Copyright 2015 Brian Smith.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+The files under third-party/chromium are licensed as described in
+third-party/chromium/LICENSE.
+
+-------------------------------------------------------------------------------
+License: ISC License (ISC)
+Used by:
+- aws-lc-rs 1.18.0 | https://github.com/aws/aws-lc-rs | registry+https://github.com/rust-lang/crates.io-index
+- aws-lc-sys 0.44.0 | https://github.com/aws/aws-lc-rs | registry+https://github.com/rust-lang/crates.io-index
+
+ISC License:
+
+Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC")
+Copyright (c) 1995-2003 by Internet Software Consortium
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -------------------------------------------------------------------------------
 License: MIT License (MIT)
@@ -7961,6 +8560,19 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+-------------------------------------------------------------------------------
+License: MIT License (MIT)
+Used by:
+- schannel 0.1.29 | https://github.com/steffengy/schannel-rs | registry+https://github.com/rust-lang/crates.io-index
+
+Copyright (c) 2015 steffengy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -------------------------------------------------------------------------------
 License: MIT License (MIT)
@@ -8972,6 +9584,35 @@ SOFTWARE.
 -------------------------------------------------------------------------------
 License: MIT License (MIT)
 Used by:
+- zip 7.2.0 | https://github.com/zip-rs/zip2.git | registry+https://github.com/rust-lang/crates.io-index
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Mathijs van de Nes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Some files in the "tests/data" subdirectory of this repository are under other
+licences; see files named LICENSE.*.txt for details.
+-------------------------------------------------------------------------------
+License: MIT License (MIT)
+Used by:
 - phf 0.13.1 | https://github.com/rust-phf/rust-phf | registry+https://github.com/rust-lang/crates.io-index
 - phf_generator 0.13.1 | https://github.com/rust-phf/rust-phf | registry+https://github.com/rust-lang/crates.io-index
 - phf_macros 0.13.1 | https://github.com/rust-phf/rust-phf | registry+https://github.com/rust-lang/crates.io-index
@@ -9112,6 +9753,34 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
+
+-------------------------------------------------------------------------------
+License: MIT License (MIT)
+Used by:
+- aws-lc-sys 0.44.0 | https://github.com/aws/aws-lc-rs | registry+https://github.com/rust-lang/crates.io-index
+
+The MIT License (MIT)
+
+Copyright (c) 2015-2020 the fiat-crypto authors (see
+https://github.com/mit-plv/fiat-crypto/blob/master/AUTHORS).
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 -------------------------------------------------------------------------------
 License: MIT License (MIT)
@@ -10561,6 +11230,31 @@ SPDX-License-Identifier: Unicode-3.0
 
 Portions of ICU4X may have been adapted from ICU4C and/or ICU4J.
 ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation and others.
+
+-------------------------------------------------------------------------------
+License: zlib License (Zlib)
+Used by:
+- zlib-rs 0.6.7 | https://github.com/trifectatechfoundation/zlib-rs | registry+https://github.com/rust-lang/crates.io-index
+
+(C) 2024 Trifecta Tech Foundation
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source distribution.
 
 -------------------------------------------------------------------------------
 License: zlib License (Zlib)

--- a/desktop/about.toml
+++ b/desktop/about.toml
@@ -3,6 +3,7 @@ accepted = [
   "MIT",
   "BSD-2-Clause",
   "BSD-3-Clause",
+  "CDLA-Permissive-2.0",
   "ISC",
   "MPL-2.0",
   "Unicode-3.0",

--- a/desktop/runtime-manifest.json
+++ b/desktop/runtime-manifest.json
@@ -11,8 +11,28 @@
     "engine": "ollama",
     "model": "qwen3.5:4b-q4_K_M",
     "download_size_bytes": 3650722202,
+    "managed_runtime": {
+      "version": "0.32.5",
+      "maximum_download_size_bytes": 1457824795,
+      "artifacts": {
+        "windows-x86_64": {
+          "url": "https://github.com/ollama/ollama/releases/download/v0.32.5/ollama-windows-amd64.zip",
+          "sha256": "7c941ae084569d298062d29f8139163a3187c76dbca0479c70d085e78fd8c7bb",
+          "download_size_bytes": 1457824795,
+          "archive": "zip",
+          "executable": "ollama.exe"
+        },
+        "macos-aarch64": {
+          "url": "https://github.com/ollama/ollama/releases/download/v0.32.5/ollama-darwin.tgz",
+          "sha256": "5789dd037a86adb328c72c11fc45e6c558452d07e5b50814a8bdb7b0fbdbcd81",
+          "download_size_bytes": 145747028,
+          "archive": "tar_gz",
+          "executable": "ollama"
+        }
+      }
+    },
     "label": "Local grounded answers",
-    "description": "Turn VidXP search evidence into cited answers on this computer. Setup reuses or installs Ollama and downloads the approved Qwen 3.5 4B model."
+    "description": "Turn VidXP search evidence into cited answers on this computer. Setup reuses Ollama when available or downloads a private headless runtime and the approved Qwen 3.5 4B model."
   },
   "surfaces": {
     "worker": {

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -231,7 +231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84790c55b5704b0d35130bf16a4ce22a8e70eb0ea773522557524d9a4852663d"
 dependencies = [
  "nix 0.30.1",
- "rand",
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -239,6 +239,29 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "base64"
@@ -453,6 +476,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -496,6 +521,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +541,15 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -544,6 +589,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -565,7 +620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -578,7 +633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -1060,6 +1115,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,12 +1132,13 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1122,6 +1188,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -1324,8 +1396,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1347,8 +1421,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1614,6 +1691,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,9 +1723,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1648,7 +1742,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1881,6 +1975,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.19",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,6 +2030,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
 ]
 
 [[package]]
@@ -2038,6 +2172,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,6 +2214,16 @@ name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2425,6 +2575,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,7 +2765,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -2622,7 +2778,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -2753,6 +2909,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2780,7 +2993,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2790,7 +3014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2800,6 +3024,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2892,15 +3131,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2937,6 +3182,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,6 +3224,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2977,6 +3311,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3035,6 +3378,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3300,6 +3666,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3412,6 +3794,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3475,6 +3863,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3495,7 +3904,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -3505,7 +3914,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3539,6 +3948,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3561,7 +3981,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -3821,7 +4241,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -3844,7 +4264,7 @@ checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -4055,6 +4475,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4295,6 +4725,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4371,6 +4807,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4430,6 +4872,7 @@ name = "vidxp-desktop"
 version = "0.4.0"
 dependencies = [
  "atomic-write-file",
+ "flate2",
  "hex",
  "log",
  "process-wrap",
@@ -4437,6 +4880,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tar",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -4447,6 +4891,7 @@ dependencies = [
  "tauri-plugin-store",
  "which",
  "windows 0.62.2",
+ "zip",
 ]
 
 [[package]]
@@ -4582,6 +5027,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4635,6 +5090,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4874,6 +5338,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4916,6 +5391,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5225,7 +5709,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -5270,6 +5754,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -5398,6 +5892,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5429,6 +5929,25 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -17,13 +17,15 @@ tauri-build = { version = "2.6.3", features = [] }
 
 [dependencies]
 atomic-write-file = "0.3.0"
+flate2 = "1.1.10"
 hex = "0.4.3"
 log = "0.4.29"
 process-wrap = { version = "9.1.0", features = ["std"] }
-reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "json"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "json", "rustls", "system-proxy"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 sha2 = "0.11.0"
+tar = "0.4.46"
 tauri = { version = "2.11.5", features = ["tray-icon"] }
 tauri-plugin-log = "2.9.0"
 tauri-plugin-dialog = "2.7.2"
@@ -32,6 +34,7 @@ tauri-plugin-shell = "2.3.5"
 tauri-plugin-single-instance = "2.4.3"
 tauri-plugin-store = "2.4.4"
 which = "8.0.0"
+zip = { version = "7.2.0", default-features = false, features = ["deflate-flate2-zlib-rs"] }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62.2", features = ["Win32_System_Threading"] }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -59,7 +59,6 @@ const PRODUCT_DATA_DIRECTORY_NAME: &str = "VidXP";
 const RUNTIME_CONSTRAINTS_FILE_NAME: &str = "runtime-constraints.txt";
 const MAX_SETUP_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
 const MEDIA_RUNTIME_INSTALL_TIMEOUT: Duration = Duration::from_secs(15 * 60);
-const QUERY_RUNTIME_INSTALL_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 const QUERY_MODEL_PULL_TIMEOUT: Duration = Duration::from_secs(2 * 60 * 60);
 static READINESS_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -98,6 +97,7 @@ struct LocalAnswersSpec {
     engine: String,
     model: String,
     download_size_bytes: u64,
+    managed_runtime: query_setup::ManagedRuntimeSpec,
     label: String,
     description: String,
 }
@@ -1549,6 +1549,14 @@ fn resolve_system_executable(name: &str) -> Option<PathBuf> {
     None
 }
 
+fn resolve_query_executable(
+    paths: &DesktopPaths,
+    spec: &query_setup::ManagedRuntimeSpec,
+) -> Option<PathBuf> {
+    resolve_system_executable("ollama")
+        .or_else(|| query_setup::managed_executable(&paths.private_data, spec))
+}
+
 fn combined_output(output: &background_process::BackgroundOutput) -> String {
     format!(
         "{}\n{}",
@@ -1641,6 +1649,11 @@ fn verified_media_runtime() -> Result<VerifiedMediaRuntime, String> {
 
 fn ollama_management_url(path: &str) -> String {
     format!("http://{}{path}", query_setup::OLLAMA_HOST)
+}
+
+fn human_bytes(bytes: u64) -> String {
+    const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+    format!("{:.2} GiB", bytes as f64 / GIB)
 }
 
 fn ollama_client(timeout: Duration) -> Result<reqwest::blocking::Client, String> {
@@ -1861,35 +1874,31 @@ async fn prepare_local_answers_runtime(
     draft_id: &str,
     current: u8,
     total_steps: u8,
-    model: &str,
+    spec: &LocalAnswersSpec,
     cancellation: background_process::CancellationToken,
 ) -> Result<(), String> {
     if let Some(error) = local_answer_platform_error() {
         return Err(error);
     }
     let server_ready = ollama_server_version().is_ok();
-    let mut executable = resolve_system_executable("ollama");
+    let mut executable = resolve_query_executable(paths, &spec.managed_runtime);
     if !server_ready && executable.is_none() {
-        let plan = query_setup::system_install_plan(resolve_system_executable).ok_or_else(|| {
-            if cfg!(target_os = "macos") {
-                "Local grounded answers require Ollama on macOS 14 or newer. Install the official Ollama app from https://ollama.com/download, then retry.".to_string()
-            } else if cfg!(target_os = "linux") {
-                "Local grounded answers require Ollama. Install it using the official Linux instructions at https://ollama.com/download/linux, then retry.".to_string()
-            } else {
-                "Local grounded answers require Ollama, but no supported automatic installer was found. Install it from https://ollama.com/download, then retry.".to_string()
-            }
+        let artifact = query_setup::current_artifact(&spec.managed_runtime).ok_or_else(|| {
+            "VidXP does not publish a managed headless Ollama runtime for this platform. Install Ollama from https://ollama.com/download, then retry."
+                .to_string()
         })?;
         let approved = app
             .dialog()
             .message(format!(
-                "Local grounded answers use Ollama and download {model} (approximately 3.4 GB, Apache-2.0).\n\nInstall Ollama with {}?\n\n{}",
-                plan.manager,
-                display_command(&plan.command)
+                "Local grounded answers require a local inference runtime and {} (approximately 3.4 GB, Apache-2.0).\n\nDownload the verified headless Ollama {} runtime ({}) into VidXP's private data? No Ollama desktop app will be installed.",
+                spec.model,
+                spec.managed_runtime.version,
+                human_bytes(artifact.download_size_bytes)
             ))
-            .title("Install local answer runtime")
+            .title("Download local answer runtime")
             .kind(MessageDialogKind::Info)
             .buttons(MessageDialogButtons::OkCancelCustom(
-                "Install".into(),
+                "Download".into(),
                 "Not now".into(),
             ))
             .blocking_show();
@@ -1901,40 +1910,56 @@ async fn prepare_local_answers_runtime(
             draft_id,
             current,
             total_steps,
-            format!("Installing Ollama with {}", plan.manager),
-            None,
-            None,
+            format!(
+                "Downloading the headless Ollama {} runtime",
+                spec.managed_runtime.version
+            ),
+            Some(0),
+            Some(artifact.download_size_bytes),
         );
-        let command = app
-            .shell()
-            .command(plan.command[0].clone())
-            .args(&plan.command[1..]);
-        supervised_output_with_timeout(
-            command.into(),
-            cancellation.clone(),
-            &format!("{} Ollama installation", plan.manager),
-            QUERY_RUNTIME_INSTALL_TIMEOUT,
-        )
-        .await?;
-        for _ in 0..10 {
-            executable = resolve_system_executable("ollama");
-            if executable.is_some() {
-                break;
-            }
-            thread::sleep(Duration::from_secs(1));
-        }
+        let download_app = app.clone();
+        let download_draft = draft_id.to_owned();
+        let private_data = paths.private_data.clone();
+        let managed_runtime = spec.managed_runtime.clone();
+        let runtime_version = managed_runtime.version.clone();
+        let runtime_cancellation = cancellation.clone();
+        executable = Some(
+            tauri::async_runtime::spawn_blocking(move || {
+                query_setup::install_managed_runtime(
+                    &private_data,
+                    &managed_runtime,
+                    &runtime_cancellation,
+                    |downloaded, total| {
+                        emit_local_answer_progress(
+                            &download_app,
+                            &download_draft,
+                            current,
+                            total_steps,
+                            format!("Downloading the headless Ollama {runtime_version} runtime"),
+                            Some(downloaded),
+                            Some(total),
+                        );
+                    },
+                )
+            })
+            .await
+            .map_err(|error| {
+                format!("Managed Ollama runtime preparation stopped unexpectedly: {error}")
+            })??,
+        );
     }
     let model_directory = paths.models.join("ollama");
     if let Some(executable) = executable {
         ensure_query_service(state, &executable, &model_directory)?;
     } else if !server_ready {
         return Err(
-            "Ollama installation finished, but VidXP could not locate its executable.".to_string(),
+            "The managed Ollama runtime finished downloading, but VidXP could not locate its executable."
+                .to_string(),
         );
     }
     let pull_app = app.clone();
     let pull_draft = draft_id.to_owned();
-    let pull_model = model.to_owned();
+    let pull_model = spec.model.clone();
     let pull_cancellation = cancellation;
     let installed = tauri::async_runtime::spawn_blocking(move || {
         pull_ollama_model(
@@ -1949,7 +1974,10 @@ async fn prepare_local_answers_runtime(
     .await
     .map_err(|error| format!("Local answer model preparation stopped unexpectedly: {error}"))??;
     if installed.digest.trim().is_empty() {
-        return Err(format!("Ollama did not report a digest for {model}."));
+        return Err(format!(
+            "Ollama did not report a digest for {}.",
+            spec.model
+        ));
     }
     Ok(())
 }
@@ -1977,8 +2005,9 @@ fn ensure_active_query_service(state: &DesktopState, paths: &DesktopPaths) -> Re
         return Ok(());
     }
     if ollama_server_version().is_err() {
-        let executable = resolve_system_executable("ollama").ok_or_else(|| {
-            "Local grounded answers are enabled, but Ollama is no longer installed. Open Setup options and repair VidXP."
+        let local_answers = manifest()?.local_answers;
+        let executable = resolve_query_executable(paths, &local_answers.managed_runtime).ok_or_else(|| {
+            "Local grounded answers are enabled, but their Ollama runtime is no longer available. Open Setup options and repair VidXP."
                 .to_string()
         })?;
         ensure_query_service(state, &executable, &paths.models.join("ollama"))?;
@@ -3461,7 +3490,7 @@ async fn install_runtime(
                 &request.draft_id,
                 2,
                 progress_total,
-                &manifest.local_answers.model,
+                &manifest.local_answers,
                 cancellation.token(),
             )
             .await?;
@@ -6132,6 +6161,41 @@ mod tests {
         assert_eq!(manifest.local_answers.engine, "ollama");
         assert_eq!(manifest.local_answers.model, "qwen3.5:4b-q4_K_M");
         assert_eq!(manifest.local_answers.download_size_bytes, 3_650_722_202);
+        assert_eq!(manifest.local_answers.managed_runtime.version, "0.32.5");
+        assert_eq!(
+            manifest
+                .local_answers
+                .managed_runtime
+                .maximum_download_size_bytes,
+            1_457_824_795
+        );
+        assert!(
+            manifest
+                .local_answers
+                .managed_runtime
+                .artifacts
+                .contains_key("windows-x86_64")
+        );
+        assert!(
+            manifest
+                .local_answers
+                .managed_runtime
+                .artifacts
+                .contains_key("macos-aarch64")
+        );
+        if let Some(artifact) =
+            super::query_setup::current_artifact(&manifest.local_answers.managed_runtime)
+        {
+            assert_eq!(artifact.sha256.len(), 64);
+            assert!(artifact.download_size_bytes > 0);
+            assert!(
+                artifact.download_size_bytes
+                    <= manifest
+                        .local_answers
+                        .managed_runtime
+                        .maximum_download_size_bytes
+            );
+        }
     }
 
     #[test]

--- a/desktop/src-tauri/src/query_setup.rs
+++ b/desktop/src-tauri/src/query_setup.rs
@@ -1,11 +1,45 @@
-use std::{env, path::PathBuf};
+use std::{
+    collections::BTreeMap,
+    env, fs,
+    fs::File,
+    io::{self, BufReader, Read, Write},
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
-#[cfg(windows)]
-use std::{fs, path::Path};
+use flate2::read::GzDecoder;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
-use crate::media_setup::SystemInstallPlan;
+use crate::background_process::CancellationToken;
 
 pub(crate) const OLLAMA_HOST: &str = "127.0.0.1:11434";
+const MANAGED_RUNTIME_DIRECTORY: &str = "query-runtimes";
+const RUNTIME_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(2 * 60 * 60);
+const DOWNLOAD_BUFFER_BYTES: usize = 1024 * 1024;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct ManagedRuntimeSpec {
+    pub(crate) version: String,
+    pub(crate) maximum_download_size_bytes: u64,
+    pub(crate) artifacts: BTreeMap<String, ManagedRuntimeArtifactSpec>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct ManagedRuntimeArtifactSpec {
+    pub(crate) url: String,
+    pub(crate) sha256: String,
+    pub(crate) download_size_bytes: u64,
+    pub(crate) archive: ManagedRuntimeArchive,
+    pub(crate) executable: PathBuf,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ManagedRuntimeArchive {
+    Zip,
+    TarGz,
+}
 
 pub(crate) fn version_meets_minimum(output: &str, minimum: (u32, u32, u32)) -> Option<bool> {
     let version = output
@@ -22,45 +56,6 @@ pub(crate) fn version_meets_minimum(output: &str, minimum: (u32, u32, u32)) -> O
     }
     let actual = (parts[0], parts[1], parts.get(2).copied().unwrap_or(0));
     Some(actual >= minimum)
-}
-
-pub(crate) fn system_install_plan(
-    mut resolve: impl FnMut(&str) -> Option<PathBuf>,
-) -> Option<SystemInstallPlan> {
-    if cfg!(windows) {
-        resolve("winget")?;
-        return Some(SystemInstallPlan {
-            manager: "Windows Package Manager".into(),
-            command: vec![
-                "winget".into(),
-                "install".into(),
-                "--id".into(),
-                "Ollama.Ollama".into(),
-                "--exact".into(),
-                "--source".into(),
-                "winget".into(),
-                "--silent".into(),
-                "--disable-interactivity".into(),
-                "--accept-package-agreements".into(),
-                "--accept-source-agreements".into(),
-            ],
-            automatic: true,
-        });
-    }
-    if cfg!(target_os = "macos") {
-        let brew = resolve("brew")?;
-        return Some(SystemInstallPlan {
-            manager: "Homebrew".into(),
-            command: vec![
-                brew.to_string_lossy().into_owned(),
-                "install".into(),
-                "--cask".into(),
-                "ollama-app".into(),
-            ],
-            automatic: true,
-        });
-    }
-    None
 }
 
 pub(crate) fn executable_candidates() -> Vec<PathBuf> {
@@ -120,17 +115,315 @@ pub(crate) fn resolve_winget_ollama_executable() -> Option<PathBuf> {
         .and_then(|candidate| fs::canonicalize(&candidate).ok().or(Some(candidate)))
 }
 
+#[cfg(all(windows, target_arch = "x86_64"))]
+fn current_platform_key() -> Option<&'static str> {
+    Some("windows-x86_64")
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn current_platform_key() -> Option<&'static str> {
+    Some("macos-aarch64")
+}
+
+#[cfg(not(any(
+    all(windows, target_arch = "x86_64"),
+    all(target_os = "macos", target_arch = "aarch64")
+)))]
+fn current_platform_key() -> Option<&'static str> {
+    None
+}
+
+pub(crate) fn current_artifact(spec: &ManagedRuntimeSpec) -> Option<&ManagedRuntimeArtifactSpec> {
+    spec.artifacts.get(current_platform_key()?)
+}
+
+fn managed_runtime_root(private_data: &Path) -> PathBuf {
+    private_data.join(MANAGED_RUNTIME_DIRECTORY)
+}
+
+fn managed_runtime_directory(
+    private_data: &Path,
+    spec: &ManagedRuntimeSpec,
+) -> Result<PathBuf, String> {
+    if spec.version.is_empty()
+        || !spec.version.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '_')
+        })
+    {
+        return Err("The managed Ollama runtime version is invalid.".into());
+    }
+    Ok(managed_runtime_root(private_data).join(format!("ollama-{}", spec.version)))
+}
+
+pub(crate) fn managed_executable(
+    private_data: &Path,
+    spec: &ManagedRuntimeSpec,
+) -> Option<PathBuf> {
+    let artifact = current_artifact(spec)?;
+    let candidate = managed_runtime_directory(private_data, spec)
+        .ok()?
+        .join(&artifact.executable);
+    candidate
+        .is_file()
+        .then(|| fs::canonicalize(&candidate).unwrap_or(candidate))
+}
+
+fn runtime_download_client() -> Result<reqwest::blocking::Client, String> {
+    reqwest::blocking::Client::builder()
+        .connect_timeout(Duration::from_secs(15))
+        .timeout(RUNTIME_DOWNLOAD_TIMEOUT)
+        .build()
+        .map_err(|error| format!("Could not configure the Ollama runtime download: {error}"))
+}
+
+fn download_archive(
+    artifact: &ManagedRuntimeArtifactSpec,
+    destination: &Path,
+    cancellation: &CancellationToken,
+    mut progress: impl FnMut(u64, u64),
+) -> Result<(), String> {
+    let mut response = runtime_download_client()?
+        .get(&artifact.url)
+        .header(reqwest::header::USER_AGENT, "VidXP-Desktop")
+        .send()
+        .and_then(reqwest::blocking::Response::error_for_status)
+        .map_err(|error| format!("Could not download the managed Ollama runtime: {error}"))?;
+    let response_total = response
+        .content_length()
+        .unwrap_or(artifact.download_size_bytes);
+    let mut output = File::create(destination).map_err(|error| {
+        format!(
+            "Could not create the temporary Ollama runtime archive at {}: {error}",
+            destination.display()
+        )
+    })?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; DOWNLOAD_BUFFER_BYTES];
+    let mut downloaded = 0_u64;
+    progress(0, response_total);
+    loop {
+        if cancellation.is_cancelled() {
+            return Err("the managed Ollama runtime download was cancelled".into());
+        }
+        let count = response
+            .read(&mut buffer)
+            .map_err(|error| format!("The managed Ollama runtime download failed: {error}"))?;
+        if count == 0 {
+            break;
+        }
+        output.write_all(&buffer[..count]).map_err(|error| {
+            format!("Could not write the managed Ollama runtime archive: {error}")
+        })?;
+        hasher.update(&buffer[..count]);
+        downloaded += count as u64;
+        progress(downloaded, response_total);
+    }
+    output
+        .sync_all()
+        .map_err(|error| format!("Could not finish the managed Ollama runtime archive: {error}"))?;
+    if downloaded != artifact.download_size_bytes {
+        return Err(format!(
+            "The managed Ollama runtime download contained {downloaded} bytes; expected {}.",
+            artifact.download_size_bytes
+        ));
+    }
+    let actual_sha256 = hex::encode(hasher.finalize());
+    if !actual_sha256.eq_ignore_ascii_case(&artifact.sha256) {
+        return Err(format!(
+            "The managed Ollama runtime failed checksum verification: expected {}, received {actual_sha256}.",
+            artifact.sha256
+        ));
+    }
+    Ok(())
+}
+
+fn extract_zip(
+    archive_path: &Path,
+    destination: &Path,
+    cancellation: &CancellationToken,
+) -> Result<(), String> {
+    let archive_file = File::open(archive_path)
+        .map_err(|error| format!("Could not open the managed Ollama archive: {error}"))?;
+    let mut archive = zip::ZipArchive::new(BufReader::new(archive_file))
+        .map_err(|error| format!("Could not read the managed Ollama ZIP archive: {error}"))?;
+    for index in 0..archive.len() {
+        if cancellation.is_cancelled() {
+            return Err("the managed Ollama runtime extraction was cancelled".into());
+        }
+        let mut entry = archive
+            .by_index(index)
+            .map_err(|error| format!("Could not inspect the managed Ollama archive: {error}"))?;
+        let relative = entry
+            .enclosed_name()
+            .ok_or("The managed Ollama archive contains an unsafe path.")?;
+        if entry
+            .unix_mode()
+            .is_some_and(|mode| mode & 0o170000 == 0o120000)
+        {
+            return Err("The managed Ollama ZIP archive contains an unsupported link.".into());
+        }
+        let output = destination.join(relative);
+        if entry.is_dir() {
+            fs::create_dir_all(&output)
+                .map_err(|error| format!("Could not create an Ollama runtime folder: {error}"))?;
+        } else if entry.is_file() {
+            if let Some(parent) = output.parent() {
+                fs::create_dir_all(parent).map_err(|error| {
+                    format!("Could not create an Ollama runtime folder: {error}")
+                })?;
+            }
+            let mut file = File::create(&output)
+                .map_err(|error| format!("Could not extract an Ollama runtime file: {error}"))?;
+            io::copy(&mut entry, &mut file)
+                .map_err(|error| format!("Could not extract an Ollama runtime file: {error}"))?;
+        } else {
+            return Err("The managed Ollama ZIP archive contains an unsupported entry.".into());
+        }
+    }
+    Ok(())
+}
+
+fn extract_tar_gz(
+    archive_path: &Path,
+    destination: &Path,
+    cancellation: &CancellationToken,
+) -> Result<(), String> {
+    let archive_file = File::open(archive_path)
+        .map_err(|error| format!("Could not open the managed Ollama archive: {error}"))?;
+    let decoder = GzDecoder::new(BufReader::new(archive_file));
+    let mut archive = tar::Archive::new(decoder);
+    let entries = archive
+        .entries()
+        .map_err(|error| format!("Could not read the managed Ollama archive: {error}"))?;
+    for entry in entries {
+        if cancellation.is_cancelled() {
+            return Err("the managed Ollama runtime extraction was cancelled".into());
+        }
+        let mut entry = entry
+            .map_err(|error| format!("Could not inspect the managed Ollama archive: {error}"))?;
+        let entry_type = entry.header().entry_type();
+        if !entry_type.is_file() && !entry_type.is_dir() {
+            return Err("The managed Ollama archive contains an unsupported entry.".into());
+        }
+        if !entry
+            .unpack_in(destination)
+            .map_err(|error| format!("Could not extract the managed Ollama archive: {error}"))?
+        {
+            return Err("The managed Ollama archive contains an unsafe path.".into());
+        }
+    }
+    Ok(())
+}
+
+fn extract_archive(
+    archive_path: &Path,
+    destination: &Path,
+    archive: ManagedRuntimeArchive,
+    cancellation: &CancellationToken,
+) -> Result<(), String> {
+    fs::create_dir_all(destination).map_err(|error| {
+        format!(
+            "Could not create the managed Ollama runtime folder at {}: {error}",
+            destination.display()
+        )
+    })?;
+    match archive {
+        ManagedRuntimeArchive::Zip => extract_zip(archive_path, destination, cancellation),
+        ManagedRuntimeArchive::TarGz => extract_tar_gz(archive_path, destination, cancellation),
+    }
+}
+
+pub(crate) fn install_managed_runtime(
+    private_data: &Path,
+    spec: &ManagedRuntimeSpec,
+    cancellation: &CancellationToken,
+    progress: impl FnMut(u64, u64),
+) -> Result<PathBuf, String> {
+    if let Some(executable) = managed_executable(private_data, spec) {
+        return Ok(executable);
+    }
+    let artifact = current_artifact(spec).ok_or_else(|| {
+        "VidXP does not publish a managed Ollama runtime for this operating system and architecture."
+            .to_string()
+    })?;
+    let runtime_root = managed_runtime_root(private_data);
+    fs::create_dir_all(&runtime_root).map_err(|error| {
+        format!(
+            "Could not create the managed query runtime folder at {}: {error}",
+            runtime_root.display()
+        )
+    })?;
+    let target = managed_runtime_directory(private_data, spec)?;
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| format!("The system clock is invalid: {error}"))?
+        .as_nanos();
+    let temporary_name = format!("ollama-{}-{}-{nonce}", spec.version, std::process::id());
+    let archive_path = runtime_root.join(format!(".{temporary_name}.download"));
+    let staging = runtime_root.join(format!(".{temporary_name}.partial"));
+    let result = (|| {
+        download_archive(artifact, &archive_path, cancellation, progress)?;
+        if cancellation.is_cancelled() {
+            return Err("the managed Ollama runtime setup was cancelled".into());
+        }
+        extract_archive(&archive_path, &staging, artifact.archive, cancellation)?;
+        let staged_executable = staging.join(&artifact.executable);
+        if !staged_executable.is_file() {
+            return Err(format!(
+                "The managed Ollama archive did not contain {}.",
+                artifact.executable.display()
+            ));
+        }
+        if target.exists() {
+            fs::remove_dir_all(&target).map_err(|error| {
+                format!("Could not replace the incomplete managed Ollama runtime: {error}")
+            })?;
+        }
+        fs::rename(&staging, &target)
+            .map_err(|error| format!("Could not activate the managed Ollama runtime: {error}"))?;
+        let executable = target.join(&artifact.executable);
+        Ok(fs::canonicalize(&executable).unwrap_or(executable))
+    })();
+    let _ = fs::remove_file(&archive_path);
+    if staging.exists() {
+        let _ = fs::remove_dir_all(&staging);
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn supported_install_plans_never_run_an_unattended_shell_script() {
-        if let Some(plan) = system_install_plan(|name| Some(PathBuf::from(name))) {
-            let command = plan.command.join(" ").to_ascii_lowercase();
-            assert!(!command.contains("curl"));
-            assert!(!command.contains("powershell"));
-            assert!(!command.contains("sh -"));
+    fn temporary_root(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "vidxp-{label}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ))
+    }
+
+    fn runtime_spec() -> ManagedRuntimeSpec {
+        ManagedRuntimeSpec {
+            version: "0.32.5".into(),
+            maximum_download_size_bytes: 10,
+            artifacts: BTreeMap::from([(
+                current_platform_key().unwrap_or("unsupported").into(),
+                ManagedRuntimeArtifactSpec {
+                    url: "https://example.invalid/ollama.zip".into(),
+                    sha256: "00".repeat(32),
+                    download_size_bytes: 10,
+                    archive: ManagedRuntimeArchive::Zip,
+                    executable: PathBuf::from(if cfg!(windows) {
+                        "ollama.exe"
+                    } else {
+                        "ollama"
+                    }),
+                },
+            )]),
         }
     }
 
@@ -150,21 +443,80 @@ mod tests {
         assert_eq!(version_meets_minimum("unknown", (14, 0, 0)), None);
     }
 
-    #[cfg(windows)]
     #[test]
-    fn windows_install_is_explicit_and_non_interactive() {
-        let plan =
-            system_install_plan(|name| (name == "winget").then(|| PathBuf::from("winget.exe")))
-                .expect("install plan");
-        assert!(
-            plan.command
-                .windows(2)
-                .any(|pair| pair == ["--id", "Ollama.Ollama"])
+    fn managed_runtime_version_cannot_escape_its_owned_root() {
+        let mut spec = runtime_spec();
+        spec.version = "../escape".into();
+        assert!(managed_runtime_directory(Path::new("runtime-root"), &spec).is_err());
+    }
+
+    #[test]
+    fn managed_executable_requires_the_expected_file() {
+        let root = temporary_root("managed-ollama-path");
+        let spec = runtime_spec();
+        assert_eq!(managed_executable(&root, &spec), None);
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn zip_runtime_archive_extracts_only_expected_files() {
+        let root = temporary_root("managed-ollama-zip");
+        let archive_path = root.join("runtime.zip");
+        let destination = root.join("extracted");
+        fs::create_dir_all(&root).expect("temporary root");
+        let archive_file = File::create(&archive_path).expect("archive file");
+        let mut archive = zip::ZipWriter::new(archive_file);
+        archive
+            .start_file(
+                "ollama.exe",
+                zip::write::SimpleFileOptions::default()
+                    .compression_method(zip::CompressionMethod::Deflated),
+            )
+            .expect("archive entry");
+        archive.write_all(b"headless-runtime").expect("entry data");
+        archive.finish().expect("finished archive");
+
+        extract_zip(&archive_path, &destination, &CancellationToken::default())
+            .expect("extracted archive");
+
+        assert_eq!(
+            fs::read(destination.join("ollama.exe")).expect("extracted executable"),
+            b"headless-runtime"
         );
-        assert!(
-            plan.command
-                .iter()
-                .any(|value| value == "--disable-interactivity")
+        fs::remove_dir_all(root).expect("temporary cleanup");
+    }
+
+    #[test]
+    fn tar_runtime_archive_extracts_only_expected_files() {
+        let root = temporary_root("managed-ollama-tar");
+        let archive_path = root.join("runtime.tgz");
+        let destination = root.join("extracted");
+        fs::create_dir_all(&root).expect("temporary root");
+        let archive_file = File::create(&archive_path).expect("archive file");
+        let encoder = flate2::write::GzEncoder::new(archive_file, flate2::Compression::default());
+        let mut archive = tar::Builder::new(encoder);
+        let contents = b"headless-runtime";
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        archive
+            .append_data(&mut header, "ollama", &contents[..])
+            .expect("archive entry");
+        archive
+            .into_inner()
+            .expect("archive encoder")
+            .finish()
+            .expect("finished archive");
+        fs::create_dir_all(&destination).expect("extraction destination");
+
+        extract_tar_gz(&archive_path, &destination, &CancellationToken::default())
+            .expect("extracted archive");
+
+        assert_eq!(
+            fs::read(destination.join("ollama")).expect("extracted executable"),
+            contents
         );
+        fs::remove_dir_all(root).expect("temporary cleanup");
     }
 }

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -96,7 +96,7 @@ describe('desktop target lifecycle', () => {
       browser: { extra: 'frontend', label: 'Browser interface', description: 'Open VidXP in your browser.', default: true },
       mcp: { extra: 'mcp', label: 'AI assistant integration', description: 'Connect a compatible AI app.', default: false },
       server: { extra: 'server', label: 'App integration service', description: 'Let other local apps connect.', default: false },
-    }, local_answers: { engine: 'ollama', model: 'qwen3.5:4b-q4_K_M', download_size_bytes: 3650722202, label: 'Local grounded answers', description: 'Turn search evidence into cited answers locally.' } });
+    }, local_answers: { engine: 'ollama', model: 'qwen3.5:4b-q4_K_M', download_size_bytes: 3650722202, managed_runtime: { version: '0.32.5', maximum_download_size_bytes: 1457824795 }, label: 'Local grounded answers', description: 'Turn search evidence into cited answers locally.' } });
     mocks.runtimeStatus.mockResolvedValue({ state: 'never_configured', ready: false, runtime_profile: null, package_version: '0.4.0', capabilities: [], surfaces: [], model_directory: 'C:\\Models', detail: 'No managed runtime yet.' });
     mocks.modelDirectoryInventory.mockResolvedValue({ directory: 'C:\\Models', exists: false, readable: true, total_bytes: 0, file_count: 0, recognized_models: [], empty: true, verification_required: false, truncated: false, detail: 'Empty.' });
     mocks.installMediaRuntime.mockResolvedValue({ ready: true });
@@ -524,7 +524,7 @@ describe('desktop target lifecycle', () => {
 
     await user.click(screen.getByRole('checkbox', { name: /Local grounded answers/i }));
     expect(screen.getByText(/There is no URL to enter/i)).toBeVisible();
-    expect(screen.getByText(/grounded-answer model adds 3.40 GiB/i)).toBeVisible();
+    expect(screen.getByText(/Grounded answers add up to 1.36 GiB for the headless runtime and 3.40 GiB for the model/i)).toBeVisible();
     await user.click(screen.getByRole('button', { name: 'Install VidXP' }));
 
     expect(mocks.installMediaRuntime).toHaveBeenCalledWith('draft-1', 9);
@@ -651,6 +651,15 @@ describe('desktop target lifecycle', () => {
     reportProgress?.({ draft_id: 'draft-1', current: 4, total: 8, stage: 'dependencies', message: 'Installing the selected search features' });
     expect(await screen.findByText('Step 4 of 8')).toBeVisible();
     expect(screen.getByText('Installing the selected search features')).toBeVisible();
+    reportProgress?.({
+      draft_id: 'draft-1',
+      current: 2,
+      total: 9,
+      stage: 'local-answers',
+      message: 'Preparing the local grounded-answer model',
+      model_message: 'Downloading the headless Ollama 0.32.5 runtime',
+    });
+    expect(await screen.findByText(/No separate app or setup window is involved/i)).toBeVisible();
     reportProgress?.({
       draft_id: 'draft-1',
       current: 7,

--- a/desktop/src/components/ManagedSetup.tsx
+++ b/desktop/src/components/ManagedSetup.tsx
@@ -416,11 +416,16 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, premiereR
     engine: 'ollama',
     model: 'qwen3.5:4b-q4_K_M',
     download_size_bytes: 3650722202,
+    managed_runtime: {
+      version: '0.32.5',
+      maximum_download_size_bytes: 1457824795,
+    },
     label: 'Local grounded answers',
     description: 'Turn VidXP search evidence into cited answers on this computer.',
   };
   const localAnswerModelBytes = localAnswers ? localAnswerSpec.download_size_bytes : 0;
-  const plannedSetupBytes = managedRuntimeBytes + selectedModelBytes + localAnswerModelBytes;
+  const localAnswerRuntimeBytes = localAnswers ? localAnswerSpec.managed_runtime.maximum_download_size_bytes : 0;
+  const plannedSetupBytes = managedRuntimeBytes + selectedModelBytes + localAnswerModelBytes + localAnswerRuntimeBytes;
   const capabilityModelSummary = capabilities
     .map((id) => {
       const capability = manifest?.capabilities[id];
@@ -524,7 +529,7 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, premiereR
             />
             {localAnswers && (
               <Alert mt="md" color="blue" title="VidXP manages the connection">
-                VidXP checks for Ollama, asks before installing it, starts only a VidXP-owned service when needed, and configures the browser, API, worker, Premiere, and MCP surfaces automatically. There is no URL to enter.
+                VidXP reuses a healthy Ollama service or executable when available. Otherwise it asks before downloading a verified headless runtime into VidXP's private data; it never installs the Ollama desktop app. There is no URL to enter.
               </Alert>
             )}
           </div>
@@ -553,7 +558,7 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, premiereR
               <Button variant="default" leftSection={<IconFolderOpen aria-hidden="true" size={16} />} loading={operation === 'folder'} disabled={isBusy} onClick={() => void chooseFolder()}>Change location…</Button>
             </Group>
             <Alert mt="md" color="blue" title="Plan for local storage">
-              <Text size="sm">The managed runtime can use approximately {formatBytes(managedRuntimeBytes)}. Selected model downloads total up to {formatBytes(selectedModelBytes)}.{localAnswers ? ` The grounded-answer model adds ${formatBytes(localAnswerModelBytes)}.` : ''}</Text>
+              <Text size="sm">The managed runtime can use approximately {formatBytes(managedRuntimeBytes)}. Selected model downloads total up to {formatBytes(selectedModelBytes)}.{localAnswers ? ` Grounded answers add up to ${formatBytes(localAnswerRuntimeBytes)} for the headless runtime and ${formatBytes(localAnswerModelBytes)} for the model.` : ''}</Text>
               <Text size="sm" mt="xs">{capabilityModelSummary}</Text>
               <Text size="sm" mt="xs">Plan for approximately {formatBytes(plannedSetupBytes)} locally, plus temporary installation space, indexes, and videos. Valid cached model files are reused.</Text>
             </Alert>
@@ -661,7 +666,11 @@ export function ManagedSetup({ draftId, selectedManagedRuntimeProfile, premiereR
               )}
             <div>
               <Text fw={650}>{setupProgress?.message ?? 'Starting managed setup'}</Text>
-              <Text size="sm" className="mutedText" mt="xs">The existing installation remains active until every step has completed and the replacement passes validation.</Text>
+              <Text size="sm" className="mutedText" mt="xs">
+                {setupProgress?.stage === 'local-answers'
+                  ? 'VidXP reuses Ollama or manages a private headless runtime. No separate app or setup window is involved.'
+                  : 'The existing installation remains active until every step has completed and the replacement passes validation.'}
+              </Text>
             </div>
             {cancelFailure && <Alert color="red" title="Could not stop setup" role="alert">{cancelFailure}</Alert>}
             <Group justify="flex-end">

--- a/desktop/src/tauri.ts
+++ b/desktop/src/tauri.ts
@@ -154,6 +154,10 @@ export interface RuntimeManifest {
     engine: string;
     model: string;
     download_size_bytes: number;
+    managed_runtime: {
+      version: string;
+      maximum_download_size_bytes: number;
+    };
     label: string;
     description: string;
   };

--- a/docs/architecture/platform.md
+++ b/docs/architecture/platform.md
@@ -870,17 +870,22 @@ self-hosted Ollama base URL selects that model unless an operator explicitly
 overrides it. VidXP sets temperature zero, disables reasoning output, and
 requires the native JSON schemas for both planning and synthesis. Model weights
 are never bundled. Desktop setup pulls the approved artifact only after the
-user selects local grounded answers and approves any required Ollama install;
-CLI and server operators pull it explicitly.
+user selects local grounded answers and approves any required headless-runtime
+download; CLI and server operators pull it explicitly.
 
-Desktop treats the provider as an optional supervised system dependency. It
-first probes the loopback `/api/version` and `/api/tags` contracts, reuses an
-existing healthy service without taking ownership, or starts a child
-`ollama serve` process that its existing process-tree supervisor owns. The
-model pull uses Ollama's streaming `/api/pull` contract. Desktop persists only
-the feature selection, injects the private `/v1` endpoint and approved model
-into managed processes, and includes the same non-secret environment in stdio
-MCP configuration. It never stops an externally owned Ollama service.
+Desktop treats the provider as an optional supervised runtime. It first probes
+the loopback `/api/version` and `/api/tags` contracts and reuses an existing
+healthy service without taking ownership. It next reuses an existing Ollama
+executable. If neither is available on a supported Desktop target, it downloads
+the pinned official headless archive declared in the embedded runtime manifest,
+verifies its expected byte count and SHA-256 digest, and atomically activates it
+under Desktop's private application data. Desktop never installs the Ollama
+desktop app. It starts a child `ollama serve` process that its existing
+process-tree supervisor owns, and the model pull uses Ollama's streaming
+`/api/pull` contract. Desktop persists only the feature selection, injects the
+private `/v1` endpoint and approved model into managed processes, and includes
+the same non-secret environment in stdio MCP configuration. It never stops an
+externally owned Ollama service.
 
 Published model results select the integration candidate; the repository gate
 does not attempt to reproduce general model leaderboards. Promotion still

--- a/docs/benchmarking/agent_ablation.md
+++ b/docs/benchmarking/agent_ablation.md
@@ -108,6 +108,9 @@ uv sync --frozen --extra local-worker --extra mcp --extra benchmarks
 npm --prefix benchmarks/codex-mcp ci
 ```
 
+The benchmark pins the Codex SDK directly and omits Promptfoo's unrelated
+optional provider packages from this install.
+
 Create all mutable state outside the checkout. The paths below are examples;
 keep the same values for both conditions:
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -204,6 +204,17 @@ wait for user confirmation before running either one. On Linux, setup shows an
 APT, DNF, or manual command and leaves elevation to the user. Existing
 installations remain responsible for their own media setup.
 
+Local grounded answers do not justify installing another desktop application.
+Desktop reuses a healthy Ollama service without taking ownership, then checks
+for an existing executable. When neither is available on Windows x86-64 or
+macOS Apple Silicon, it downloads the pinned headless archive declared in
+`runtime-manifest.json`, verifies its byte count and SHA-256 digest, extracts it
+into Desktop's private application data, and starts `ollama serve` through the
+shared process supervisor. Downloads are cancellable, incomplete archives and
+staging directories are removed, and only a completely extracted version is
+activated. Linux and unsupported architectures require an external Ollama
+installation. Desktop never invokes an Ollama desktop-app installer.
+
 Starting Desktop shows the control panel without opening a browser. **Open
 VidXP** starts or reuses the browser service and opens one tab. Closing the
 configured window hides it in the system tray. **Quit VidXP** stops only the

--- a/docs/local-api.md
+++ b/docs/local-api.md
@@ -93,12 +93,14 @@ evidence. VidXP falls back to deterministic evidence retrieval when Ollama is
 not configured or unavailable.
 
 For VidXP Desktop, open **Setup options** and enable **Local grounded
-answers**. Desktop performs the Ollama health check, asks before installing a
-supported system package, downloads the approved model with visible progress,
-and carries the non-secret local provider settings into every managed surface,
-including copied stdio MCP JSON and **Set up in Codex**. If Desktop starts
-`ollama serve`, it supervises and stops only that owned process. It never stops
-an Ollama app or service that was already running.
+answers**. Desktop first reuses a healthy Ollama service or existing executable.
+On supported Desktop platforms, it otherwise asks before downloading the
+pinned, checksum-verified headless runtime into VidXP's private data. It never
+installs the Ollama desktop app. Desktop downloads the approved model with
+visible progress and carries the non-secret local provider settings into every
+managed surface, including copied stdio MCP JSON and **Set up in Codex**. If
+Desktop starts `ollama serve`, it supervises and stops only that owned process.
+It never stops an Ollama app or service that was already running.
 
 The commands below are only for command-line installations and custom
 deployments.
@@ -126,13 +128,15 @@ $env:VIDXP_SLM_BASE_URL = "http://127.0.0.1:11434/v1"
 vidxp query "When does the taxi arrive?"
 ```
 
-The official Q4_K_M model download is approximately 3.4 GB. It runs locally,
-so there is no model API fee or numbered hosted-model run; it still uses local
-storage, memory, compute time, and electricity. Desktop downloads it only when
-the user selects the feature; CLI users pull it explicitly. VidXP never bundles
-the model with the Python or Desktop packages. A reused external Ollama service
-continues to own its model storage; VidXP does not claim those files are in its
-search-model cache.
+The official Q4_K_M model download is approximately 3.4 GB. A Desktop-managed
+headless runtime can add up to approximately 1.36 GiB; an existing service or
+executable avoids that download. Local inference has no model API fee or
+numbered hosted-model run, but it still uses local storage, memory, compute time,
+and electricity. Desktop downloads the model only when the user selects the
+feature; CLI users pull it explicitly. VidXP never bundles the model with the
+Python or Desktop packages. A reused external Ollama service continues to own
+its model storage; VidXP does not claim those files are in its search-model
+cache.
 
 The current query adapter sends structured search evidence, not video or audio
 bytes, to Qwen. Speech transcripts can support generated factual claims.

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,4 +1,5 @@
 import json
+import re
 import subprocess
 import sys
 import tarfile
@@ -587,6 +588,30 @@ class PackagingTests(unittest.TestCase):
             compose,
         )
         self.assertNotIn("ollama pull", compose.lower())
+
+    def test_bundled_chroma_service_is_not_published(self):
+        compose = (ROOT / "compose.coolify.yaml").read_text(
+            encoding="utf-8"
+        )
+        service = re.search(
+            r"(?ms)^  chroma:\n(?P<body>.*?)(?=^  [a-z0-9_-]+:\n|\Z)",
+            compose,
+        )
+
+        self.assertIsNotNone(service)
+        body = service.group("body")
+        self.assertNotRegex(body, r"(?m)^    ports:\s*$")
+        self.assertNotRegex(body, r"(?m)^    network_mode:\s*host\s*$")
+
+    def test_codex_benchmark_omits_unused_optional_providers(self):
+        benchmark = ROOT / "benchmarks" / "codex-mcp"
+        npm_config = (benchmark / ".npmrc").read_text(encoding="utf-8")
+        package = json.loads(
+            (benchmark / "package.json").read_text(encoding="utf-8")
+        )
+
+        self.assertIn("omit=optional", npm_config.splitlines())
+        self.assertIn("@openai/codex-sdk", package["devDependencies"])
 
     def test_desktop_manifest_matches_published_package_contract(self):
         project = tomllib.loads(


### PR DESCRIPTION
## Related issue

No linked issue.

## Summary

- reuse a healthy external Ollama service or an existing Ollama executable without taking ownership
- otherwise ask before downloading the official Ollama 0.32.5 headless archive into VidXP private application data on Windows x86-64 and macOS Apple Silicon
- pin each managed artifact by URL, byte count, and SHA-256; reject unsafe archive entries and activate only a completely extracted runtime
- keep runtime download, extraction, service startup, and model pull inside the central cancellable setup flow with visible progress and partial-file cleanup
- include the possible headless-runtime download in the setup storage estimate and document the external-install requirement on Linux
- never invoke WinGet, Homebrew, or an Ollama desktop-app installer for local grounded answers
- accept CDLA-Permissive-2.0 in the locked Rust license policy and regenerate the complete Desktop third-party notice inventory
- omit Promptfoo's unrelated optional provider packages from Codex benchmark installs while retaining the directly pinned Codex SDK
- enforce that the bundled Chroma service cannot publish a host port or use host networking

The managed Ollama behavior is a user-visible Desktop fix. The dependency and deployment safeguards are internal-only. This does not change stored repository/index formats and does not require a model or repository rebuild.

## Validation

- `$env:TAURI_CONFIG = '{"bundle":{"resources":[]}}'; cargo test --release --locked --manifest-path desktop/src-tauri/Cargo.toml` — 91 native Desktop tests passed, including Windows ZIP and macOS tar.gz extraction coverage
- `cargo test --locked --manifest-path desktop/src-tauri/Cargo.toml query_setup::tests -- --nocapture` — 5 focused managed-runtime tests passed
- `npm --prefix desktop run check` — TypeScript typecheck, ESLint, 47 Vitest tests, and the production Vite build passed
- `cargo about --version` — confirmed the CI-pinned cargo-about 0.9.1 locally
- `npm --prefix desktop run notices:check` — the regenerated locked Rust and frontend notice inventory passed
- `uv run --no-sync pytest -q tests/test_packaging.py -k "bundled_chroma_service_is_not_published or codex_benchmark_omits_unused_optional_providers or optional_ollama_profile_never_pulls_a_model_implicitly"` — 3 targeted packaging tests passed; pytest also reported its existing local cache-path warning
- `uv run --no-sync ruff check tests/test_packaging.py` — passed
- `npm ci --ignore-scripts --force` in `benchmarks/codex-mcp` — test-only engine override installed 374 packages, omitted the unrelated optional provider tree, and audited 0 installed vulnerabilities; the normal install correctly rejected local Node 22.19 because the benchmark requires Node 22.22+
- `npm ls @openai/codex-sdk --depth=0` — confirmed the direct Codex SDK remains installed
- `npm ls @openai/codex-security @huggingface/transformers onnxruntime-node sharp adm-zip extract-zip --all` — confirmed the unused optional packages are absent
- compared the embedded Ollama 0.32.5 artifact names, byte counts, and SHA-256 digests with GitHub release metadata — Windows x86-64 and macOS Apple Silicon matched
- `npx --yes markdownlint-cli2@0.23.2` — passed
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check` — passed
- `git diff --check` — passed

The real 1.36 GiB Windows runtime download and a real macOS runtime launch were not exercised locally. The archive paths were covered with synthetic ZIP and tar.gz fixtures, and the published asset metadata was verified. Promptfoo validation was not run because the local Node 22.19 runtime is below its enforced Node 22.22 minimum. Lychee was unavailable locally and Docker Desktop was not running, so the link and Compose configuration checks were not run; no external links were added and the Chroma invariant has direct regression coverage.