### PR TITLE
Persist real face embeddings during actor indexing (unblocks #74)

### DIFF
--- a/src/vidxp/capabilities/actor/indexing.py
+++ b/src/vidxp/capabilities/actor/indexing.py
@@ -74,7 +74,7 @@ def _actor_records(
         records.append(
             StorageRecord(
                 source_id=source_id,
-                embedding=[0.0],
+                embedding=detection["encoding"],
                 metadata={
                     **config.record_identity("actor", source_id),
                     "detection_id": detection["detection_id"],
@@ -209,6 +209,7 @@ def process_actor_samples(
                             min(height, int(face[1] + face[3])),
                             max(0, int(face[0])),
                         ),
+                        "encoding": encoding.tolist(),
                     }
                 )
             state.processed_frames += 1

--- a/src/vidxp/core/contracts.py
+++ b/src/vidxp/core/contracts.py
@@ -11,7 +11,7 @@ from typing import Any, Iterable, Mapping, Sequence
 from urllib.parse import quote
 
 
-INDEX_SCHEMA_VERSION = 7
+INDEX_SCHEMA_VERSION = 8
 MANIFEST_SCHEMA_VERSION = 2
 
 

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -444,6 +444,7 @@ class IndexingTests(unittest.TestCase):
                     "frame_index": 0,
                     "timestamp": 0.0,
                     "bbox": (1, 2, 3, 0),
+                    "encoding": [0.6, 0.8],
                 }
             ],
             config,
@@ -455,6 +456,73 @@ class IndexingTests(unittest.TestCase):
             "generation-1:actors:video-1:actor-cluster:1",
         )
         self.assertEqual(records[0].metadata["bbox_top"], 1)
+        self.assertEqual(records[0].embedding, [0.6, 0.8])
+
+    def test_actor_indexing_persists_real_face_embeddings_not_placeholders(self):
+        import numpy as np
+        from unittest.mock import Mock
+
+        from vidxp.capabilities.actor.indexing import (
+            ActorIndexState,
+            process_actor_samples,
+        )
+        from vidxp.core.video import FrameSample
+
+        config = IndexConfig(
+            dataset="sample",
+            split="test",
+            run_id="actors",
+            video_id="video-1",
+            generation_id="generation-1",
+            enabled_modalities=("actor",),
+        )
+
+        raw_encoding = np.array([3.0, 4.0], dtype="float32")
+        expected_normalized = (raw_encoding / np.linalg.norm(raw_encoding)).tolist()
+
+        detector = Mock()
+        detector.setInputSize = Mock()
+        detector.setScoreThreshold = Mock()
+        detector.detect.return_value = (
+            True,
+            np.array([[10.0, 10.0, 20.0, 20.0]], dtype="float32"),
+        )
+
+        recognizer = Mock()
+        recognizer.alignCrop.return_value = np.zeros((112, 112, 3), dtype="uint8")
+        recognizer.feature.return_value = raw_encoding.reshape(1, -1)
+
+        state = ActorIndexState(
+            models=Mock(detector=detector, recognizer=recognizer)
+        )
+        storage = Mock()
+
+        samples = [
+            FrameSample(
+                frame_index=0,
+                timestamp=0.0,
+                frame=np.zeros((48, 48, 3), dtype="uint8"),
+            ),
+        ]
+
+        process_actor_samples(
+            samples,
+            state=state,
+            config=config,
+            storage=storage,
+            cancellation=CancellationToken(),
+        )
+
+        self.assertEqual(storage.upsert.call_count, 1)
+        (_, records), _ = storage.upsert.call_args
+        self.assertEqual(len(records), 1)
+        record = records[0]
+
+        self.assertIsNotNone(record.embedding)
+        self.assertNotEqual(list(record.embedding), [0.0])
+        self.assertEqual(len(record.embedding), 2)
+        for actual, expected in zip(record.embedding, expected_normalized):
+            self.assertAlmostEqual(actual, expected, places=5)
 
     def test_actor_cluster_identity_is_unique_by_media_and_generation(self):
         def config(video_id, generation_id):


### PR DESCRIPTION
# Prep Work for #74 — Find People Using a Reference Image

## The Bug

Actor indexing detects a face, aligns it, and computes a normalized SFace encoding for each detection — but that encoding was never actually persisted.

`_actor_records()` was writing a placeholder `embedding=[0.0]` into every `StorageRecord` sent to Chroma. As a result, the `actor` collection's vector index has never contained real, searchable face embeddings.

During indexing, matching only used `ActorIndexState.known_encodings`, which is an in-memory list scoped to a single indexing run and discarded once the run finishes.

This silently blocks **#74**: finding a person using a reference image requires comparing a new face embedding against all previously detected faces across the repository, but there was no durable embedding data to compare against.

## The Fix

* Carry the computed `encoding` through into each detection dictionary in `process_actor_samples`.
* Update `_actor_records()` to persist the real, normalized encoding as `StorageRecord.embedding` instead of `[0.0]`.
* Leave `_actor_cluster_records()` unchanged. A cluster summary spans multiple detections and does not represent a single face image, so it has no single embedding to persist.

## Schema Version Bump

Because this changes what is actually persisted for each actor detection, existing generations with the `actor` modality enabled contain placeholder vectors and are no longer trustworthy for face search.

The repository already has a mechanism for handling this:

* `CompletedGenerationManifest.index_schema_version` is typed as `Literal[INDEX_SCHEMA_VERSION]`.
* `local_snapshots.py::validate_generation()` validates the manifest on disk using `model_validate_json()`.
* `ValidationError` is explicitly caught and re-raised as `IndexSchemaError`.

This PR bumps `INDEX_SCHEMA_VERSION` from **7 → 8**.

As a result, old generations will fail validation cleanly with `IndexSchemaError` instead of silently being treated as complete, searchable indexes containing meaningless vectors.

### User-facing impact

Any existing generation with the `actor` modality enabled will need to be **re-indexed** after this change.

This is intentional. The alternative would be allowing #74 to search against invalid placeholder embeddings with no indication that the underlying data is unusable.

## Testing

### New test

Added:

`test_actor_indexing_persists_real_face_embeddings_not_placeholders`

This drives `process_actor_samples` through mocked YuNet/SFace calls end-to-end and verifies that the `StorageRecord` sent to `storage.upsert` contains the real normalized encoding rather than the placeholder `[0.0]`.

### Updated test

Updated:

`test_actor_records_preserve_stable_detection_metadata`

The test previously created fake detection dictionaries without an `encoding` field. It now provides an explicit encoding and verifies that the resulting `StorageRecord.embedding` matches the real value.

### Test results

Full test suite:

**590 passed, 2 skipped, 0 failed**

Also re-ran the tests covering `INDEX_SCHEMA_VERSION` and actor indexing:

* `test_generation_manifest.py`
* `test_local_snapshots.py`
* `test_indexing.py`
* `test_actor_results.py`
* `test_cli.py`
* `test_frontend_app.py`

All tests pass, including the existing test that constructs a manifest with `INDEX_SCHEMA_VERSION + 1` to verify that the rejection path still works.

## Not Included

This PR does **not** implement reference-image search itself.

Reference-image search remains the actual feature tracked by **#74** and will be implemented as a separate follow-up PR once this change lands, since it depends on real actor embeddings being persisted first.
