### PR TITLE
docs: correct the contributor test command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ from the contributing guide before submitting a pull request. Common checks:
 
 ```bash
 uv run --no-sync ruff check .
-uv run --no-sync pytest -q
+uv run --no-sync python -m pytest -q
 npm --prefix desktop run check
 ```
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -62,8 +62,12 @@ Initialize and verify the local media runtime:
 uv run --no-sync vidxp init
 uv run --no-sync vidxp --version
 uv run --no-sync vidxp doctor
-uv run --no-sync pytest -q
+uv run --no-sync python -m pytest -q
 ```
+
+Run the test suite as `python -m pytest`. That form puts the repository root
+on the import path, which the root-level tooling tests require. Calling
+`pytest` directly fails to collect them.
 
 `vidxp init` verifies FFmpeg, ffprobe, `libx264`, and `aac`. A fresh checkout
 may report that model files have not been prepared; that is expected. Prepare
@@ -143,7 +147,7 @@ Common checks are:
 
 ```bash
 uv run --no-sync ruff check .
-uv run --no-sync pytest -q
+uv run --no-sync python -m pytest -q
 npm --prefix desktop run check
 docker compose config --quiet
 ```


### PR DESCRIPTION
## Related issue

None.

## Summary

The contributor setup and validation steps in `docs/CONTRIBUTING.md`, and the coding-agent instructions in `AGENTS.md`, told readers to run `uv run --no-sync pytest -q`. From a clean checkout that fails during collection, because five root-level tooling tests import the top-level `utils` package:

```text
ERROR tests/test_ci_scope.py
ERROR tests/test_normalize_sdist.py
ERROR tests/test_published_distribution.py
ERROR tests/test_release_contract.py
ERROR tests/test_release_notes.py
ModuleNotFoundError: No module named 'utils'
!!!! Interrupted: 5 errors during collection !!!!
```

The repository has no `[tool.pytest.ini_options]` section and no `conftest.py`, so nothing places the repository root on the import path. `python -m pytest` does, and collects the suite cleanly.

CI does not surface this because it runs `python -m unittest discover -s tests` (`.github/workflows/ci.yml`), which prepends the working directory for the same reason. `docs/benchmarking/runtime_validation.md` already records that the automated suite depends on import-path selection.

This is the first command a new contributor runs, so the failure reads as a broken checkout. The change uses `python -m pytest` in both validation steps and in `AGENTS.md`, and records why the invocation matters so it is not shortened again.

Documentation only. No product behavior changes. An alternative fix is to add pytest configuration or a root `conftest.py` so the bare command works; I kept this to the documentation because adding pytest configuration to a repository whose CI standardizes on `unittest` is a maintainer decision, and I am happy to send that instead if you prefer it.

## Validation

- `uv run --no-sync python -m pytest -q --collect-only` — 740 tests collected, no errors.
- `uv run --no-sync pytest -q` — reproduces the 5 collection errors quoted above, confirming the documented command is the failing one.
- `npx --yes markdownlint-cli2@0.23.2 "AGENTS.md" "docs/CONTRIBUTING.md"` — exit 0, no findings.
- Local link check not run: `lychee` is not installed here and the change adds no links. Please let the documentation workflow cover it.

For transparency, the corrected command does not produce a clean suite on Windows today: `uv run --no-sync python -m pytest -q` on `upstream/main` reports 4 failed, 731 passed, 5 skipped. Two of those are Windows path-resolution assertions I have sent separately; the other two are `test_native_ingestion.py` autonomous-indexing failures I have not diagnosed. This change only corrects which command to run, and does not claim the suite is green.

One related observation, not changed here: CI's `python -m unittest discover -s tests` collects 655 tests, while `python -m pytest` collects 740. The difference is the module-level pytest functions in `test_codex_plugin.py` and `test_native_ingestion.py` plus the five root-level tooling tests, none of which `unittest` discovery collects. So the documented command and the CI command exercise different sets.
