### PR TITLE
test: compare resolved paths where the product resolves

### DIFF
--- a/tests/test_codex_plugin.py
+++ b/tests/test_codex_plugin.py
@@ -52,7 +52,7 @@ def test_export_codex_plugin_materializes_the_canonical_skill_bundle() -> None:
             "installation": "AVAILABLE",
             "authentication": "ON_INSTALL",
         }
-        assert exported.marketplace_path == str(marketplace_path)
+        assert Path(exported.marketplace_path) == marketplace_path.resolve()
         assert not (root / "marketplace.json").exists()
 
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2353,7 +2353,10 @@ class MCPTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(linked.structured_content["etag"], f'"{"1" * 64}"')
         self.assertEqual(linked.structured_content["state"], "ready")
         self.assertEqual(linked.structured_content["delivery_mode"], "local_file")
-        self.assertEqual(Path(linked.structured_content["local_path"]), clip)
+        self.assertEqual(
+            Path(linked.structured_content["local_path"]),
+            clip.resolve(),
+        )
         self.assertIsNone(linked.structured_content["download_url"])
         self.assertEqual(downloaded.contents[0].blob, "Y2xpcC1jb250ZW50")
 


### PR DESCRIPTION
## Related issue

None.

## Summary

Two test assertions compared a product-returned path against an unresolved `TemporaryDirectory` path. The product resolves deliberately at both boundaries, so the comparisons hold only when no path component is rewritten during resolution:

- `verified_local_path` in `src/vidxp/artifact_delivery.py` calls `path.resolve(strict=True)` before an artifact path reaches the caller.
- `_validated_marketplace_root` in `src/vidxp/codex_plugin.py` calls `.expanduser().resolve()` before the Codex marketplace root is used.

On Windows, `TMP` commonly contains an 8.3 short component when the user profile name contains a space. Resolution expands it, and both assertions fail on the short-versus-long form of the same path:

```text
AssertionError: WindowsPath('C:/Users/Hasnain Ibrar Butt/AppData/Local/Temp/tmpzyyjwosm/clip.mp4')
            != WindowsPath('C:/Users/HASNAI~1/AppData/Local/Temp/tmpzyyjwosm/clip.mp4')

AssertionError: assert 'C:\Users\HASNAI~1\...\.agents\plugins\marketplace.json'
             == 'C:\Users\Hasnain Ibrar Butt\...\.agents\plugins\marketplace.json'
```

The change compares the resolved form on both sides, which is what each boundary documents and returns.

Internal-only, test scope. No product behavior changes: both delivered paths were already correct and are still asserted, now in the form the boundaries actually return.

### Why CI does not catch these

- The full suite runs on `ubuntu-latest`, and the `windows-2025` provider job runs only `test_models.py` and `test_indexing.py`, so `test_mcp.py` is never executed on Windows.
- `test_codex_plugin.py` is never collected by CI at all. It defines module-level pytest functions, and CI discovers tests with `python -m unittest discover -s tests`, which collects only `unittest.TestCase` subclasses. `test_native_ingestion.py` (4 tests) is in the same position. That is a separate gap and I have not touched it here; happy to open an issue if it is not already known.

## Validation

Windows 11, Python 3.12.14 in the project venv, `TMP=C:\Users\HASNAI~1\AppData\Local\Temp`.

- `uv run --no-sync python -m pytest -q tests/test_codex_plugin.py tests/test_mcp.py` — 60 passed, 7 subtests passed. Both assertions fail on `upstream/main` with the errors quoted above, so this exercises the real failure rather than a mock.
- `uv run --no-sync python -m pytest -q` on `upstream/main` before the change — 4 failed, 731 passed, 5 skipped. Two failures are the assertions fixed here.
- `uvx "ruff~=0.16.1" check src tests` — all checks passed.

The other two pre-existing failures on `upstream/main` are `test_native_ingestion.py::test_local_ingestion_automatically_indexes_and_becomes_searchable` and `::test_streamable_http_browser_upload_indexes_in_one_session`, both `AssertionError: Autonomous indexing did not finish without status polling`. They are unrelated to this change and I have not prepared model artifacts locally, so I cannot tell whether they are environmental or a real defect. Flagging rather than claiming.
