### PR TITLE
fix(release): update uv lock version structurally

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,8 +13,9 @@
     ".": {
       "extra-files": [
         {
+          "jsonpath": "$.package[?(@.name.value==\"vidxp\")].version",
           "path": "uv.lock",
-          "type": "generic"
+          "type": "toml"
         },
         {
           "jsonpath": "$.version",

--- a/release-please-config.stable.json
+++ b/release-please-config.stable.json
@@ -16,8 +16,9 @@
           "type": "json"
         },
         {
+          "jsonpath": "$.package[?(@.name.value==\"vidxp\")].version",
           "path": "uv.lock",
-          "type": "generic"
+          "type": "toml"
         },
         {
           "jsonpath": "$.version",

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -726,10 +726,7 @@ class PackagingTests(unittest.TestCase):
             }
             self.assertEqual(
                 generic_files,
-                {
-                    "uv.lock",
-                    "desktop/src-tauri/Cargo.toml",
-                },
+                {"desktop/src-tauri/Cargo.toml"},
                 filename,
             )
             toml_files = {
@@ -740,6 +737,9 @@ class PackagingTests(unittest.TestCase):
             self.assertEqual(
                 toml_files,
                 {
+                    "uv.lock": (
+                        '$.package[?(@.name.value=="vidxp")].version'
+                    ),
                     "desktop/src-tauri/Cargo.lock": (
                         '$.package[?(@.name.value=="vidxp-desktop")].version'
                     )
@@ -815,11 +815,15 @@ class PackagingTests(unittest.TestCase):
             if package["name"] == "vidxp-desktop"
         )
         self.assertEqual(desktop_lock["version"], version)
-        self.assertIn(
-            version_marker,
-            (ROOT / "uv.lock").read_text(encoding="utf-8"),
-            "uv.lock",
+        uv_lock = tomllib.loads(
+            (ROOT / "uv.lock").read_text(encoding="utf-8")
         )
+        project_lock = next(
+            package
+            for package in uv_lock["package"]
+            if package["name"] == "vidxp"
+        )
+        self.assertEqual(project_lock["version"], version)
         self.assertNotIn(
             f"vidxp=={version}",
             (

--- a/uv.lock
+++ b/uv.lock
@@ -4561,7 +4561,7 @@ wheels = [
 
 [[package]]
 name = "vidxp"
-version = "0.4.0" # x-release-please-version
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "dbos" },


### PR DESCRIPTION
## Summary

- make release-please update the VidXP package entry in `uv.lock` by TOML path
- remove the inline marker that Dependabot strips when regenerating the lockfile
- keep the existing packaging contract focused on the actual lockfile version

## Validation

- `pytest -q tests/test_packaging.py::PackagingTests::test_combined_release_version_contract`
- `uvx --from ruff==0.16.1 ruff check tests/test_packaging.py`
- verified release-please 17.6.1 updates exactly the VidXP version in an LF `uv.lock` fixture

## Release notes

Internal-only. No user-facing behavior changes.

No model, index, or generated artifact rebuild is required.