### PR TITLE
perf(indexing): run independent capability groups concurrently

### DIFF
--- a/benchmark_concurrency.py
+++ b/benchmark_concurrency.py
@@ -1,0 +1,157 @@
+"""
+Benchmark: sequential vs concurrent capability-group indexing.
+
+Run from the repo root with the venv active:
+
+    python benchmark_concurrency.py
+
+This does NOT touch real models — it patches the two capability entry
+points (visual.index_visuals, speech.operations.index_speech) with a
+fixed artificial delay to simulate model-inference latency, the same
+way tests/test_runner.py does. That isolates the orchestration
+overhead/speedup from actual model performance, which is the thing
+this PR changes.
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from vidxp.capabilities.contracts import CapabilityIndexResult
+from vidxp.capabilities.registry import create_capability_registry
+from vidxp.core.contracts import IndexConfig, VideoSource
+from vidxp.core.manifest import ManifestStore
+from vidxp.core.runner import run_index
+from vidxp.runtime import ModelRuntime
+from vidxp.settings import VidXPSettings
+
+# Simulated per-group latencies (seconds). Numbers are illustrative
+# stand-ins for real model call durations (e.g. a SigLIP2 batch vs a
+# faster-whisper transcription pass) — swap these for numbers pulled
+# from a real profiling run before quoting them in a PR description.
+SCENE_LATENCY = 0.40
+SPEECH_LATENCY = 0.55
+
+REPEATS = 5
+
+
+class FakeStorage:
+    def clear(self, modalities=None):
+        pass
+
+    def delete_video(self, modality, video_id):
+        pass
+
+    def delete_records(self, modality, *, video_id, filters=None):
+        pass
+
+    def size_bytes(self):
+        return 0
+
+
+def _visual_result(summary):
+    normalized = dict(summary)
+    normalized.setdefault("sampled_frames", 1)
+    normalized.setdefault("processed_frames", 1)
+    normalized.setdefault("frame_operations", 1)
+    normalized.setdefault("source_frames_advanced", 1)
+    return CapabilityIndexResult(summary=normalized, timings={})
+
+
+def slow_visual(*_args, **_kwargs):
+    time.sleep(SCENE_LATENCY)
+    return _visual_result({"scene_frames": 1})
+
+
+def slow_speech(*_args, **_kwargs):
+    time.sleep(SPEECH_LATENCY)
+    return {"dialogue_phrases": 1}
+
+
+
+def _run_once(config, source):
+    registry = create_capability_registry()
+    runtime = ModelRuntime(
+        VidXPSettings(
+            repository_root=config.run_directory,
+            runtime_backend=config.device,
+        )
+    )
+    manifest_store = ManifestStore(config, registry=registry, runtime=runtime)
+
+    with (
+        patch("vidxp.core.runner.require_dependencies"),
+        patch("vidxp.capabilities.visual.index_visuals", side_effect=slow_visual),
+        patch(
+            "vidxp.capabilities.speech.operations.index_speech",
+            side_effect=slow_speech,
+        ),
+        patch(
+            "vidxp.core.manifest.execution_state",
+            return_value={
+                "git": {"commit": "bench", "dirty": False},
+                "implementation_sha256": "bench",
+                "package_version": "0.0.0",
+                "python": "bench",
+                "platform": "bench",
+                "dependencies": {},
+            },
+        ),
+    ):
+        start = time.perf_counter()
+        run_index(
+            [source],
+            config,
+            storage=FakeStorage(),
+            registry=registry,
+            runtime=runtime,
+            manifest_store=manifest_store,
+            reset=True,
+        )
+        return time.perf_counter() - start
+
+
+def main() -> None:
+    with TemporaryDirectory() as directory:
+        path = Path(directory) / "video.mp4"
+        path.write_bytes(b"video")
+        source = VideoSource(video_id="bench-video", path=path)
+        config = IndexConfig(
+            dataset="bench",
+            split="test",
+            run_id="bench-run",
+            enabled_modalities=("scene", "speech"),
+            output_root=directory,
+        )
+
+        durations = [_run_once(config, source) for _ in range(REPEATS)]
+
+    theoretical_sequential = SCENE_LATENCY + SPEECH_LATENCY
+    theoretical_concurrent = max(SCENE_LATENCY, SPEECH_LATENCY)
+
+    print(f"Simulated per-group latency: scene={SCENE_LATENCY}s, speech={SPEECH_LATENCY}s")
+    print(f"Theoretical sequential total: {theoretical_sequential:.3f}s")
+    print(f"Theoretical concurrent total (Amdahl ceiling = slowest group): {theoretical_concurrent:.3f}s")
+    print(f"Theoretical max speedup: {theoretical_sequential / theoretical_concurrent:.2f}x")
+    print()
+    print(f"Measured wall-clock over {REPEATS} runs (current runner, concurrent groups):")
+    for i, d in enumerate(durations, 1):
+        print(f"  run {i}: {d:.3f}s")
+    print(f"  mean: {statistics.mean(durations):.3f}s")
+    print(f"  stdev: {statistics.pstdev(durations):.3f}s" if len(durations) > 1 else "")
+    print()
+    measured_speedup = theoretical_sequential / statistics.mean(durations)
+    print(f"Measured speedup vs sequential baseline: {measured_speedup:.2f}x")
+    print(
+        "Note: measured speedup should approach but not exceed the theoretical "
+        "ceiling above — overhead (thread startup, lock contention, manifest "
+        "writes) accounts for the gap."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/vidxp/core/manifest.py
+++ b/src/vidxp/core/manifest.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any, Mapping
+from threading import RLock
 
 from vidxp.capabilities.registry import (
     CapabilityRegistry,
@@ -250,6 +251,7 @@ class ManifestStore:
         self.checkpoint_directory = (
             self.run_directory / CHECKPOINT_DIRECTORY
         )
+        self._lock = RLock()
 
     def _checkpoint_path(self, video_id: str) -> Path:
         digest = hashlib.sha256(video_id.encode("utf-8")).hexdigest()
@@ -366,10 +368,12 @@ class ManifestStore:
         return manifest
 
     def read(self) -> dict[str, Any]:
-        return json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        with self._lock:
+            return json.loads(self.manifest_path.read_text(encoding="utf-8"))
 
     def write(self, manifest: Mapping[str, Any]) -> None:
-        write_json_atomic(self.manifest_path, manifest)
+        with self._lock:
+            write_json_atomic(self.manifest_path, manifest)
 
     def _refresh_runtime(self, manifest: dict[str, Any]) -> None:
         manifest["models"]["runtime"] = self.runtime.describe()
@@ -401,26 +405,27 @@ class ManifestStore:
         if checkpoint.get("state") != "complete":
             return False
 
-        manifest = self.read()
-        if video_id not in manifest["completed_videos"]:
-            manifest["videos"][video_id] = {
-                "state": "complete",
-                "completed_at": checkpoint["completed_at"],
-                "summary": checkpoint.get("summary", {}),
-                "stages": manifest["videos"].get(video_id, {}).get(
-                    "stages",
-                    {},
-                ),
-            }
-            manifest["completed_videos"].append(video_id)
-            manifest["completed_videos"].sort()
-            for key in ("failed_videos", "interrupted_videos"):
-                manifest[key] = [
-                    item for item in manifest[key] if item != video_id
-                ]
-            manifest["updated_at"] = utc_now()
-            self.write(manifest)
-        return True
+        with self._lock:
+            manifest = self.read()
+            if video_id not in manifest["completed_videos"]:
+                manifest["videos"][video_id] = {
+                    "state": "complete",
+                    "completed_at": checkpoint["completed_at"],
+                    "summary": checkpoint.get("summary", {}),
+                    "stages": manifest["videos"].get(video_id, {}).get(
+                        "stages",
+                        {},
+                    ),
+                }
+                manifest["completed_videos"].append(video_id)
+                manifest["completed_videos"].sort()
+                for key in ("failed_videos", "interrupted_videos"):
+                    manifest[key] = [
+                        item for item in manifest[key] if item != video_id
+                    ]
+                manifest["updated_at"] = utc_now()
+                self.write(manifest)
+            return True
 
     def start_video(self, video_id: str) -> None:
         self._checkpoint_path(video_id).unlink(missing_ok=True)
@@ -455,10 +460,11 @@ class ManifestStore:
             "recorded_at": utc_now(),
         }
         _append_jsonl(self.timings_path, timing)
-        manifest = self.read()
-        manifest["videos"][video_id]["stages"][stage] = timing
-        manifest["updated_at"] = utc_now()
-        self.write(manifest)
+        with self._lock:
+            manifest = self.read()
+            manifest["videos"][video_id]["stages"][stage] = timing
+            manifest["updated_at"] = utc_now()
+            self.write(manifest)
 
     def complete_video(
         self,

--- a/src/vidxp/core/runner.py
+++ b/src/vidxp/core/runner.py
@@ -8,7 +8,6 @@ from filelock import FileLock, Timeout
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from threading import Lock
 
-from filelock import FileLock, Timeout
 
 from vidxp.capabilities.registry import CapabilityRegistry
 from vidxp.core.contracts import (
@@ -240,7 +239,6 @@ def _index_groups(
     return tuple(tuple(group) for group in groups)
 
 
-# after
 def _run_enabled_modalities(
     source: VideoSource,
     config: IndexConfig,

--- a/src/vidxp/core/runner.py
+++ b/src/vidxp/core/runner.py
@@ -5,6 +5,10 @@ from time import perf_counter
 from typing import Any, Callable, Sequence
 
 from filelock import FileLock, Timeout
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
+
+from filelock import FileLock, Timeout
 
 from vidxp.capabilities.registry import CapabilityRegistry
 from vidxp.core.contracts import (
@@ -236,6 +240,7 @@ def _index_groups(
     return tuple(tuple(group) for group in groups)
 
 
+# after
 def _run_enabled_modalities(
     source: VideoSource,
     config: IndexConfig,
@@ -247,12 +252,27 @@ def _run_enabled_modalities(
     registry: CapabilityRegistry,
     runtime: ModelRuntimePort,
 ) -> dict[str, Any]:
+    groups = _index_groups(config.enabled_modalities, registry)
+
     summary: dict[str, Any] = {}
-    for names in _index_groups(config.enabled_modalities, registry):
+    summary_lock = Lock()
+    stage_lock = Lock()
+    active_stages: dict[str, str] = {}
+
+    def report_stage(group_key: str, value: str | None) -> None:
+        with stage_lock:
+            if value is None:
+                active_stages.pop(group_key, None)
+            else:
+                active_stages[group_key] = value
+            set_stage(", ".join(sorted(active_stages.values())))
+
+    def run_group(names: tuple[str, ...]) -> dict[str, Any]:
         cancellation.raise_if_cancelled()
-        set_stage(str(registry.get(names[0]).index_stage))
-        summary.update(
-            _run_capability_group(
+        group_key = names[0]
+        report_stage(group_key, str(registry.get(group_key).index_stage))
+        try:
+            return _run_capability_group(
                 names,
                 source,
                 config,
@@ -263,9 +283,28 @@ def _run_enabled_modalities(
                 registry,
                 runtime,
             )
-        )
-    return summary
+        except BaseException:
+            cancellation.cancel()
+            raise
+        finally:
+            report_stage(group_key, None)
 
+    first_error: BaseException | None = None
+    with ThreadPoolExecutor(max_workers=max(1, len(groups))) as pool:
+        futures = {pool.submit(run_group, names): names for names in groups}
+        for future in as_completed(futures):
+            try:
+                summary_part = future.result()
+            except BaseException as exc:
+                if first_error is None:
+                    first_error = exc
+            else:
+                with summary_lock:
+                    summary.update(summary_part)
+
+    if first_error is not None:
+        raise first_error
+    return summary
 
 def _process_video(
     video_id: str,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -721,7 +721,7 @@ class RunnerTests(unittest.TestCase):
             ).read_text(encoding="utf-8").splitlines()
             self.assertEqual(manifest["configuration"]["frame_stride"], 1)
             self.assertTrue(all(json.loads(line) for line in timing_lines))
-            
+
     def test_concurrent_capability_groups_do_not_drop_stages(self):
         with TemporaryDirectory() as directory:
             path = Path(directory) / "video.mp4"
@@ -766,6 +766,53 @@ class RunnerTests(unittest.TestCase):
                     {"visual_indexing", "speech_indexing"},
                     f"attempt {attempt}: stages were {stages!r}",
                 )
+
+    def test_capability_groups_actually_run_concurrently(self):
+        from threading import Event
+
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "video.mp4"
+            path.write_bytes(b"video")
+            config = self._config(directory, ("scene", "speech"))
+            source = VideoSource(video_id="video-1", path=path)
+
+            visual_started = Event()
+            speech_started = Event()
+
+            def blocking_visual(*_, **__):
+                visual_started.set()
+                self.assertTrue(
+                    speech_started.wait(timeout=2),
+                    "speech group never started while visual was running "
+                    "— groups are not overlapping",
+                )
+                return visual_result({"scene_frames": 1})
+
+            def blocking_speech(*_, **__):
+                speech_started.set()
+                self.assertTrue(
+                    visual_started.wait(timeout=2),
+                    "visual group never started while speech was running "
+                    "— groups are not overlapping",
+                )
+                return {"dialogue_phrases": 1}
+
+            with (
+                patch("vidxp.core.runner.require_dependencies"),
+                patch(
+                    "vidxp.capabilities.visual.index_visuals",
+                    side_effect=blocking_visual,
+                ),
+                patch(
+                    "vidxp.capabilities.speech.operations.index_speech",
+                    side_effect=blocking_speech,
+                ),
+                patch(
+                    "vidxp.core.manifest.execution_state",
+                    return_value=EXECUTION_STATE,
+                ),
+            ):
+                run_index([source], config, storage=FakeStorage())
 
 
 if __name__ == "__main__":

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,6 +1,7 @@
 import json
 import unittest
 from pathlib import Path
+from time import sleep
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock, patch
 
@@ -720,6 +721,51 @@ class RunnerTests(unittest.TestCase):
             ).read_text(encoding="utf-8").splitlines()
             self.assertEqual(manifest["configuration"]["frame_stride"], 1)
             self.assertTrue(all(json.loads(line) for line in timing_lines))
+            
+    def test_concurrent_capability_groups_do_not_drop_stages(self):
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "video.mp4"
+            path.write_bytes(b"video")
+            config = self._config(directory, ("scene", "speech"))
+            source = VideoSource(video_id="video-1", path=path)
+
+            def slow_visual(*_, **__):
+                sleep(0.05)
+                return visual_result({"scene_frames": 1})
+
+            def slow_speech(*_, **__):
+                sleep(0.05)
+                return {"dialogue_phrases": 1}
+
+            for attempt in range(20):
+                with (
+                    patch("vidxp.core.runner.require_dependencies"),
+                    patch(
+                        "vidxp.capabilities.visual.index_visuals",
+                        side_effect=slow_visual,
+                    ),
+                    patch(
+                        "vidxp.capabilities.speech.operations.index_speech",
+                        side_effect=slow_speech,
+                    ),
+                    patch(
+                        "vidxp.core.manifest.execution_state",
+                        return_value=EXECUTION_STATE,
+                    ),
+                ):
+                    manifest = run_index(
+                        [source],
+                        config,
+                        storage=FakeStorage(),
+                        reset=True,
+                    )
+
+                stages = manifest["videos"]["video-1"]["stages"]
+                self.assertEqual(
+                    set(stages.keys()),
+                    {"visual_indexing", "speech_indexing"},
+                    f"attempt {attempt}: stages were {stages!r}",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Related issue

Closes #96

## Summary

Parallelizes `_run_enabled_modalities` so independent capability groups (for example, `scene` and `speech`) can run concurrently instead of sequentially, using `ThreadPoolExecutor`.

The implementation also tracks active stages per capability group so concurrent workers cannot overwrite a single shared stage value.

This PR adds regression coverage for concurrent execution and manifest stage preservation.

GPU/CPU resource coordination via `ResourceScheduler` is intentionally left out of scope. It is not currently wired into the relevant capability indexers, so resource contention should be measured before introducing additional scheduling logic.

No public interfaces or capability contracts are changed. The change is limited to the internal execution of independent capability groups.

## Validation

* `PYTHONPATH=src python -m pytest tests/test_runner.py -v`

  * **18 passed**
* `git diff --check`

  * **No whitespace errors**
* `test_concurrent_capability_groups_do_not_drop_stages`

  * Runs concurrent `scene` + `speech` indexing repeatedly and verifies that both stages are preserved in the manifest.
* `test_capability_groups_actually_run_concurrently`

  * Uses `threading.Event` synchronization to verify that the two capability groups actually overlap in execution rather than merely being dispatched independently.

## Benchmark

Added `benchmark_concurrency.py` to measure the orchestration behavior using simulated capability latency.

With simulated latencies of 0.40s for `scene` and 0.55s for `speech`:

* Theoretical sequential time: **0.950s**
* Theoretical concurrent ceiling: **0.550s**
* Theoretical maximum speedup: **1.73×**
* Measured concurrent mean: **~0.565s**
* Measured speedup against the simulated sequential baseline: **~1.68×**

These numbers use artificial delays and **do not represent real model-inference performance**. The benchmark is intended to demonstrate the concurrency behavior and orchestration overhead. Real-world speedup will depend on model execution, CPU/GPU resources, and workload characteristics.
